### PR TITLE
perf: use volume mount for faster Docker test runs

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,11 +2,8 @@ FROM golang:1.23
 
 WORKDIR /app
 
-# Copy dependency files first for better caching
+# Copy dependency files only (source mounted at runtime)
 COPY go.mod go.sum ./
 RUN go mod download
-
-# Copy everything
-COPY . .
 
 CMD ["bash", "-c", "ulimit -u 256 && go test ./... -count=1 -timeout 5m"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test coverage fmt clean test-docker-build test-safe test-safe-race
+.PHONY: build test coverage fmt clean test-docker-build test-docker-ensure test-safe test-safe-race
 
 APP_NAME=haystack
 BUILD_DIR=build
@@ -45,12 +45,22 @@ DOCKER_TEST_IMAGE=haystack-test
 test-docker-build:
 	@docker build -f Dockerfile.test -t $(DOCKER_TEST_IMAGE) .
 
+test-docker-ensure:
+	@if [ -z "$$(docker images -q $(DOCKER_TEST_IMAGE) 2>/dev/null)" ]; then \
+		echo "Building test image (first time or after cleanup)..."; \
+		$(MAKE) test-docker-build; \
+	fi
+
 # NOTE: --network=none blocks all network access. If integration tests need
 # localhost networking, use 'go test' directly or adjust this flag.
-test-safe: test-docker-build
+test-safe: test-docker-ensure
 	@echo "Running tests in Docker (isolated)..."
-	@docker run --rm --cpus=2 --memory=2g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE)
+	@docker run --rm --cpus=2 --memory=2g --pids-limit=256 --network=none \
+		-v $$(pwd):/app:ro \
+		$(DOCKER_TEST_IMAGE)
 
-test-safe-race: test-docker-build
+test-safe-race: test-docker-ensure
 	@echo "Running tests with race detector in Docker (isolated)..."
-	@docker run --rm --cpus=2 --memory=4g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE) bash -c "ulimit -u 256 && go test -race ./... -count=1 -timeout 5m"
+	@docker run --rm --cpus=2 --memory=4g --pids-limit=256 --network=none \
+		-v $$(pwd):/app:ro \
+		$(DOCKER_TEST_IMAGE) bash -c "ulimit -u 256 && go test -race ./... -count=1 -timeout 5m"

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ test-safe: test-docker-build
 
 test-safe-race: test-docker-build
 	@echo "Running tests with race detector in Docker (isolated)..."
-	@docker run --rm --cpus=2 --memory=4g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE) bash -c "ulimit -u 256 && cd /app/src && go test -race ./... -count=1 -timeout 5m"
+	@docker run --rm --cpus=2 --memory=4g --pids-limit=256 --network=none $(DOCKER_TEST_IMAGE) bash -c "ulimit -u 256 && go test -race ./... -count=1 -timeout 5m"


### PR DESCRIPTION
Changes Dockerfile.test to only cache dependencies (go mod download), source code is mounted via -v at runtime with :ro flag. Eliminates need to rebuild image on every code change. Resource limits (2c/2g/pids-limit=256) unchanged.