### PR TITLE
refactor: rename indexingStatus to indexingProgress (state mgmt step 3)

### DIFF
--- a/internal/core/workspace/init_test.go
+++ b/internal/core/workspace/init_test.go
@@ -506,7 +506,7 @@ func TestGet_NotFound(t *testing.T) {
 	}
 }
 
-func TestGetAll_WithIndexingStatus(t *testing.T) {
+func TestGetAll_WithIndexingProgress(t *testing.T) {
 	cleanup, tempDir := setupFullEnv(t)
 	defer cleanup()
 

--- a/internal/core/workspace/manage.go
+++ b/internal/core/workspace/manage.go
@@ -33,7 +33,7 @@ func GetAll() []types.Workspace {
 
 	result := []types.Workspace{}
 	for _, workspace := range workspaces {
-		indexing := workspace.GetIndexingStatus()
+		indexing := workspace.GetIndexingProgress()
 
 		totalFiles := workspace.GetTotalFiles()
 

--- a/internal/core/workspace/workspace.go
+++ b/internal/core/workspace/workspace.go
@@ -25,9 +25,8 @@ const (
 // circular imports.
 var CountByWorkspaceFunc func(wsId int) int
 
-type IndexingStatus struct {
+type IndexingProgress struct {
 	StartedAt         *time.Time
-	TotalFiles        int
 	IndexedFiles      int
 	SymbolParsedFiles int
 }
@@ -43,18 +42,18 @@ type Workspace struct {
 	LastAccessed time.Time `json:"last_accessed_time"`
 	LastFullSync time.Time `json:"last_full_sync_time"`
 
-	deleted        bool            `json:"-"`
-	indexingState  IndexingState   `json:"-"`
-	indexingStatus *IndexingStatus `json:"-"`
-	mutex          sync.Mutex      `json:"-"`
+	deleted          bool              `json:"-"`
+	indexingState    IndexingState     `json:"-"`
+	indexingProgress *IndexingProgress `json:"-"`
+	mutex            sync.Mutex        `json:"-"`
 }
 
 func (w *Workspace) AddIndexingFiles(n int) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	if w.indexingStatus != nil {
-		w.indexingStatus.IndexedFiles += n
+	if w.indexingProgress != nil {
+		w.indexingProgress.IndexedFiles += n
 	}
 }
 
@@ -62,8 +61,8 @@ func (w *Workspace) AddSymbolParsedFiles(n int) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	if w.indexingStatus != nil {
-		w.indexingStatus.SymbolParsedFiles += n
+	if w.indexingProgress != nil {
+		w.indexingProgress.SymbolParsedFiles += n
 	}
 }
 
@@ -77,11 +76,11 @@ func (w *Workspace) GetTotalFiles() int {
 	return 0
 }
 
-func (w *Workspace) GetIndexingStatus() *IndexingStatus {
+func (w *Workspace) GetIndexingProgress() *IndexingProgress {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	return w.indexingStatus
+	return w.indexingProgress
 }
 
 func (w *Workspace) StartIndexing() error {
@@ -94,9 +93,8 @@ func (w *Workspace) StartIndexing() error {
 
 	now := time.Now()
 	w.indexingState = IndexingScanning
-	w.indexingStatus = &IndexingStatus{
+	w.indexingProgress = &IndexingProgress{
 		StartedAt:         &now,
-		TotalFiles:        0,
 		IndexedFiles:      0,
 		SymbolParsedFiles: 0,
 	}
@@ -124,8 +122,8 @@ func (w *Workspace) UpdateLastFullSync() {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	if w.indexingStatus != nil {
-		w.indexingStatus = nil
+	if w.indexingProgress != nil {
+		w.indexingProgress = nil
 	}
 
 	w.indexingState = IndexingDone
@@ -156,7 +154,7 @@ func (w *Workspace) SetIndexingFailed() {
 	defer w.mutex.Unlock()
 
 	w.indexingState = IndexingFailed
-	w.indexingStatus = nil
+	w.indexingProgress = nil
 }
 
 func (w *Workspace) ResetIndexingState() {
@@ -164,7 +162,7 @@ func (w *Workspace) ResetIndexingState() {
 	defer w.mutex.Unlock()
 
 	w.indexingState = IndexingIdle
-	w.indexingStatus = nil
+	w.indexingProgress = nil
 }
 
 func (w *Workspace) GetIndexingState() IndexingState {

--- a/internal/core/workspace/workspace_indexing_test.go
+++ b/internal/core/workspace/workspace_indexing_test.go
@@ -21,12 +21,12 @@ func TestStartIndexing_IdleState(t *testing.T) {
 		t.Errorf("state should be IndexingScanning after StartIndexing, got %d", ws.GetIndexingState())
 	}
 
-	status := ws.GetIndexingStatus()
+	status := ws.GetIndexingProgress()
 	if status == nil {
-		t.Fatal("indexing status should not be nil after StartIndexing")
+		t.Fatal("indexing progress should not be nil after StartIndexing")
 	}
 	if status.StartedAt == nil {
-		t.Error("indexing status StartedAt should be set")
+		t.Error("indexing progress StartedAt should be set")
 	}
 }
 
@@ -63,8 +63,8 @@ func TestStartIndexing_AfterFailure_Succeeds(t *testing.T) {
 	if ws.GetIndexingState() != IndexingFailed {
 		t.Fatalf("state should be IndexingFailed, got %d", ws.GetIndexingState())
 	}
-	if ws.GetIndexingStatus() != nil {
-		t.Error("indexing status should be nil after SetIndexingFailed")
+	if ws.GetIndexingProgress() != nil {
+		t.Error("indexing progress should be nil after SetIndexingFailed")
 	}
 
 	// Should be able to start indexing again
@@ -76,8 +76,8 @@ func TestStartIndexing_AfterFailure_Succeeds(t *testing.T) {
 	if ws.GetIndexingState() != IndexingScanning {
 		t.Errorf("state should be IndexingScanning, got %d", ws.GetIndexingState())
 	}
-	if ws.GetIndexingStatus() == nil {
-		t.Error("indexing status should not be nil after restart")
+	if ws.GetIndexingProgress() == nil {
+		t.Error("indexing progress should not be nil after restart")
 	}
 }
 
@@ -97,8 +97,8 @@ func TestStartIndexing_AfterDone_Succeeds(t *testing.T) {
 	if ws.GetIndexingState() != IndexingDone {
 		t.Fatalf("state should be IndexingDone after UpdateLastFullSync, got %d", ws.GetIndexingState())
 	}
-	if ws.GetIndexingStatus() != nil {
-		t.Error("indexing status should be nil after UpdateLastFullSync")
+	if ws.GetIndexingProgress() != nil {
+		t.Error("indexing progress should be nil after UpdateLastFullSync")
 	}
 
 	// Should be able to start indexing again
@@ -127,8 +127,8 @@ func TestResetIndexingState(t *testing.T) {
 	if ws.GetIndexingState() != IndexingIdle {
 		t.Errorf("state should be IndexingIdle after reset, got %d", ws.GetIndexingState())
 	}
-	if ws.GetIndexingStatus() != nil {
-		t.Error("indexing status should be nil after reset")
+	if ws.GetIndexingProgress() != nil {
+		t.Error("indexing progress should be nil after reset")
 	}
 
 	// Test reset from Failed state
@@ -188,13 +188,10 @@ func TestScanInterruptionRecovery(t *testing.T) {
 		t.Fatalf("StartIndexing after failure should succeed: %v", err)
 	}
 
-	// 5. Verify the new indexing status is fresh
-	status := ws.GetIndexingStatus()
+	// 5. Verify the new indexing progress is fresh
+	status := ws.GetIndexingProgress()
 	if status == nil {
-		t.Fatal("indexing status should not be nil after restart")
-	}
-	if status.TotalFiles != 0 {
-		t.Errorf("restarted indexing should have TotalFiles=0, got %d", status.TotalFiles)
+		t.Fatal("indexing progress should not be nil after restart")
 	}
 	if status.IndexedFiles != 0 {
 		t.Errorf("restarted indexing should have IndexedFiles=0, got %d", status.IndexedFiles)

--- a/internal/core/workspace/workspace_test.go
+++ b/internal/core/workspace/workspace_test.go
@@ -34,7 +34,7 @@ func TestWorkspaceMethods(t *testing.T) {
 
 	// Test AddIndexingFiles
 	ws.AddIndexingFiles(3)
-	status := ws.GetIndexingStatus()
+	status := ws.GetIndexingProgress()
 	if status == nil {
 		t.Fatal("Indexing status is nil")
 	}
@@ -52,8 +52,8 @@ func TestWorkspaceMethods(t *testing.T) {
 
 	// Test UpdateLastFullSync
 	ws.UpdateLastFullSync()
-	if ws.indexingStatus != nil {
-		t.Error("UpdateLastFullSync failed to clear indexing status")
+	if ws.indexingProgress != nil {
+		t.Error("UpdateLastFullSync failed to clear indexing progress")
 	}
 
 	// Test GetFilters
@@ -169,10 +169,10 @@ func TestWorkspaceFilters(t *testing.T) {
 func TestAddSymbolParsedFiles(t *testing.T) {
 	ws := &Workspace{Id: 1, Path: "/test"}
 
-	// When no indexing status, should be a no-op
+	// When no indexing progress, should be a no-op
 	ws.AddSymbolParsedFiles(5)
-	if ws.indexingStatus != nil {
-		t.Error("AddSymbolParsedFiles should not create indexing status")
+	if ws.indexingProgress != nil {
+		t.Error("AddSymbolParsedFiles should not create indexing progress")
 	}
 
 	// Start indexing, then add
@@ -183,7 +183,7 @@ func TestAddSymbolParsedFiles(t *testing.T) {
 	ws.AddSymbolParsedFiles(3)
 	ws.AddSymbolParsedFiles(2)
 
-	status := ws.GetIndexingStatus()
+	status := ws.GetIndexingProgress()
 	if status == nil {
 		t.Fatal("Indexing status should not be nil")
 	}
@@ -192,11 +192,11 @@ func TestAddSymbolParsedFiles(t *testing.T) {
 	}
 }
 
-func TestAddIndexingFiles_NoIndexingStatus(t *testing.T) {
+func TestAddIndexingFiles_NoIndexingProgress(t *testing.T) {
 	ws := &Workspace{Id: 1, Path: "/test"}
 	ws.AddIndexingFiles(5)
-	if ws.indexingStatus != nil {
-		t.Error("AddIndexingFiles should not create indexing status")
+	if ws.indexingProgress != nil {
+		t.Error("AddIndexingFiles should not create indexing progress")
 	}
 }
 
@@ -236,7 +236,7 @@ func TestIsDeleted_Default(t *testing.T) {
 	}
 }
 
-func TestUpdateLastFullSync_NoIndexingStatus(t *testing.T) {
+func TestUpdateLastFullSync_NoIndexingProgress(t *testing.T) {
 	ws := &Workspace{Id: 1, Path: "/test", TotalFiles: 50}
 	ws.UpdateLastFullSync()
 	// TotalFiles should remain unchanged (it's no longer overwritten)
@@ -248,14 +248,14 @@ func TestUpdateLastFullSync_NoIndexingStatus(t *testing.T) {
 	}
 }
 
-func TestUpdateLastFullSync_ClearsIndexingStatus(t *testing.T) {
+func TestUpdateLastFullSync_ClearsIndexingProgress(t *testing.T) {
 	ws := &Workspace{Id: 1, Path: "/test"}
 	if err := ws.StartIndexing(); err != nil {
 		t.Fatalf("StartIndexing failed: %v", err)
 	}
 	ws.UpdateLastFullSync()
-	if ws.indexingStatus != nil {
-		t.Error("UpdateLastFullSync should clear indexing status")
+	if ws.indexingProgress != nil {
+		t.Error("UpdateLastFullSync should clear indexing progress")
 	}
 	if ws.GetLastFullSync().IsZero() {
 		t.Error("LastFullSync should be set after UpdateLastFullSync")

--- a/internal/server/httpapi/workspace.go
+++ b/internal/server/httpapi/workspace.go
@@ -231,7 +231,7 @@ func handleGetWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	totalFiles := ws.GetTotalFiles()
-	indexing := ws.GetIndexingStatus() != nil
+	indexing := ws.GetIndexingProgress() != nil
 
 	json.NewEncoder(w).Encode(types.GetWorkspaceResponse{
 		Code:    0,

--- a/internal/server/mcptools/mcptools_test.go
+++ b/internal/server/mcptools/mcptools_test.go
@@ -130,7 +130,7 @@ This is a test project.`,
 		deadline := time.Now().Add(5 * time.Second)
 		for time.Now().Before(deadline) {
 			ws, wsErr := workspace.GetByPath(testWorkspacePath)
-			if wsErr == nil && !ws.GetLastFullSync().IsZero() && ws.GetIndexingStatus() == nil {
+			if wsErr == nil && !ws.GetLastFullSync().IsZero() && ws.GetIndexingProgress() == nil {
 				break
 			}
 			time.Sleep(15 * time.Millisecond)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -105,7 +105,7 @@ func waitForIndexingDone(t *testing.T, wsPath string, timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		ws, err := workspace.GetByPath(wsPath)
-		if err == nil && !ws.GetLastFullSync().IsZero() && ws.GetIndexingStatus() == nil {
+		if err == nil && !ws.GetLastFullSync().IsZero() && ws.GetIndexingProgress() == nil {
 			// Wait for inverted index flush ticker + cooldown to commit.
 			time.Sleep(200 * time.Millisecond)
 			return


### PR DESCRIPTION
Renames indexingStatus to indexingProgress for semantic clarity. Removes dead TotalFiles field from IndexingProgress (now derived from documents store). Removes GetTotalFiles fallback logic.