### PR TITLE
feat: add Docker-isolated test runner (make test-safe)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+build
+.vscode
+.idea
+*.md
+LICENSE
+docs
+scripts
+deps

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,12 @@
+FROM golang:1.23
+
+WORKDIR /app
+
+# Copy dependency files first for better caching
+COPY src/go.mod src/go.sum ./src/
+RUN cd src && go mod download
+
+# Copy everything
+COPY . .
+
+CMD ["bash", "-c", "ulimit -u 256 && cd /app/src && go test ./... -count=1 -timeout 5m"]

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ DOCKER_TEST_IMAGE=haystack-test
 test-docker-build:
 	@docker build -f Dockerfile.test -t $(DOCKER_TEST_IMAGE) .
 
+# NOTE: --network=none blocks all network access. If integration tests need
+# localhost networking, use 'go test' directly or adjust this flag.
 test-safe: test-docker-build
 	@echo "Running tests in Docker (isolated)..."
 	@docker run --rm --cpus=2 --memory=2g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test coverage fmt clean
+.PHONY: build test coverage fmt clean test-docker-build test-safe test-safe-race
 
 APP_NAME=haystack
 BUILD_DIR=build
@@ -40,3 +40,16 @@ fmt:
 clean:
 	@echo "Cleaning..."
 	@$(RM_RF)
+
+DOCKER_TEST_IMAGE=haystack-test
+
+test-docker-build:
+	@docker build -f Dockerfile.test -t $(DOCKER_TEST_IMAGE) .
+
+test-safe: test-docker-build
+	@echo "Running tests in Docker (isolated)..."
+	@docker run --rm --cpus=2 --memory=2g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE)
+
+test-safe-race: test-docker-build
+	@echo "Running tests with race detector in Docker (isolated)..."
+	@docker run --rm --cpus=2 --memory=4g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE) bash -c "ulimit -u 256 && cd /app/src && go test -race ./... -count=1 -timeout 5m"


### PR DESCRIPTION
Adds Dockerfile.test and Makefile targets for running tests in a resource-limited Docker container (2c/2g/pids-limit=256) to prevent fork bombs from crashing the host machine.