### PR TITLE
ci: fix path filters and add main branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,26 @@
 name: CI Pipeline
 
 on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "Dockerfile*"
+      - "scripts/**"
+      - ".github/workflows/ci.yml"
   pull_request:
     branches: [ "main", "master" ]
     paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'scripts/**'
-      - '.github/workflows/ci.yml'
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "Dockerfile*"
+      - "scripts/**"
+      - ".github/workflows/ci.yml"
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Updates CI workflow path filters to match new directory structure after src/ removal. Adds main branch to push triggers so CI runs on merge.