### PR TITLE
refactor: remove Workspace.TotalFiles persistent field (state mgmt step 4)

### DIFF
--- a/internal/client/handle_workspace.go
+++ b/internal/client/handle_workspace.go
@@ -134,13 +134,12 @@ func printWorkspace(prefix string, ws types.Workspace) {
   Created at: %s
   Last accessed: %s
   Last full sync: %s
-  Total files: %d
   Use global filters: %t
   Filters: %v
   Indexing: %t
 `,
 		prefix, ws.Id, ws.Path, ws.CreatedAt, ws.LastAccessed, ws.LastFullSync,
-		ws.TotalFiles, ws.UseGlobalFilters, ws.Filters, ws.Indexing)
+		ws.UseGlobalFilters, ws.Filters, ws.Indexing)
 }
 
 func handleWorkspaceCreate(workspacePath string) {

--- a/internal/client/handle_workspace_test.go
+++ b/internal/client/handle_workspace_test.go
@@ -82,9 +82,6 @@ func TestHandleWorkspaceList_Success(t *testing.T) {
 	if !strings.Contains(output, "/home/user/project") {
 		t.Errorf("expected workspace path, got: %s", output)
 	}
-	if !strings.Contains(output, "Total files: 100") {
-		t.Errorf("expected total files, got: %s", output)
-	}
 }
 
 func TestHandleWorkspaceList_ServerError(t *testing.T) {
@@ -428,9 +425,6 @@ func TestPrintWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(output, "/home/user/myproject") {
 		t.Error("expected path in output")
-	}
-	if !strings.Contains(output, "Total files: 1234") {
-		t.Error("expected total files in output")
 	}
 	if !strings.Contains(output, "Use global filters: true") {
 		t.Error("expected use global filters in output")

--- a/internal/core/workspace/workspace.go
+++ b/internal/core/workspace/workspace.go
@@ -36,7 +36,6 @@ type Workspace struct {
 	Path             string         `json:"path"`
 	UseGlobalFilters bool           `json:"use_global_filters"`
 	Filters          *types.Filters `json:"filters,omitempty" optional:"true"`
-	TotalFiles       int            `json:"total_files"`
 
 	CreatedAt    time.Time `json:"created_time"`
 	LastAccessed time.Time `json:"last_accessed_time"`

--- a/internal/core/workspace/workspace_test.go
+++ b/internal/core/workspace/workspace_test.go
@@ -20,7 +20,6 @@ func TestWorkspaceMethods(t *testing.T) {
 		Id:               99,
 		Path:             "/test/path",
 		UseGlobalFilters: true,
-		TotalFiles:       0,
 		CreatedAt:        time.Now(),
 		LastAccessed:     time.Now(),
 		LastFullSync:     time.Now(),
@@ -216,7 +215,6 @@ func TestSerialize_Success(t *testing.T) {
 		Id:               5,
 		Path:             "/test/serialize",
 		UseGlobalFilters: true,
-		TotalFiles:       10,
 		CreatedAt:        time.Now(),
 		LastAccessed:     time.Now(),
 	}
@@ -237,12 +235,8 @@ func TestIsDeleted_Default(t *testing.T) {
 }
 
 func TestUpdateLastFullSync_NoIndexingProgress(t *testing.T) {
-	ws := &Workspace{Id: 1, Path: "/test", TotalFiles: 50}
+	ws := &Workspace{Id: 1, Path: "/test"}
 	ws.UpdateLastFullSync()
-	// TotalFiles should remain unchanged (it's no longer overwritten)
-	if ws.TotalFiles != 50 {
-		t.Errorf("TotalFiles changed to %d, should stay 50", ws.TotalFiles)
-	}
 	if ws.GetLastFullSync().IsZero() {
 		t.Error("LastFullSync should be set after UpdateLastFullSync")
 	}


### PR DESCRIPTION
Final step of state management refactor. Removes the redundant TotalFiles field from Workspace struct. File counts are now fully derived from the documents store in-memory counter (Step 1). Old persisted data with TotalFiles field is safely ignored by Go JSON decoder.