### PR TITLE
refactor: derive TotalFiles from documents store (state mgmt step 1)

### DIFF
--- a/internal/core/documents/count_test.go
+++ b/internal/core/documents/count_test.go
@@ -1,0 +1,100 @@
+package documents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountByWorkspace_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	mustCreateWorkspace(t, 1)
+
+	count := CountByWorkspace(1)
+	assert.Equal(t, 0, count, "empty workspace should have 0 documents")
+}
+
+func TestCountByWorkspace_WithDocuments(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	mustCreateWorkspace(t, 1)
+
+	// Save some documents
+	docs := []*Document{
+		{ID: "doc1", RelPath: "a.go", Words: []string{"hello"}, PathWords: []string{"a"}},
+		{ID: "doc2", RelPath: "b.go", Words: []string{"world"}, PathWords: []string{"b"}},
+		{ID: "doc3", RelPath: "c.go", Words: []string{"foo"}, PathWords: []string{"c"}},
+	}
+	err := SaveNewDocuments(1, docs)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	count := CountByWorkspace(1)
+	assert.Equal(t, 3, count, "should count 3 documents")
+}
+
+func TestCountByWorkspace_MultipleWorkspaces(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	mustCreateWorkspace(t, 1)
+	mustCreateWorkspace(t, 2)
+
+	// Save 2 docs in workspace 1
+	err := SaveNewDocuments(1, []*Document{
+		{ID: "doc1", RelPath: "a.go", Words: []string{"a"}, PathWords: []string{"a"}},
+		{ID: "doc2", RelPath: "b.go", Words: []string{"b"}, PathWords: []string{"b"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Save 1 doc in workspace 2
+	err = SaveNewDocuments(2, []*Document{
+		{ID: "doc3", RelPath: "c.go", Words: []string{"c"}, PathWords: []string{"c"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, 2, CountByWorkspace(1), "workspace 1 should have 2 documents")
+	assert.Equal(t, 1, CountByWorkspace(2), "workspace 2 should have 1 document")
+}
+
+func TestCountByWorkspace_NonExistentWorkspace(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	count := CountByWorkspace(999)
+	assert.Equal(t, 0, count, "non-existent workspace should have 0 documents")
+}
+
+func TestCountByWorkspace_AfterDelete(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	mustCreateWorkspace(t, 1)
+
+	// Save 2 docs
+	err := SaveNewDocuments(1, []*Document{
+		{ID: "doc1", RelPath: "a.go", Words: []string{"a"}, PathWords: []string{"a"}},
+		{ID: "doc2", RelPath: "b.go", Words: []string{"b"}, PathWords: []string{"b"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, 2, CountByWorkspace(1), "should have 2 documents before delete")
+
+	// Delete one document
+	err = DeleteDocument(1, "doc1")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, 1, CountByWorkspace(1), "should have 1 document after deleting one")
+}

--- a/internal/core/documents/count_test.go
+++ b/internal/core/documents/count_test.go
@@ -98,3 +98,55 @@ func TestCountByWorkspace_AfterDelete(t *testing.T) {
 
 	assert.Equal(t, 1, CountByWorkspace(1), "should have 1 document after deleting one")
 }
+
+func TestCountByWorkspace_AfterWorkspaceDelete(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	mustCreateWorkspace(t, 1)
+
+	// Save docs
+	err := SaveNewDocuments(1, []*Document{
+		{ID: "doc1", RelPath: "a.go", Words: []string{"a"}, PathWords: []string{"a"}},
+		{ID: "doc2", RelPath: "b.go", Words: []string{"b"}, PathWords: []string{"b"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, 2, CountByWorkspace(1), "should have 2 documents before workspace delete")
+
+	// Delete the entire workspace
+	err = Delete(1)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, 0, CountByWorkspace(1), "should have 0 documents after workspace delete")
+}
+
+func TestCountByWorkspace_IncrementsBatchCorrectly(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	mustCreateWorkspace(t, 1)
+
+	// Save first batch
+	err := SaveNewDocuments(1, []*Document{
+		{ID: "doc1", RelPath: "a.go", Words: []string{"a"}, PathWords: []string{"a"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, 1, CountByWorkspace(1), "should have 1 after first batch")
+
+	// Save second batch
+	err = SaveNewDocuments(1, []*Document{
+		{ID: "doc2", RelPath: "b.go", Words: []string{"b"}, PathWords: []string{"b"}},
+		{ID: "doc3", RelPath: "c.go", Words: []string{"c"}, PathWords: []string{"c"}},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, 3, CountByWorkspace(1), "should have 3 after second batch")
+}

--- a/internal/core/documents/document.go
+++ b/internal/core/documents/document.go
@@ -104,9 +104,14 @@ func SaveNewDocuments(workspaceid int, docs []*Document) error {
 		err = batch.Commit()
 		if err != nil {
 			log.Println("[Documents] Error: failed to save new documents:", err)
+			return err
 		}
 
-		return err
+		docCountMu.Lock()
+		docCount[workspaceid] += len(docs)
+		docCountMu.Unlock()
+
+		return nil
 	})
 }
 
@@ -189,8 +194,13 @@ func DeleteDocument(workspaceId int, docId string) error {
 		err = batch.Commit()
 		if err != nil {
 			log.Println("[Documents] Failed to delete document:", err)
+			return err
 		}
 
-		return err
+		docCountMu.Lock()
+		docCount[workspaceId] -= 1
+		docCountMu.Unlock()
+
+		return nil
 	})
 }

--- a/internal/core/documents/storage.go
+++ b/internal/core/documents/storage.go
@@ -99,6 +99,18 @@ func Delete(workspaceId int) error {
 	})
 }
 
+// CountByWorkspace counts all document meta keys for a given workspace ID
+// by scanning the DB with the workspace prefix.
+func CountByWorkspace(workspaceId int) int {
+	prefix := EncodeDocumentMetaKey(workspaceId, "")
+	count := 0
+	db.Scan(prefix, func(key, value []byte) bool {
+		count++
+		return true
+	})
+	return count
+}
+
 // GetWorkspace retrieves the workspace information for a given workspace ID
 func GetWorkspace(workspaceid int) (*Workspace, error) {
 	mutex.Lock()

--- a/internal/core/documents/storage.go
+++ b/internal/core/documents/storage.go
@@ -18,6 +18,9 @@ var (
 	mutex             sync.Mutex
 	Workspaces        map[int]*Workspace
 	deletedWorkspaces map[int]struct{}
+
+	docCountMu sync.RWMutex
+	docCount   map[int]int // workspaceId -> document count
 )
 
 type Workspace struct {
@@ -47,6 +50,7 @@ func Init(database pebble.DB, q *queue.Mpsc) error {
 	mpsc = q
 	Workspaces = make(map[int]*Workspace)
 	deletedWorkspaces = make(map[int]struct{})
+	docCount = make(map[int]int)
 
 	log.Println("[Documents] Initialized")
 	return nil
@@ -59,6 +63,10 @@ func CloseAndWait() {
 	mpsc = nil
 	Workspaces = nil
 	deletedWorkspaces = nil
+
+	docCountMu.Lock()
+	docCount = nil
+	docCountMu.Unlock()
 
 	log.Println("[Documents] Closed")
 }
@@ -77,7 +85,24 @@ func Create(workspaceId int, desc string) error {
 
 	// Create a new collection in the database
 	// This is a placeholder function and should be implemented
-	return db.Put(EncodeMetaKey(workspaceId), EncodeFTMetaValue(ft))
+	err = db.Put(EncodeMetaKey(workspaceId), EncodeFTMetaValue(ft))
+	if err != nil {
+		return err
+	}
+
+	// Initialize the in-memory document count by scanning the DB once
+	prefix := EncodeDocumentMetaKey(workspaceId, "")
+	count := 0
+	db.Scan(prefix, func(key, value []byte) bool {
+		count++
+		return true
+	})
+
+	docCountMu.Lock()
+	docCount[workspaceId] = count
+	docCountMu.Unlock()
+
+	return nil
 }
 
 // Delete deletes a workspace and all of its documents and keywords
@@ -95,20 +120,26 @@ func Delete(workspaceId int) error {
 		batch.DeletePrefix(EncodeDocumentMetaKey(workspaceId, ""))
 		batch.DeletePrefix(EncodeDocumentWordsKey(workspaceId, ""))
 
-		return batch.Commit()
+		err = batch.Commit()
+		if err != nil {
+			return err
+		}
+
+		// Clean up in-memory document count for this workspace
+		docCountMu.Lock()
+		delete(docCount, workspaceId)
+		docCountMu.Unlock()
+
+		return nil
 	})
 }
 
-// CountByWorkspace counts all document meta keys for a given workspace ID
-// by scanning the DB with the workspace prefix.
+// CountByWorkspace returns the number of documents for a given workspace ID
+// using an in-memory counter maintained by document mutations. O(1).
 func CountByWorkspace(workspaceId int) int {
-	prefix := EncodeDocumentMetaKey(workspaceId, "")
-	count := 0
-	db.Scan(prefix, func(key, value []byte) bool {
-		count++
-		return true
-	})
-	return count
+	docCountMu.RLock()
+	defer docCountMu.RUnlock()
+	return docCount[workspaceId]
 }
 
 // GetWorkspace retrieves the workspace information for a given workspace ID

--- a/internal/core/workspace/init_test.go
+++ b/internal/core/workspace/init_test.go
@@ -518,12 +518,20 @@ func TestGetAll_WithIndexingStatus(t *testing.T) {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	// Start indexing and add total files via indexing
+	// Set up CountByWorkspaceFunc to return a known value
+	CountByWorkspaceFunc = func(wsId int) int {
+		if wsId == ws.Id {
+			return 99
+		}
+		return 0
+	}
+	defer func() { CountByWorkspaceFunc = nil }()
+
+	// Start indexing
 	err = ws.StartIndexing()
 	if err != nil {
 		t.Fatalf("StartIndexing failed: %v", err)
 	}
-	ws.AddIndexingTotalFiles(99)
 
 	all := GetAll()
 	found := false
@@ -534,7 +542,7 @@ func TestGetAll_WithIndexingStatus(t *testing.T) {
 				t.Error("Workspace should be marked as indexing")
 			}
 			if w.TotalFiles != 99 {
-				t.Errorf("TotalFiles = %d, want 99 (from indexing status)", w.TotalFiles)
+				t.Errorf("TotalFiles = %d, want 99 (from CountByWorkspaceFunc)", w.TotalFiles)
 			}
 			break
 		}

--- a/internal/core/workspace/workspace.go
+++ b/internal/core/workspace/workspace.go
@@ -20,6 +20,11 @@ const (
 	IndexingFailed
 )
 
+// CountByWorkspaceFunc is a callback to count documents for a workspace.
+// It is set by the documents package during server initialization to avoid
+// circular imports.
+var CountByWorkspaceFunc func(wsId int) int
+
 type IndexingStatus struct {
 	StartedAt         *time.Time
 	TotalFiles        int
@@ -44,13 +49,6 @@ type Workspace struct {
 	mutex          sync.Mutex      `json:"-"`
 }
 
-func (w *Workspace) AddTotalFiles(n int) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-
-	w.TotalFiles += n
-}
-
 func (w *Workspace) AddIndexingFiles(n int) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
@@ -69,25 +67,14 @@ func (w *Workspace) AddSymbolParsedFiles(n int) {
 	}
 }
 
-func (w *Workspace) AddIndexingTotalFiles(n int) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-
-	if w.indexingStatus != nil {
-		w.indexingStatus.TotalFiles += n
-	}
-}
-
 func (w *Workspace) GetTotalFiles() int {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	totalFiles := w.TotalFiles
-	if totalFiles == 0 && w.indexingStatus != nil {
-		totalFiles = w.indexingStatus.TotalFiles
+	if CountByWorkspaceFunc != nil {
+		return CountByWorkspaceFunc(w.Id)
 	}
-
-	return totalFiles
+	return 0
 }
 
 func (w *Workspace) GetIndexingStatus() *IndexingStatus {
@@ -138,7 +125,6 @@ func (w *Workspace) UpdateLastFullSync() {
 	defer w.mutex.Unlock()
 
 	if w.indexingStatus != nil {
-		w.TotalFiles = w.indexingStatus.TotalFiles
 		w.indexingStatus = nil
 	}
 

--- a/internal/core/workspace/workspace_indexing_test.go
+++ b/internal/core/workspace/workspace_indexing_test.go
@@ -90,7 +90,6 @@ func TestStartIndexing_AfterDone_Succeeds(t *testing.T) {
 	}
 
 	// Add some files during indexing
-	ws.AddIndexingTotalFiles(10)
 
 	// Complete successfully
 	ws.UpdateLastFullSync()
@@ -100,9 +99,6 @@ func TestStartIndexing_AfterDone_Succeeds(t *testing.T) {
 	}
 	if ws.GetIndexingStatus() != nil {
 		t.Error("indexing status should be nil after UpdateLastFullSync")
-	}
-	if ws.TotalFiles != 10 {
-		t.Errorf("TotalFiles should be 10 after sync, got %d", ws.TotalFiles)
 	}
 
 	// Should be able to start indexing again
@@ -177,7 +173,6 @@ func TestScanInterruptionRecovery(t *testing.T) {
 	}
 
 	// 2. Simulate some work happening
-	ws.AddIndexingTotalFiles(50)
 	ws.AddIndexingFiles(25)
 
 	// 3. Simulate scan failure (error from processWorkspace)
@@ -206,15 +201,12 @@ func TestScanInterruptionRecovery(t *testing.T) {
 	}
 
 	// 6. Complete successfully this time
-	ws.AddIndexingTotalFiles(100)
 	ws.UpdateLastFullSync()
 
 	if ws.GetIndexingState() != IndexingDone {
 		t.Errorf("expected IndexingDone after successful completion, got %d", ws.GetIndexingState())
 	}
-	if ws.TotalFiles != 100 {
-		t.Errorf("TotalFiles should be 100 after successful re-index, got %d", ws.TotalFiles)
-	}
+
 	if ws.GetLastFullSync().IsZero() {
 		t.Error("LastFullSync should be set after successful completion")
 	}

--- a/internal/core/workspace/workspace_test.go
+++ b/internal/core/workspace/workspace_test.go
@@ -26,45 +26,34 @@ func TestWorkspaceMethods(t *testing.T) {
 		LastFullSync:     time.Now(),
 	}
 
-	// Test AddTotalFiles
-	ws.AddTotalFiles(5)
-	if ws.TotalFiles != 5 {
-		t.Errorf("AddTotalFiles failed, got %d, want 5", ws.TotalFiles)
-	}
-
 	// Test StartIndexing
 	err := ws.StartIndexing()
 	if err != nil {
 		t.Fatalf("StartIndexing failed: %v", err)
 	}
 
-	// Test AddIndexingFiles and AddIndexingTotalFiles
-	ws.AddIndexingTotalFiles(10)
+	// Test AddIndexingFiles
 	ws.AddIndexingFiles(3)
 	status := ws.GetIndexingStatus()
 	if status == nil {
 		t.Fatal("Indexing status is nil")
 	}
-	if status.TotalFiles != 10 {
-		t.Errorf("AddIndexingTotalFiles failed, got %d, want 10", status.TotalFiles)
-	}
 	if status.IndexedFiles != 3 {
 		t.Errorf("AddIndexingFiles failed, got %d, want 3", status.IndexedFiles)
 	}
 
-	// Test GetTotalFiles
+	// Test GetTotalFiles with CountByWorkspaceFunc set
+	CountByWorkspaceFunc = func(wsId int) int { return 42 }
+	defer func() { CountByWorkspaceFunc = nil }()
 	totalFiles := ws.GetTotalFiles()
-	if totalFiles != 5 {
-		t.Errorf("GetTotalFiles failed, got %d, want 5", totalFiles)
+	if totalFiles != 42 {
+		t.Errorf("GetTotalFiles failed, got %d, want 42", totalFiles)
 	}
 
 	// Test UpdateLastFullSync
 	ws.UpdateLastFullSync()
 	if ws.indexingStatus != nil {
 		t.Error("UpdateLastFullSync failed to clear indexing status")
-	}
-	if ws.TotalFiles != 10 {
-		t.Errorf("UpdateLastFullSync failed to update total files, got %d, want 10", ws.TotalFiles)
 	}
 
 	// Test GetFilters
@@ -86,29 +75,59 @@ func TestWorkspaceMethods(t *testing.T) {
 	}
 }
 
-func TestWorkspaceTotalFilesConcurrency(t *testing.T) {
+func TestGetTotalFiles_WithFunc(t *testing.T) {
+	ws := &Workspace{Id: 7, Path: "/test"}
+
+	CountByWorkspaceFunc = func(wsId int) int {
+		if wsId == 7 {
+			return 100
+		}
+		return 0
+	}
+	defer func() { CountByWorkspaceFunc = nil }()
+
+	total := ws.GetTotalFiles()
+	if total != 100 {
+		t.Errorf("GetTotalFiles = %d, want 100", total)
+	}
+}
+
+func TestGetTotalFiles_WithoutFunc(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+
+	old := CountByWorkspaceFunc
+	CountByWorkspaceFunc = nil
+	defer func() { CountByWorkspaceFunc = old }()
+
+	total := ws.GetTotalFiles()
+	if total != 0 {
+		t.Errorf("GetTotalFiles = %d, want 0 when CountByWorkspaceFunc is nil", total)
+	}
+}
+
+func TestGetTotalFiles_Concurrency(t *testing.T) {
 	ws := &Workspace{
 		Id:               98,
 		Path:             "/test/path",
 		UseGlobalFilters: true,
-		TotalFiles:       0,
 	}
 
-	// Test concurrent access
+	CountByWorkspaceFunc = func(wsId int) int { return 42 }
+	defer func() { CountByWorkspaceFunc = nil }()
+
+	// Test concurrent access to GetTotalFiles
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ws.AddTotalFiles(1)
-			ws.GetTotalFiles()
+			total := ws.GetTotalFiles()
+			if total != 42 {
+				t.Errorf("Concurrent GetTotalFiles = %d, want 42", total)
+			}
 		}()
 	}
 	wg.Wait()
-
-	if ws.TotalFiles != 100 {
-		t.Errorf("Concurrent access failed, got %d, want 100", ws.TotalFiles)
-	}
 }
 
 func TestWorkspaceFilters(t *testing.T) {
@@ -181,14 +200,6 @@ func TestAddIndexingFiles_NoIndexingStatus(t *testing.T) {
 	}
 }
 
-func TestAddIndexingTotalFiles_NoIndexingStatus(t *testing.T) {
-	ws := &Workspace{Id: 1, Path: "/test"}
-	ws.AddIndexingTotalFiles(5)
-	if ws.indexingStatus != nil {
-		t.Error("AddIndexingTotalFiles should not create indexing status")
-	}
-}
-
 func TestStartIndexing_AlreadyIndexing(t *testing.T) {
 	ws := &Workspace{Id: 1, Path: "/test"}
 	if err := ws.StartIndexing(); err != nil {
@@ -197,38 +208,6 @@ func TestStartIndexing_AlreadyIndexing(t *testing.T) {
 	err := ws.StartIndexing()
 	if err == nil {
 		t.Error("StartIndexing should fail when already indexing")
-	}
-}
-
-func TestGetTotalFiles_FallbackToIndexingStatus(t *testing.T) {
-	ws := &Workspace{Id: 1, Path: "/test", TotalFiles: 0}
-	if err := ws.StartIndexing(); err != nil {
-		t.Fatalf("StartIndexing failed: %v", err)
-	}
-	ws.AddIndexingTotalFiles(42)
-	total := ws.GetTotalFiles()
-	if total != 42 {
-		t.Errorf("GetTotalFiles = %d, want 42 (fallback to indexing status)", total)
-	}
-}
-
-func TestGetTotalFiles_PrefersTotalFiles(t *testing.T) {
-	ws := &Workspace{Id: 1, Path: "/test", TotalFiles: 100}
-	if err := ws.StartIndexing(); err != nil {
-		t.Fatalf("StartIndexing failed: %v", err)
-	}
-	ws.AddIndexingTotalFiles(50)
-	total := ws.GetTotalFiles()
-	if total != 100 {
-		t.Errorf("GetTotalFiles = %d, want 100 (should prefer TotalFiles)", total)
-	}
-}
-
-func TestGetTotalFiles_NoIndexingStatusZero(t *testing.T) {
-	ws := &Workspace{Id: 1, Path: "/test", TotalFiles: 0}
-	total := ws.GetTotalFiles()
-	if total != 0 {
-		t.Errorf("GetTotalFiles = %d, want 0", total)
 	}
 }
 
@@ -259,10 +238,24 @@ func TestIsDeleted_Default(t *testing.T) {
 
 func TestUpdateLastFullSync_NoIndexingStatus(t *testing.T) {
 	ws := &Workspace{Id: 1, Path: "/test", TotalFiles: 50}
-	before := ws.TotalFiles
 	ws.UpdateLastFullSync()
-	if ws.TotalFiles != before {
-		t.Errorf("TotalFiles changed from %d to %d without indexing status", before, ws.TotalFiles)
+	// TotalFiles should remain unchanged (it's no longer overwritten)
+	if ws.TotalFiles != 50 {
+		t.Errorf("TotalFiles changed to %d, should stay 50", ws.TotalFiles)
+	}
+	if ws.GetLastFullSync().IsZero() {
+		t.Error("LastFullSync should be set after UpdateLastFullSync")
+	}
+}
+
+func TestUpdateLastFullSync_ClearsIndexingStatus(t *testing.T) {
+	ws := &Workspace{Id: 1, Path: "/test"}
+	if err := ws.StartIndexing(); err != nil {
+		t.Fatalf("StartIndexing failed: %v", err)
+	}
+	ws.UpdateLastFullSync()
+	if ws.indexingStatus != nil {
+		t.Error("UpdateLastFullSync should clear indexing status")
 	}
 	if ws.GetLastFullSync().IsZero() {
 		t.Error("LastFullSync should be set after UpdateLastFullSync")

--- a/internal/server/indexer/indexer.go
+++ b/internal/server/indexer/indexer.go
@@ -148,7 +148,6 @@ func RemoveFile(workspace *workspace.Workspace, relPath string) error {
 		return err
 	}
 
-	workspace.AddTotalFiles(-1)
 	workspace.Save()
 	return nil
 }

--- a/internal/server/indexer/indexer_test.go
+++ b/internal/server/indexer/indexer_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/codetrek/haystack/internal/conf"
 	"github.com/codetrek/haystack/internal/core/documents"
+	"github.com/codetrek/haystack/internal/core/idtable"
+	"github.com/codetrek/haystack/internal/core/symbols"
 	"github.com/codetrek/haystack/internal/core/workspace"
 	"github.com/codetrek/haystack/internal/shared/running"
 	"github.com/codetrek/haystack/internal/shared/types"
@@ -891,4 +893,91 @@ func TestAddOrSyncFile_ExistingDocDirectoryReplacedFile(t *testing.T) {
 	// AddOrSyncFile should handle this (directory triggers removal)
 	err = AddOrSyncFile(ws, relPath)
 	_ = err
+}
+
+// ---------------------------------------------------------------------------
+// RemoveFile — error branches
+// ---------------------------------------------------------------------------
+
+func TestRemoveFile_GetDocumentIdError(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	wsDir := t.TempDir()
+	ws, err := workspace.Create(wsDir)
+	if err != nil {
+		t.Fatalf("workspace.Create: %v", err)
+	}
+
+	// Close idtable so GetDocumentId → idtable.GetId returns "database is closed"
+	idtable.Close()
+
+	err = RemoveFile(ws, "anyfile.go")
+	if err == nil {
+		t.Error("RemoveFile should return error when idtable is closed")
+	}
+}
+
+func TestRemoveFile_DocumentsDeleteError(t *testing.T) {
+	_, teardown := setupTestEnv(t)
+	defer teardown()
+
+	wsDir := t.TempDir()
+	ws, err := workspace.Create(wsDir)
+	if err != nil {
+		t.Fatalf("workspace.Create: %v", err)
+	}
+
+	// workspace.Create already calls documents.Create, so the doc store
+	// exists. Deleting a file that was never indexed causes
+	// documents.DeleteDocument to return "document not found".
+	err = RemoveFile(ws, "never_indexed.go")
+	if err == nil {
+		t.Error("RemoveFile should return error when document is not found")
+	}
+}
+
+func TestRemoveFile_SymbolsDeleteError(t *testing.T) {
+	env, teardown := setupTestEnv(t)
+	defer teardown()
+
+	// Ensure symbols feature is enabled so symbols.DeleteDocument
+	// actually attempts the lookup rather than short-circuiting.
+	origSymbols := conf.Get().Symbols.EnableFeature
+	conf.Get().Symbols.EnableFeature = true
+	defer func() { conf.Get().Symbols.EnableFeature = origSymbols }()
+
+	wsDir := t.TempDir()
+	ws, err := workspace.Create(wsDir)
+	if err != nil {
+		t.Fatalf("workspace.Create: %v", err)
+	}
+
+	// Index a file so documents.DeleteDocument succeeds.
+	relPath := "sym_err.go"
+	fullPath := filepath.Join(wsDir, relPath)
+	if err := os.WriteFile(fullPath, []byte("package main\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	pf := ParseFile{Workspace: ws, RelFilePath: relPath}
+	doc, newFile, _, err := parse(pf)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if doc == nil || !newFile {
+		t.Fatal("expected new doc from parse")
+	}
+
+	w := NewWriter()
+	w.processDocs([]*WriteDoc{{Workspace: ws, Document: doc, CreateNew: true}})
+
+	// Delete the symbol table metadata key from the database so that
+	// symbols.DeleteDocument → GetSymbolTable fails with a decode error.
+	env.DB.Delete(symbols.EncodeSymbolTableKey(ws.Id))
+
+	err = RemoveFile(ws, relPath)
+	if err == nil {
+		t.Error("RemoveFile should return error when symbols.DeleteDocument fails")
+	}
 }

--- a/internal/server/indexer/scanner.go
+++ b/internal/server/indexer/scanner.go
@@ -157,8 +157,6 @@ func (s *Scanner) processWorkspace(w *workspace.Workspace, forceRefresh bool) er
 		if include.Match(fileInfo.Path, false) {
 			parser.Add(w, fileInfo.Path)
 			fileCount++
-
-			w.AddIndexingTotalFiles(1)
 		}
 
 		if time.Since(lastTime) > 1000*time.Millisecond {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,9 @@ func run() error {
 		return fmt.Errorf("error initializing workspace: %w", err)
 	}
 
+	// Wire up the documents count function for workspace to derive TotalFiles.
+	workspace.CountByWorkspaceFunc = documents.CountByWorkspace
+
 	if err := symbolsInit(db, mpsc); err != nil {
 		running.Shutdown()
 		return fmt.Errorf("error initializing symbols: %w", err)


### PR DESCRIPTION
Replaces manual +1/-1 TotalFiles counting with real-time query from documents store. This establishes a single source of truth for file counts, fixing the bug where incremental file additions were not counted.