### PR TITLE
fix(server): replace global DefaultServeMux with per-server mux

### DIFF
--- a/server/server/handlers_test.go
+++ b/server/server/handlers_test.go
@@ -1324,7 +1324,8 @@ var mcpInitOnce sync.Once
 
 func TestMcpInit(t *testing.T) {
 	mcpInitOnce.Do(func() {
-		mcpInit("127.0.0.1:19999")
+		mux := http.NewServeMux()
+		mcpInit("127.0.0.1:19999", mux)
 	})
 	// If we get here without panic, the init succeeded.
 }
@@ -1579,10 +1580,6 @@ var startServerUnixOnce sync.Once
 
 func TestStartServer_UnixSocket(t *testing.T) {
 	startServerUnixOnce.Do(func() {
-		// Reset the default mux to avoid duplicate route panic from the
-		// previous TestStartServer_NoAddrNoSocket call.
-		http.DefaultServeMux = http.NewServeMux()
-
 		socketPath := filepath.Join(t.TempDir(), "haystack-test.sock")
 
 		// Initialize shutdown for this test.
@@ -1619,9 +1616,6 @@ var startServerTCPAndUnixOnce sync.Once
 
 func TestStartServer_TCPAndUnix(t *testing.T) {
 	startServerTCPAndUnixOnce.Do(func() {
-		// Reset the default mux again.
-		http.DefaultServeMux = http.NewServeMux()
-
 		socketPath := filepath.Join(t.TempDir(), "haystack-test-both.sock")
 		// Use port 0 style — pick a high ephemeral port to reduce collision risk.
 		tcpAddr := "127.0.0.1:0"
@@ -1670,8 +1664,6 @@ var startServerRemoveOnce sync.Once
 
 func TestStartServer_UnixSocketRemovesExisting(t *testing.T) {
 	startServerRemoveOnce.Do(func() {
-		http.DefaultServeMux = http.NewServeMux()
-
 		socketPath := filepath.Join(t.TempDir(), "haystack-test-existing.sock")
 
 		// Create a stale socket file.
@@ -1709,10 +1701,7 @@ func setupMCPHandler(t *testing.T) http.HandlerFunc {
 	t.Helper()
 	mcpHandlerOnce.Do(func() {
 		captureMux := http.NewServeMux()
-		origMux := http.DefaultServeMux
-		http.DefaultServeMux = captureMux
-		mcpInit("127.0.0.1:29999")
-		http.DefaultServeMux = origMux
+		mcpInit("127.0.0.1:29999", captureMux)
 
 		// Extract the concrete handler registered for "/mcp".
 		h, _ := captureMux.Handler(httptest.NewRequest("GET", "/mcp", nil))

--- a/server/server/mcp.go
+++ b/server/server/mcp.go
@@ -31,7 +31,7 @@ var (
 )
 
 // mcpInit initializes and sets up the Model Context Protocol (MCP) server
-func mcpInit(addr string) {
+func mcpInit(addr string, mux *http.ServeMux) {
 	hooks := &server.Hooks{}
 
 	// Create a new MCP server instance
@@ -57,7 +57,7 @@ func mcpInit(addr string) {
 		server.WithHeartbeatInterval(20*time.Second),
 	)
 
-	http.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/mcp/sse" || r.URL.Path == "/mcp/message" {
 			sse.ServeHTTP(w, r)
 		} else {

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -20,30 +20,32 @@ func StartServer(wg *sync.WaitGroup, addr string, socketPath string) {
 
 	var shuttingDown atomic.Bool
 
-	http.HandleFunc("/", http.NotFound)
-	http.HandleFunc("/health", handleHealth)
-	http.HandleFunc("/api/v1/server/restart", handleRestart)
-	http.HandleFunc("/api/v1/server/stop", handleStop)
-	http.HandleFunc("/api/v1/server/status", handleStatus)
+	mux := http.NewServeMux()
 
-	http.HandleFunc("/api/v1/document/update", handleUpdateDocument)
-	http.HandleFunc("/api/v1/document/delete", handleDeleteDocument)
+	mux.HandleFunc("/", http.NotFound)
+	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/api/v1/server/restart", handleRestart)
+	mux.HandleFunc("/api/v1/server/stop", handleStop)
+	mux.HandleFunc("/api/v1/server/status", handleStatus)
 
-	http.HandleFunc("/api/v1/workspace/create", handleCreateWorkspace)
-	http.HandleFunc("/api/v1/workspace/delete", handleDeleteWorkspace)
-	http.HandleFunc("/api/v1/workspace/list", handleListWorkspace)
-	http.HandleFunc("/api/v1/workspace/get", handleGetWorkspace)
-	http.HandleFunc("/api/v1/workspace/sync-all", handleSyncAllWorkspaces)
-	http.HandleFunc("/api/v1/workspace/sync", handleSyncWorkspace)
-	http.HandleFunc("/api/v1/workspace/update", handleUpdateWorkspace)
-	http.HandleFunc("/api/v1/workspace/move", handleMoveWorkspace)
+	mux.HandleFunc("/api/v1/document/update", handleUpdateDocument)
+	mux.HandleFunc("/api/v1/document/delete", handleDeleteDocument)
 
-	http.HandleFunc("/api/v1/search/content", handleSearchContent)
-	http.HandleFunc("/api/v1/search/files", handleSearchFiles)
-	http.HandleFunc("/api/v1/search/symbols", handleSearchSymbols)
+	mux.HandleFunc("/api/v1/workspace/create", handleCreateWorkspace)
+	mux.HandleFunc("/api/v1/workspace/delete", handleDeleteWorkspace)
+	mux.HandleFunc("/api/v1/workspace/list", handleListWorkspace)
+	mux.HandleFunc("/api/v1/workspace/get", handleGetWorkspace)
+	mux.HandleFunc("/api/v1/workspace/sync-all", handleSyncAllWorkspaces)
+	mux.HandleFunc("/api/v1/workspace/sync", handleSyncWorkspace)
+	mux.HandleFunc("/api/v1/workspace/update", handleUpdateWorkspace)
+	mux.HandleFunc("/api/v1/workspace/move", handleMoveWorkspace)
+
+	mux.HandleFunc("/api/v1/search/content", handleSearchContent)
+	mux.HandleFunc("/api/v1/search/files", handleSearchFiles)
+	mux.HandleFunc("/api/v1/search/symbols", handleSearchSymbols)
 
 	if addr != "" {
-		mcpInit(addr)
+		mcpInit(addr, mux)
 	} else {
 		log.Println("[HTTP] No TCP address provided, skipping MCP server initialization")
 	}
@@ -52,7 +54,8 @@ func StartServer(wg *sync.WaitGroup, addr string, socketPath string) {
 	var tcpServer *http.Server
 	if addr != "" {
 		tcpServer = &http.Server{
-			Addr: addr,
+			Addr:    addr,
+			Handler: mux,
 		}
 		go func() {
 			log.Printf("[HTTP] Server starting on %s", addr)
@@ -76,7 +79,7 @@ func StartServer(wg *sync.WaitGroup, addr string, socketPath string) {
 		if err != nil {
 			log.Fatalf("[HTTP] Error: Listen on unix socket %s failed: %v", socketPath, err)
 		}
-		unixSocketServer = &http.Server{}
+		unixSocketServer = &http.Server{Handler: mux}
 		go func() {
 			log.Printf("[HTTP] Unix socket server starting on %s", socketPath)
 			err := unixSocketServer.Serve(unixSocketListener)


### PR DESCRIPTION
Fixes flaky test panic when running with -shuffle=on -count=3. Replaces global http.DefaultServeMux with per-server http.NewServeMux() to avoid duplicate route registration across test runs.