### PR TITLE
Bugfix: Wrong position of HaystackSearch file seperation line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [next]
+- Bugfix: Wrong position of HaystackSearch file seperation line
+
 ## [1.2.3]
 - Bugfix: MCP SSE connection lost after a while
 

--- a/src/server/server/mcp.go
+++ b/src/server/server/mcp.go
@@ -221,8 +221,8 @@ func handleSearch(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallTo
 
 	for _, result := range results {
 		printLine(tr, "")
-		printLine(tr, fmt.Sprintf("File: %s, %d result%s", result.File, len(result.Lines), toTruncated(result.Truncate)))
 		printLine(tr, strings.Repeat("=", 20))
+		printLine(tr, fmt.Sprintf("File: %s, %d result%s", result.File, len(result.Lines), toTruncated(result.Truncate)))
 		for _, line := range result.Lines {
 			printLine(tr, strings.Repeat("-", 20))
 			for _, before := range line.Before {


### PR DESCRIPTION
Bugfix: Wrong position of HaystackSearch file seperation line, it should be placed before filename