### PR TITLE
fix: prevent workspace indexing deadlock after scan interruption (state mgmt step 2)

### DIFF
--- a/internal/core/workspace/workspace.go
+++ b/internal/core/workspace/workspace.go
@@ -11,6 +11,15 @@ import (
 	"github.com/codetrek/haystack/internal/shared/types"
 )
 
+type IndexingState int
+
+const (
+	IndexingIdle IndexingState = iota
+	IndexingScanning
+	IndexingDone
+	IndexingFailed
+)
+
 type IndexingStatus struct {
 	StartedAt         *time.Time
 	TotalFiles        int
@@ -30,6 +39,7 @@ type Workspace struct {
 	LastFullSync time.Time `json:"last_full_sync_time"`
 
 	deleted        bool            `json:"-"`
+	indexingState  IndexingState   `json:"-"`
 	indexingStatus *IndexingStatus `json:"-"`
 	mutex          sync.Mutex      `json:"-"`
 }
@@ -91,11 +101,12 @@ func (w *Workspace) StartIndexing() error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	if w.indexingStatus != nil {
+	if w.indexingState == IndexingScanning {
 		return fmt.Errorf("workspace is indexing")
 	}
 
 	now := time.Now()
+	w.indexingState = IndexingScanning
 	w.indexingStatus = &IndexingStatus{
 		StartedAt:         &now,
 		TotalFiles:        0,
@@ -131,6 +142,7 @@ func (w *Workspace) UpdateLastFullSync() {
 		w.indexingStatus = nil
 	}
 
+	w.indexingState = IndexingDone
 	w.LastFullSync = time.Now()
 }
 
@@ -151,6 +163,29 @@ func (w *Workspace) GetFilters() types.Filters {
 	}
 
 	return t
+}
+
+func (w *Workspace) SetIndexingFailed() {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	w.indexingState = IndexingFailed
+	w.indexingStatus = nil
+}
+
+func (w *Workspace) ResetIndexingState() {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	w.indexingState = IndexingIdle
+	w.indexingStatus = nil
+}
+
+func (w *Workspace) GetIndexingState() IndexingState {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	return w.indexingState
 }
 
 func (w *Workspace) SetDeleted() {

--- a/internal/core/workspace/workspace_indexing_test.go
+++ b/internal/core/workspace/workspace_indexing_test.go
@@ -1,0 +1,221 @@
+package workspace
+
+import (
+	"testing"
+)
+
+func TestStartIndexing_IdleState(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	// Fresh workspace should be in Idle state
+	if ws.GetIndexingState() != IndexingIdle {
+		t.Fatalf("new workspace should be in IndexingIdle state, got %d", ws.GetIndexingState())
+	}
+
+	err := ws.StartIndexing()
+	if err != nil {
+		t.Fatalf("StartIndexing on idle workspace should succeed: %v", err)
+	}
+
+	if ws.GetIndexingState() != IndexingScanning {
+		t.Errorf("state should be IndexingScanning after StartIndexing, got %d", ws.GetIndexingState())
+	}
+
+	status := ws.GetIndexingStatus()
+	if status == nil {
+		t.Fatal("indexing status should not be nil after StartIndexing")
+	}
+	if status.StartedAt == nil {
+		t.Error("indexing status StartedAt should be set")
+	}
+}
+
+func TestStartIndexing_ScanningState_Rejected(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	err := ws.StartIndexing()
+	if err != nil {
+		t.Fatalf("first StartIndexing should succeed: %v", err)
+	}
+
+	// Second call while scanning should be rejected
+	err = ws.StartIndexing()
+	if err == nil {
+		t.Fatal("StartIndexing should fail when already scanning")
+	}
+
+	if ws.GetIndexingState() != IndexingScanning {
+		t.Errorf("state should still be IndexingScanning, got %d", ws.GetIndexingState())
+	}
+}
+
+func TestStartIndexing_AfterFailure_Succeeds(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	// Start indexing
+	if err := ws.StartIndexing(); err != nil {
+		t.Fatalf("StartIndexing failed: %v", err)
+	}
+
+	// Simulate failure
+	ws.SetIndexingFailed()
+
+	if ws.GetIndexingState() != IndexingFailed {
+		t.Fatalf("state should be IndexingFailed, got %d", ws.GetIndexingState())
+	}
+	if ws.GetIndexingStatus() != nil {
+		t.Error("indexing status should be nil after SetIndexingFailed")
+	}
+
+	// Should be able to start indexing again
+	err := ws.StartIndexing()
+	if err != nil {
+		t.Fatalf("StartIndexing after failure should succeed: %v", err)
+	}
+
+	if ws.GetIndexingState() != IndexingScanning {
+		t.Errorf("state should be IndexingScanning, got %d", ws.GetIndexingState())
+	}
+	if ws.GetIndexingStatus() == nil {
+		t.Error("indexing status should not be nil after restart")
+	}
+}
+
+func TestStartIndexing_AfterDone_Succeeds(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	// Start indexing
+	if err := ws.StartIndexing(); err != nil {
+		t.Fatalf("StartIndexing failed: %v", err)
+	}
+
+	// Add some files during indexing
+	ws.AddIndexingTotalFiles(10)
+
+	// Complete successfully
+	ws.UpdateLastFullSync()
+
+	if ws.GetIndexingState() != IndexingDone {
+		t.Fatalf("state should be IndexingDone after UpdateLastFullSync, got %d", ws.GetIndexingState())
+	}
+	if ws.GetIndexingStatus() != nil {
+		t.Error("indexing status should be nil after UpdateLastFullSync")
+	}
+	if ws.TotalFiles != 10 {
+		t.Errorf("TotalFiles should be 10 after sync, got %d", ws.TotalFiles)
+	}
+
+	// Should be able to start indexing again
+	err := ws.StartIndexing()
+	if err != nil {
+		t.Fatalf("StartIndexing after Done should succeed: %v", err)
+	}
+
+	if ws.GetIndexingState() != IndexingScanning {
+		t.Errorf("state should be IndexingScanning, got %d", ws.GetIndexingState())
+	}
+}
+
+func TestResetIndexingState(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	// Test reset from Scanning state
+	if err := ws.StartIndexing(); err != nil {
+		t.Fatalf("StartIndexing failed: %v", err)
+	}
+	if ws.GetIndexingState() != IndexingScanning {
+		t.Fatalf("expected IndexingScanning, got %d", ws.GetIndexingState())
+	}
+
+	ws.ResetIndexingState()
+	if ws.GetIndexingState() != IndexingIdle {
+		t.Errorf("state should be IndexingIdle after reset, got %d", ws.GetIndexingState())
+	}
+	if ws.GetIndexingStatus() != nil {
+		t.Error("indexing status should be nil after reset")
+	}
+
+	// Test reset from Failed state
+	if err := ws.StartIndexing(); err != nil {
+		t.Fatalf("StartIndexing failed: %v", err)
+	}
+	ws.SetIndexingFailed()
+	if ws.GetIndexingState() != IndexingFailed {
+		t.Fatalf("expected IndexingFailed, got %d", ws.GetIndexingState())
+	}
+
+	ws.ResetIndexingState()
+	if ws.GetIndexingState() != IndexingIdle {
+		t.Errorf("state should be IndexingIdle after reset from Failed, got %d", ws.GetIndexingState())
+	}
+
+	// Test reset from Done state
+	if err := ws.StartIndexing(); err != nil {
+		t.Fatalf("StartIndexing failed: %v", err)
+	}
+	ws.UpdateLastFullSync()
+	if ws.GetIndexingState() != IndexingDone {
+		t.Fatalf("expected IndexingDone, got %d", ws.GetIndexingState())
+	}
+
+	ws.ResetIndexingState()
+	if ws.GetIndexingState() != IndexingIdle {
+		t.Errorf("state should be IndexingIdle after reset from Done, got %d", ws.GetIndexingState())
+	}
+}
+
+func TestScanInterruptionRecovery(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	// 1. Start indexing (simulates scanner.Add)
+	err := ws.StartIndexing()
+	if err != nil {
+		t.Fatalf("initial StartIndexing should succeed: %v", err)
+	}
+	if ws.GetIndexingState() != IndexingScanning {
+		t.Fatalf("expected IndexingScanning, got %d", ws.GetIndexingState())
+	}
+
+	// 2. Simulate some work happening
+	ws.AddIndexingTotalFiles(50)
+	ws.AddIndexingFiles(25)
+
+	// 3. Simulate scan failure (error from processWorkspace)
+	ws.SetIndexingFailed()
+	if ws.GetIndexingState() != IndexingFailed {
+		t.Fatalf("expected IndexingFailed, got %d", ws.GetIndexingState())
+	}
+
+	// 4. Verify re-indexing is rejected while not reset (shouldn't be - Failed allows restart)
+	// Actually, Failed state should allow restart per the design
+	err = ws.StartIndexing()
+	if err != nil {
+		t.Fatalf("StartIndexing after failure should succeed: %v", err)
+	}
+
+	// 5. Verify the new indexing status is fresh
+	status := ws.GetIndexingStatus()
+	if status == nil {
+		t.Fatal("indexing status should not be nil after restart")
+	}
+	if status.TotalFiles != 0 {
+		t.Errorf("restarted indexing should have TotalFiles=0, got %d", status.TotalFiles)
+	}
+	if status.IndexedFiles != 0 {
+		t.Errorf("restarted indexing should have IndexedFiles=0, got %d", status.IndexedFiles)
+	}
+
+	// 6. Complete successfully this time
+	ws.AddIndexingTotalFiles(100)
+	ws.UpdateLastFullSync()
+
+	if ws.GetIndexingState() != IndexingDone {
+		t.Errorf("expected IndexingDone after successful completion, got %d", ws.GetIndexingState())
+	}
+	if ws.TotalFiles != 100 {
+		t.Errorf("TotalFiles should be 100 after successful re-index, got %d", ws.TotalFiles)
+	}
+	if ws.GetLastFullSync().IsZero() {
+		t.Error("LastFullSync should be set after successful completion")
+	}
+}

--- a/internal/server/indexer/scanner.go
+++ b/internal/server/indexer/scanner.go
@@ -81,6 +81,7 @@ func (s *Scanner) run(wg *sync.WaitGroup) {
 		s.setCurrent(workspace)
 		if err := s.processWorkspace(workspace, scanTask.forceRefresh); err != nil {
 			log.Printf("[Indexer] Error scanning workspace %s: %v", workspace.Path, err)
+			workspace.SetIndexingFailed()
 		} else {
 			workspace.UpdateLastFullSync()
 			workspace.Save()


### PR DESCRIPTION
Introduces IndexingState enum to replace nil-check on indexingStatus. Scanning failures now properly transition to Failed state, allowing re-indexing. Fixes the bug where interrupted scans permanently blocked workspace re-indexing.