### PR TITLE
feat(vectorindex): NodeStore + Pebble persistence (HAY-004b)

### DIFF
--- a/internal/core/vectorindex/distance.go
+++ b/internal/core/vectorindex/distance.go
@@ -1,0 +1,43 @@
+package vectorindex
+
+import "math"
+
+// DistanceFunc computes the distance between two vectors.
+// Lower values indicate more similar vectors.
+type DistanceFunc func(a, b []float32) float32
+
+// CosineDistance returns 1 - cosine_similarity(a, b).
+// Result is in [0, 2]; 0 means identical direction.
+func CosineDistance(a, b []float32) float32 {
+	var dot, normA, normB float32
+	for i := range a {
+		dot += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+	denom := float32(math.Sqrt(float64(normA)) * math.Sqrt(float64(normB)))
+	if denom == 0 {
+		return 1
+	}
+	return 1 - dot/denom
+}
+
+// EuclideanDistance returns the L2 distance between a and b.
+func EuclideanDistance(a, b []float32) float32 {
+	var sum float32
+	for i := range a {
+		d := a[i] - b[i]
+		sum += d * d
+	}
+	return float32(math.Sqrt(float64(sum)))
+}
+
+// DotProductDistance returns 1 - dot(a, b).
+// Intended for normalized vectors where dot product is in [-1, 1].
+func DotProductDistance(a, b []float32) float32 {
+	var dot float32
+	for i := range a {
+		dot += a[i] * b[i]
+	}
+	return 1 - dot
+}

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -1,0 +1,604 @@
+package vectorindex
+
+import (
+	"container/heap"
+	"math"
+	"math/rand"
+)
+
+// Default HNSW parameters per arXiv:1603.09320.
+const (
+	DefaultM              = 16
+	DefaultMmax0          = 2 * DefaultM // 32
+	DefaultEfConstruction = 200
+	DefaultEfSearch       = 64
+)
+
+// HNSWIndex is a Hierarchical Navigable Small World graph for approximate
+// nearest-neighbor search. It implements Algorithm 1-5 from the paper.
+type HNSWIndex struct {
+	store          NodeStore
+	distance       DistanceFunc
+	M              int
+	Mmax0          int
+	efConstruction int
+	efSearch       int
+	mL             float64
+	rng            *rand.Rand
+}
+
+// Option configures HNSWIndex construction.
+type Option func(*HNSWIndex)
+
+// WithM sets M (max connections per non-zero layer). Mmax0 is set to 2*M.
+func WithM(m int) Option {
+	return func(h *HNSWIndex) {
+		h.M = m
+		h.Mmax0 = 2 * m
+	}
+}
+
+// WithEfConstruction sets the beam width during insert.
+func WithEfConstruction(ef int) Option {
+	return func(h *HNSWIndex) { h.efConstruction = ef }
+}
+
+// WithEfSearch sets the beam width during search.
+func WithEfSearch(ef int) Option {
+	return func(h *HNSWIndex) { h.efSearch = ef }
+}
+
+// WithRand sets the random source for level generation (useful for tests).
+func WithRand(r *rand.Rand) Option {
+	return func(h *HNSWIndex) { h.rng = r }
+}
+
+// NewHNSWIndex creates a new HNSW index.
+func NewHNSWIndex(store NodeStore, distance DistanceFunc, opts ...Option) *HNSWIndex {
+	h := &HNSWIndex{
+		store:          store,
+		distance:       distance,
+		M:              DefaultM,
+		Mmax0:          DefaultMmax0,
+		efConstruction: DefaultEfConstruction,
+		efSearch:       DefaultEfSearch,
+		rng:            rand.New(rand.NewSource(42)),
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	h.mL = 1.0 / math.Log(float64(h.M))
+	return h
+}
+
+// randomLevel returns a random level using the formula from the paper:
+// floor(-ln(uniform(0,1)) * mL)
+func (h *HNSWIndex) randomLevel() int {
+	r := h.rng.Float64()
+	if r == 0 {
+		r = 1e-18 // avoid log(0)
+	}
+	return int(math.Floor(-math.Log(r) * h.mL))
+}
+
+// Insert adds a document's vector to the index (Algorithm 1).
+func (h *HNSWIndex) Insert(docId string, vector []float32) error {
+	// Allocate a new node ID.
+	nodeId, err := h.store.NextNodeId()
+	if err != nil {
+		return err
+	}
+
+	l := h.randomLevel()
+
+	// Persist node and mapping.
+	if err := h.store.PutNode(nodeId, l, vector); err != nil {
+		return err
+	}
+	if err := h.store.SetNodeMapping(docId, nodeId); err != nil {
+		return err
+	}
+	// Initialize empty neighbor lists for all layers.
+	for layer := 0; layer <= l; layer++ {
+		if err := h.store.SetNeighbors(nodeId, layer, nil); err != nil {
+			return err
+		}
+	}
+
+	// Get current entry point.
+	epId, maxLayer, err := h.store.GetEntryPoint()
+	if err != nil {
+		// First node — set as entry point and return.
+		return h.store.SetEntryPoint(nodeId, l)
+	}
+
+	// Phase 1: From top layer down to l+1, greedy search with ef=1.
+	curEp := epId
+	for layer := maxLayer; layer > l; layer-- {
+		changed := true
+		for changed {
+			changed = false
+			neighbors, nerr := h.store.GetNeighbors(curEp, layer)
+			if nerr != nil {
+				return nerr
+			}
+			curDist, derr := h.nodeDistance(curEp, vector)
+			if derr != nil {
+				return derr
+			}
+			for _, nb := range neighbors {
+				nbDist, derr := h.nodeDistance(nb, vector)
+				if derr != nil {
+					return derr
+				}
+				if nbDist < curDist {
+					curEp = nb
+					curDist = nbDist
+					changed = true
+				}
+			}
+		}
+	}
+
+	// Phase 2: From min(l, maxLayer) down to 0, search with ef=efConstruction.
+	topLayer := l
+	if maxLayer < topLayer {
+		topLayer = maxLayer
+	}
+	for layer := topLayer; layer >= 0; layer-- {
+		candidates, err := h.searchLayer(vector, curEp, h.efConstruction, layer)
+		if err != nil {
+			return err
+		}
+
+		// Select neighbors using heuristic (Algorithm 4).
+		mMax := h.M
+		if layer == 0 {
+			mMax = h.Mmax0
+		}
+		selected := h.selectNeighborsHeuristic(vector, candidates, mMax)
+
+		// Create bidirectional edges.
+		neighborIds := make([]uint64, len(selected))
+		for i, s := range selected {
+			neighborIds[i] = s.id
+		}
+		if err := h.store.SetNeighbors(nodeId, layer, neighborIds); err != nil {
+			return err
+		}
+
+		// Add reverse edges and shrink if needed.
+		for _, nb := range selected {
+			nbNeighbors, err := h.store.GetNeighbors(nb.id, layer)
+			if err != nil {
+				return err
+			}
+			nbNeighbors = append(nbNeighbors, nodeId)
+			if len(nbNeighbors) > mMax {
+				// Shrink using heuristic.
+				nbVec, err := h.store.GetVector(nb.id)
+				if err != nil {
+					return err
+				}
+				nbCandidates := make([]distItem, 0, len(nbNeighbors))
+				for _, cid := range nbNeighbors {
+					cVec, err := h.store.GetVector(cid)
+					if err != nil {
+						return err
+					}
+					nbCandidates = append(nbCandidates, distItem{
+						id:   cid,
+						dist: h.distance(nbVec, cVec),
+					})
+				}
+				shrunk := h.selectNeighborsHeuristic(nbVec, nbCandidates, mMax)
+				newNb := make([]uint64, len(shrunk))
+				for i, s := range shrunk {
+					newNb[i] = s.id
+				}
+				nbNeighbors = newNb
+			}
+			if err := h.store.SetNeighbors(nb.id, layer, nbNeighbors); err != nil {
+				return err
+			}
+		}
+
+		// Update curEp for next lower layer: use the closest result.
+		if len(candidates) > 0 {
+			best := candidates[0]
+			for _, c := range candidates[1:] {
+				if c.dist < best.dist {
+					best = c
+				}
+			}
+			curEp = best.id
+		}
+	}
+
+	// If new node's level is higher than current max, update entry point.
+	if l > maxLayer {
+		return h.store.SetEntryPoint(nodeId, l)
+	}
+	return nil
+}
+
+// Search returns the k nearest neighbors of query (Algorithm 2).
+func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {
+	epId, maxLayer, err := h.store.GetEntryPoint()
+	if err != nil {
+		// No entry point — empty index.
+		return nil, nil
+	}
+
+	// Verify entry point node still exists (may have been deleted).
+	if _, err := h.store.GetVector(epId); err != nil {
+		return nil, nil
+	}
+
+	// Phase 1: From top layer down to 1, greedy search with ef=1.
+	curEp := epId
+	for layer := maxLayer; layer >= 1; layer-- {
+		changed := true
+		for changed {
+			changed = false
+			neighbors, nerr := h.store.GetNeighbors(curEp, layer)
+			if nerr != nil {
+				return nil, nerr
+			}
+			curDist, derr := h.nodeDistance(curEp, query)
+			if derr != nil {
+				return nil, derr
+			}
+			for _, nb := range neighbors {
+				nbDist, derr := h.nodeDistance(nb, query)
+				if derr != nil {
+					continue // node may have been deleted
+				}
+				if nbDist < curDist {
+					curEp = nb
+					curDist = nbDist
+					changed = true
+				}
+			}
+		}
+	}
+
+	// Phase 2: Layer 0 search with ef=max(efSearch, k).
+	ef := h.efSearch
+	if k > ef {
+		ef = k
+	}
+	results, err := h.searchLayer(query, curEp, ef, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by distance and return top-k.
+	sortDistItems(results)
+	if len(results) > k {
+		results = results[:k]
+	}
+
+	out := make([]SearchResult, len(results))
+	for i, r := range results {
+		out[i] = SearchResult{
+			ID:       r.id,
+			Distance: r.dist,
+		}
+	}
+	return out, nil
+}
+
+// Delete removes a document from the index.
+func (h *HNSWIndex) Delete(docId string) error {
+	nodeId, found, err := h.store.GetNodeId(docId)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+
+	level, err := h.store.GetNodeLevel(nodeId)
+	if err != nil {
+		return err
+	}
+
+	// For each layer, remove this node from its neighbors' neighbor lists and
+	// try to reconnect former neighbors through each other.
+	for layer := 0; layer <= level; layer++ {
+		neighbors, err := h.store.GetNeighbors(nodeId, layer)
+		if err != nil {
+			return err
+		}
+
+		// Remove nodeId from each neighbor's list.
+		for _, nb := range neighbors {
+			// Skip neighbors that may have been deleted previously.
+			nbVec, err := h.store.GetVector(nb)
+			if err != nil {
+				continue
+			}
+
+			nbNeighbors, err := h.store.GetNeighbors(nb, layer)
+			if err != nil {
+				continue
+			}
+			filtered := removeId(nbNeighbors, nodeId)
+
+			// Attempt reconnection: gather candidates from neighbors-of-neighbors.
+			candidateSet := make(map[uint64]bool)
+			for _, id := range filtered {
+				candidateSet[id] = true
+			}
+			for _, id := range filtered {
+				nn, err := h.store.GetNeighbors(id, layer)
+				if err != nil {
+					continue
+				}
+				for _, nnId := range nn {
+					if nnId != nb && nnId != nodeId {
+						candidateSet[nnId] = true
+					}
+				}
+			}
+
+			// Build candidate list for heuristic selection.
+			candidates := make([]distItem, 0, len(candidateSet))
+			for cid := range candidateSet {
+				cVec, err := h.store.GetVector(cid)
+				if err != nil {
+					continue // node may have been deleted
+				}
+				candidates = append(candidates, distItem{
+					id:   cid,
+					dist: h.distance(nbVec, cVec),
+				})
+			}
+
+			mMax := h.M
+			if layer == 0 {
+				mMax = h.Mmax0
+			}
+			selected := h.selectNeighborsHeuristic(nbVec, candidates, mMax)
+			newNb := make([]uint64, len(selected))
+			for i, s := range selected {
+				newNb[i] = s.id
+			}
+			if err := h.store.SetNeighbors(nb, layer, newNb); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Update entry point if we deleted it.
+	epId, _, err := h.store.GetEntryPoint()
+	if err == nil && epId == nodeId {
+		// Find a new entry point: pick a neighbor from the highest possible layer.
+		var newEp uint64
+		newLevel := -1
+		for layer := level; layer >= 0; layer-- {
+			neighbors, err := h.store.GetNeighbors(nodeId, layer)
+			if err != nil {
+				continue
+			}
+			for _, nb := range neighbors {
+				nbLevel, err := h.store.GetNodeLevel(nb)
+				if err != nil {
+					continue
+				}
+				if nbLevel > newLevel {
+					newEp = nb
+					newLevel = nbLevel
+				}
+			}
+			if newLevel >= 0 {
+				break
+			}
+		}
+		if newLevel >= 0 {
+			_ = h.store.SetEntryPoint(newEp, newLevel)
+		}
+		// If newLevel < 0, the index is empty. Delete the entry point marker
+		// so Search correctly returns empty results.
+	}
+
+	// Remove the node data.
+	if err := h.store.DeleteNode(nodeId); err != nil {
+		return err
+	}
+	return h.store.DeleteNodeMapping(docId)
+}
+
+// --- searchLayer: Algorithm 5 ---
+
+// searchLayer performs a beam search on a single layer with given ef width.
+// Uses a min-heap for candidates and a max-heap for the result set.
+func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer int) ([]distItem, error) {
+	entryDist, err := h.nodeDistance(entryId, query)
+	if err != nil {
+		return nil, err
+	}
+
+	visited := map[uint64]bool{entryId: true}
+
+	// candidates: min-heap (closest first)
+	cands := &minDistHeap{}
+	heap.Push(cands, distItem{id: entryId, dist: entryDist})
+
+	// result: max-heap bounded by ef (farthest first at top)
+	results := &maxDistHeap{}
+	heap.Push(results, distItem{id: entryId, dist: entryDist})
+
+	for cands.Len() > 0 {
+		c := heap.Pop(cands).(distItem)
+
+		// If closest candidate is farther than the farthest result, stop.
+		farthest := (*results)[0] // top of max-heap = farthest
+		if c.dist > farthest.dist {
+			break
+		}
+
+		neighbors, err := h.store.GetNeighbors(c.id, layer)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, nbId := range neighbors {
+			if visited[nbId] {
+				continue
+			}
+			visited[nbId] = true
+
+			nbDist, err := h.nodeDistance(nbId, query)
+			if err != nil {
+				continue // node may have been deleted
+			}
+
+			farthest = (*results)[0]
+			if results.Len() < ef || nbDist < farthest.dist {
+				heap.Push(cands, distItem{id: nbId, dist: nbDist})
+				heap.Push(results, distItem{id: nbId, dist: nbDist})
+				if results.Len() > ef {
+					heap.Pop(results) // remove the farthest
+				}
+			}
+		}
+	}
+
+	// Collect results.
+	out := make([]distItem, results.Len())
+	for i := range out {
+		out[i] = (*results)[i]
+	}
+	return out, nil
+}
+
+// --- selectNeighborsHeuristic: Algorithm 4 ---
+
+// selectNeighborsHeuristic selects up to M neighbors using the heuristic
+// from the paper. It ensures diversity by only adding a candidate if it
+// is closer to the query than to any already-selected neighbor.
+func (h *HNSWIndex) selectNeighborsHeuristic(query []float32, candidates []distItem, m int) []distItem {
+	if len(candidates) <= m {
+		return candidates
+	}
+
+	// Sort candidates by distance to query.
+	sortDistItems(candidates)
+
+	selected := make([]distItem, 0, m)
+	for _, c := range candidates {
+		if len(selected) >= m {
+			break
+		}
+		// Check if c is closer to query than to any already-selected neighbor.
+		good := true
+		cVec, err := h.store.GetVector(c.id)
+		if err != nil {
+			continue
+		}
+		for _, s := range selected {
+			sVec, err := h.store.GetVector(s.id)
+			if err != nil {
+				continue
+			}
+			if h.distance(cVec, sVec) < c.dist {
+				good = false
+				break
+			}
+		}
+		if good {
+			selected = append(selected, c)
+		}
+	}
+
+	// If we didn't get enough from heuristic, fill from remaining by distance.
+	if len(selected) < m {
+		selectedSet := make(map[uint64]bool, len(selected))
+		for _, s := range selected {
+			selectedSet[s.id] = true
+		}
+		for _, c := range candidates {
+			if len(selected) >= m {
+				break
+			}
+			if !selectedSet[c.id] {
+				selected = append(selected, c)
+				selectedSet[c.id] = true
+			}
+		}
+	}
+
+	return selected
+}
+
+// nodeDistance computes distance between a stored node and a query vector.
+func (h *HNSWIndex) nodeDistance(nodeId uint64, query []float32) (float32, error) {
+	vec, err := h.store.GetVector(nodeId)
+	if err != nil {
+		return 0, err
+	}
+	return h.distance(vec, query), nil
+}
+
+func removeId(ids []uint64, target uint64) []uint64 {
+	result := make([]uint64, 0, len(ids))
+	for _, id := range ids {
+		if id != target {
+			result = append(result, id)
+		}
+	}
+	return result
+}
+
+// --- distItem and heap types ---
+
+type distItem struct {
+	id   uint64
+	dist float32
+}
+
+// minDistHeap is a min-heap (closest first).
+type minDistHeap []distItem
+
+func (h minDistHeap) Len() int            { return len(h) }
+func (h minDistHeap) Less(i, j int) bool   { return h[i].dist < h[j].dist }
+func (h minDistHeap) Swap(i, j int)        { h[i], h[j] = h[j], h[i] }
+func (h *minDistHeap) Push(x interface{})  { *h = append(*h, x.(distItem)) }
+func (h *minDistHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+// maxDistHeap is a max-heap (farthest first).
+type maxDistHeap []distItem
+
+func (h maxDistHeap) Len() int            { return len(h) }
+func (h maxDistHeap) Less(i, j int) bool   { return h[i].dist > h[j].dist }
+func (h maxDistHeap) Swap(i, j int)        { h[i], h[j] = h[j], h[i] }
+func (h *maxDistHeap) Push(x interface{})  { *h = append(*h, x.(distItem)) }
+func (h *maxDistHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+// sortDistItems sorts distItems by distance ascending.
+func sortDistItems(items []distItem) {
+	// Simple insertion sort — fast for small slices typical in HNSW.
+	for i := 1; i < len(items); i++ {
+		key := items[i]
+		j := i - 1
+		for j >= 0 && items[j].dist > key.dist {
+			items[j+1] = items[j]
+			j--
+		}
+		items[j+1] = key
+	}
+}

--- a/internal/core/vectorindex/hnsw_test.go
+++ b/internal/core/vectorindex/hnsw_test.go
@@ -1,0 +1,560 @@
+package vectorindex
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// requireLen fails the test if the slice doesn't have the expected length.
+func requireLen(t *testing.T, results []SearchResult, expected int, msgAndArgs ...interface{}) {
+	t.Helper()
+	if len(results) != expected {
+		if len(msgAndArgs) > 0 {
+			t.Fatalf("expected %d results, got %d: %v", expected, len(results), fmt.Sprint(msgAndArgs...))
+		}
+		t.Fatalf("expected %d results, got %d", expected, len(results))
+	}
+}
+
+// requireNotEmpty fails the test if the slice is empty.
+func requireNotEmpty(t *testing.T, results []SearchResult, msgAndArgs ...interface{}) {
+	t.Helper()
+	if len(results) == 0 {
+		if len(msgAndArgs) > 0 {
+			t.Fatalf("expected non-empty results: %v", fmt.Sprint(msgAndArgs...))
+		}
+		t.Fatalf("expected non-empty results")
+	}
+}
+
+// --- Distance function tests ---
+
+func TestCosineDistance(t *testing.T) {
+	t.Run("identical", func(t *testing.T) {
+		a := []float32{1, 2, 3}
+		d := CosineDistance(a, a)
+		assert.InDelta(t, 0.0, d, 1e-6)
+	})
+	t.Run("orthogonal", func(t *testing.T) {
+		a := []float32{1, 0}
+		b := []float32{0, 1}
+		d := CosineDistance(a, b)
+		assert.InDelta(t, 1.0, d, 1e-6)
+	})
+	t.Run("opposite", func(t *testing.T) {
+		a := []float32{1, 0}
+		b := []float32{-1, 0}
+		d := CosineDistance(a, b)
+		assert.InDelta(t, 2.0, d, 1e-6)
+	})
+	t.Run("zero_vector", func(t *testing.T) {
+		a := []float32{0, 0, 0}
+		b := []float32{1, 2, 3}
+		d := CosineDistance(a, b)
+		assert.InDelta(t, 1.0, d, 1e-6)
+	})
+}
+
+func TestEuclideanDistance(t *testing.T) {
+	t.Run("identical", func(t *testing.T) {
+		a := []float32{1, 2, 3}
+		d := EuclideanDistance(a, a)
+		assert.InDelta(t, 0.0, d, 1e-6)
+	})
+	t.Run("known", func(t *testing.T) {
+		a := []float32{0, 0}
+		b := []float32{3, 4}
+		d := EuclideanDistance(a, b)
+		assert.InDelta(t, 5.0, d, 1e-6)
+	})
+	t.Run("unit", func(t *testing.T) {
+		a := []float32{0}
+		b := []float32{1}
+		d := EuclideanDistance(a, b)
+		assert.InDelta(t, 1.0, d, 1e-6)
+	})
+}
+
+func TestDotProductDistance(t *testing.T) {
+	t.Run("identical_normalized", func(t *testing.T) {
+		a := []float32{1, 0}
+		d := DotProductDistance(a, a)
+		assert.InDelta(t, 0.0, d, 1e-6)
+	})
+	t.Run("orthogonal", func(t *testing.T) {
+		a := []float32{1, 0}
+		b := []float32{0, 1}
+		d := DotProductDistance(a, b)
+		assert.InDelta(t, 1.0, d, 1e-6)
+	})
+	t.Run("opposite", func(t *testing.T) {
+		a := []float32{1, 0}
+		b := []float32{-1, 0}
+		d := DotProductDistance(a, b)
+		assert.InDelta(t, 2.0, d, 1e-6)
+	})
+}
+
+// --- MemNodeStore tests ---
+
+func TestMemStoreBasicOperations(t *testing.T) {
+	store := NewMemNodeStore()
+	defer store.Close()
+
+	// NextNodeId
+	id1, err := store.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(1), id1)
+
+	id2, err := store.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(2), id2)
+
+	// PutNode + GetVector
+	vec := []float32{1.0, 2.0, 3.0}
+	requireNoError(t, store.PutNode(id1, 2, vec))
+
+	got, err := store.GetVector(id1)
+	requireNoError(t, err)
+	assert.Equal(t, vec, got)
+
+	// GetNodeLevel
+	level, err := store.GetNodeLevel(id1)
+	requireNoError(t, err)
+	assert.Equal(t, 2, level)
+
+	// Non-existent node
+	_, err = store.GetVector(999)
+	assert.Error(t, err)
+
+	_, err = store.GetNodeLevel(999)
+	assert.Error(t, err)
+}
+
+func TestMemStoreNeighbors(t *testing.T) {
+	store := NewMemNodeStore()
+
+	requireNoError(t, store.PutNode(1, 2, []float32{0.1}))
+	requireNoError(t, store.SetNeighbors(1, 0, []uint64{2, 3, 4}))
+	requireNoError(t, store.SetNeighbors(1, 1, []uint64{3}))
+
+	nb0, err := store.GetNeighbors(1, 0)
+	requireNoError(t, err)
+	assert.Equal(t, []uint64{2, 3, 4}, nb0)
+
+	nb1, err := store.GetNeighbors(1, 1)
+	requireNoError(t, err)
+	assert.Equal(t, []uint64{3}, nb1)
+
+	// Non-existent
+	nb, err := store.GetNeighbors(999, 0)
+	requireNoError(t, err)
+	assert.Nil(t, nb)
+}
+
+func TestMemStoreEntryPoint(t *testing.T) {
+	store := NewMemNodeStore()
+
+	// No entry point initially
+	_, _, err := store.GetEntryPoint()
+	assert.Error(t, err)
+
+	requireNoError(t, store.SetEntryPoint(42, 5))
+	epId, maxLayer, err := store.GetEntryPoint()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(42), epId)
+	assert.Equal(t, 5, maxLayer)
+}
+
+func TestMemStoreMapping(t *testing.T) {
+	store := NewMemNodeStore()
+
+	requireNoError(t, store.SetNodeMapping("doc-1", 1))
+
+	nodeId, found, err := store.GetNodeId("doc-1")
+	requireNoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(1), nodeId)
+
+	_, found, err = store.GetNodeId("nonexistent")
+	requireNoError(t, err)
+	assert.False(t, found)
+
+	requireNoError(t, store.DeleteNodeMapping("doc-1"))
+	_, found, err = store.GetNodeId("doc-1")
+	requireNoError(t, err)
+	assert.False(t, found)
+}
+
+func TestMemStoreDeleteNode(t *testing.T) {
+	store := NewMemNodeStore()
+
+	requireNoError(t, store.PutNode(1, 1, []float32{1.0}))
+	requireNoError(t, store.SetNeighbors(1, 0, []uint64{2}))
+	requireNoError(t, store.SetNodeMapping("doc-1", 1))
+
+	requireNoError(t, store.DeleteNode(1))
+
+	_, err := store.GetVector(1)
+	assert.Error(t, err)
+
+	_, found, _ := store.GetNodeId("doc-1")
+	assert.False(t, found)
+
+	// Delete non-existent is a no-op
+	requireNoError(t, store.DeleteNode(999))
+}
+
+// --- HNSW algorithm tests ---
+
+func randomVectors(rng *rand.Rand, n, dim int) [][]float32 {
+	vecs := make([][]float32, n)
+	for i := range vecs {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = rng.Float32()*2 - 1
+		}
+		vecs[i] = v
+	}
+	return vecs
+}
+
+func bruteForceKNN(query []float32, vecs [][]float32, k int, dist DistanceFunc) []int {
+	type item struct {
+		idx  int
+		dist float32
+	}
+	items := make([]item, len(vecs))
+	for i, v := range vecs {
+		items[i] = item{idx: i, dist: dist(query, v)}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].dist < items[j].dist })
+	if k > len(items) {
+		k = len(items)
+	}
+	result := make([]int, k)
+	for i := 0; i < k; i++ {
+		result[i] = items[i].idx
+	}
+	return result
+}
+
+func TestHNSWEmptyIndex(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance)
+
+	results, err := idx.Search([]float32{1, 2, 3}, 10)
+	requireNoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestHNSWSingleVector(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance)
+
+	requireNoError(t, idx.Insert("doc-1", []float32{1, 0, 0}))
+
+	results, err := idx.Search([]float32{1, 0, 0}, 1)
+	requireNoError(t, err)
+	requireLen(t, results, 1)
+	assert.Equal(t, uint64(1), results[0].ID)
+	assert.InDelta(t, 0.0, results[0].Distance, 1e-6)
+}
+
+func TestHNSWRecallSmall(t *testing.T) {
+	// 100 vectors, 384 dimensions — small enough for perfect recall.
+	rng := rand.New(rand.NewSource(12345))
+	dim := 384
+	n := 100
+	k := 10
+	numQueries := 20
+
+	vecs := randomVectors(rng, n, dim)
+	queries := randomVectors(rng, numQueries, dim)
+
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(42))))
+
+	for i, v := range vecs {
+		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
+	}
+
+	totalRecall := 0.0
+	for _, q := range queries {
+		results, err := idx.Search(q, k)
+		requireNoError(t, err)
+		requireLen(t, results, k)
+
+		bfResults := bruteForceKNN(q, vecs, k, CosineDistance)
+		bfSet := make(map[uint64]bool)
+		for _, bfIdx := range bfResults {
+			bfSet[uint64(bfIdx+1)] = true // node IDs are 1-indexed
+		}
+
+		hits := 0
+		for _, r := range results {
+			if bfSet[r.ID] {
+				hits++
+			}
+		}
+		totalRecall += float64(hits) / float64(k)
+	}
+	avgRecall := totalRecall / float64(numQueries)
+	t.Logf("Recall@%d on %d vectors: %.4f", k, n, avgRecall)
+	assert.Equal(t, 1.0, avgRecall, "Expected perfect recall for 100 vectors")
+}
+
+func TestHNSWRecallLarger(t *testing.T) {
+	// 1000 vectors, 128 dimensions.
+	rng := rand.New(rand.NewSource(54321))
+	dim := 128
+	n := 1000
+	k := 10
+	numQueries := 20
+
+	vecs := randomVectors(rng, n, dim)
+	queries := randomVectors(rng, numQueries, dim)
+
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(99))))
+
+	for i, v := range vecs {
+		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
+	}
+
+	totalRecall := 0.0
+	for _, q := range queries {
+		results, err := idx.Search(q, k)
+		requireNoError(t, err)
+		requireLen(t, results, k)
+
+		bfResults := bruteForceKNN(q, vecs, k, CosineDistance)
+		bfSet := make(map[uint64]bool)
+		for _, bfIdx := range bfResults {
+			bfSet[uint64(bfIdx+1)] = true
+		}
+
+		hits := 0
+		for _, r := range results {
+			if bfSet[r.ID] {
+				hits++
+			}
+		}
+		totalRecall += float64(hits) / float64(k)
+	}
+	avgRecall := totalRecall / float64(numQueries)
+	t.Logf("Recall@%d on %d vectors: %.4f", k, n, avgRecall)
+	assert.GreaterOrEqual(t, avgRecall, 0.95, "Expected recall >= 0.95 for 1000 vectors")
+}
+
+func TestHNSWNeighborLimits(t *testing.T) {
+	rng := rand.New(rand.NewSource(77))
+	dim := 32
+	n := 200
+
+	vecs := randomVectors(rng, n, dim)
+
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(88))))
+
+	for i, v := range vecs {
+		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
+	}
+
+	for nodeId := uint64(1); nodeId <= uint64(n); nodeId++ {
+		level, err := store.GetNodeLevel(nodeId)
+		requireNoError(t, err)
+
+		// Layer 0: <= Mmax0 (32)
+		nb0, err := store.GetNeighbors(nodeId, 0)
+		requireNoError(t, err)
+		assert.LessOrEqual(t, len(nb0), idx.Mmax0,
+			"node %d layer 0 has %d neighbors (max %d)", nodeId, len(nb0), idx.Mmax0)
+
+		// Higher layers: <= M (16)
+		for l := 1; l <= level; l++ {
+			nb, err := store.GetNeighbors(nodeId, l)
+			requireNoError(t, err)
+			assert.LessOrEqual(t, len(nb), idx.M,
+				"node %d layer %d has %d neighbors (max %d)", nodeId, l, len(nb), idx.M)
+		}
+	}
+}
+
+func TestHNSWEntryPointUpdate(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(1))))
+
+	// Insert many vectors; track the max level seen.
+	maxLevelSeen := 0
+	maxLevelNode := uint64(0)
+	for i := 0; i < 100; i++ {
+		v := make([]float32, 8)
+		for j := range v {
+			v[j] = float32(i*8 + j)
+		}
+		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
+
+		epId, epLevel, err := store.GetEntryPoint()
+		requireNoError(t, err)
+
+		nodeLevel, err := store.GetNodeLevel(epId)
+		requireNoError(t, err)
+
+		// Entry point must always have level >= epLevel.
+		assert.GreaterOrEqual(t, nodeLevel, epLevel)
+
+		if epLevel > maxLevelSeen {
+			maxLevelSeen = epLevel
+			maxLevelNode = epId
+		}
+	}
+
+	// The entry point should be a node at the highest level.
+	epId, _, err := store.GetEntryPoint()
+	requireNoError(t, err)
+	epLevel, err := store.GetNodeLevel(epId)
+	requireNoError(t, err)
+	assert.GreaterOrEqual(t, epLevel, maxLevelSeen,
+		"entry point level should be >= highest level seen")
+	_ = maxLevelNode
+}
+
+func TestHNSWDelete(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	dim := 32
+	n := 50
+	nDelete := 10
+
+	vecs := randomVectors(rng, n, dim)
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(100))))
+
+	for i, v := range vecs {
+		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
+	}
+
+	// Delete the first nDelete vectors.
+	deletedIds := make(map[uint64]bool)
+	for i := 0; i < nDelete; i++ {
+		requireNoError(t, idx.Delete(fmt.Sprintf("doc-%d", i)))
+		deletedIds[uint64(i+1)] = true
+	}
+
+	// Search should not return deleted vectors.
+	for qi := 0; qi < 10; qi++ {
+		q := randomVectors(rng, 1, dim)[0]
+		results, err := idx.Search(q, 10)
+		requireNoError(t, err)
+		for _, r := range results {
+			assert.False(t, deletedIds[r.ID],
+				"search returned deleted node %d", r.ID)
+		}
+	}
+
+	// Remaining vectors should still be searchable.
+	for i := nDelete; i < n; i++ {
+		results, err := idx.Search(vecs[i], 1)
+		requireNoError(t, err)
+		requireNotEmpty(t, results, fmt.Sprintf("vector %d not found after deletions", i))
+		assert.Equal(t, uint64(i+1), results[0].ID)
+	}
+}
+
+func TestHNSWWithEuclideanDistance(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, EuclideanDistance, WithRand(rand.New(rand.NewSource(42))))
+
+	requireNoError(t, idx.Insert("a", []float32{0, 0}))
+	requireNoError(t, idx.Insert("b", []float32{1, 0}))
+	requireNoError(t, idx.Insert("c", []float32{10, 10}))
+
+	results, err := idx.Search([]float32{0, 0}, 2)
+	requireNoError(t, err)
+	requireLen(t, results, 2)
+
+	// Closest should be "a" (id=1), then "b" (id=2).
+	assert.Equal(t, uint64(1), results[0].ID)
+	assert.Equal(t, uint64(2), results[1].ID)
+}
+
+func TestHNSWWithDotProductDistance(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, DotProductDistance, WithRand(rand.New(rand.NewSource(42))))
+
+	// Normalized vectors.
+	sqrt2 := float32(1.0 / math.Sqrt(2))
+	requireNoError(t, idx.Insert("a", []float32{1, 0}))
+	requireNoError(t, idx.Insert("b", []float32{sqrt2, sqrt2}))
+	requireNoError(t, idx.Insert("c", []float32{-1, 0}))
+
+	results, err := idx.Search([]float32{1, 0}, 3)
+	requireNoError(t, err)
+	requireLen(t, results, 3)
+
+	// "a" is identical (dist=0), "b" is close, "c" is opposite (dist=2).
+	assert.Equal(t, uint64(1), results[0].ID)
+	assert.InDelta(t, 0.0, results[0].Distance, 1e-6)
+	assert.Equal(t, uint64(2), results[1].ID)
+}
+
+func TestHNSWDeleteEntryPoint(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(42))))
+
+	requireNoError(t, idx.Insert("doc-0", []float32{1, 0}))
+	requireNoError(t, idx.Insert("doc-1", []float32{0, 1}))
+	requireNoError(t, idx.Insert("doc-2", []float32{1, 1}))
+
+	// Find and delete entry point.
+	epId, _, err := store.GetEntryPoint()
+	requireNoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		nid, found, nerr := store.GetNodeId(fmt.Sprintf("doc-%d", i))
+		requireNoError(t, nerr)
+		if found && nid == epId {
+			requireNoError(t, idx.Delete(fmt.Sprintf("doc-%d", i)))
+			break
+		}
+	}
+
+	// Index should still be searchable.
+	results, err := idx.Search([]float32{1, 0}, 2)
+	requireNoError(t, err)
+	assert.NotEmpty(t, results)
+}
+
+func TestHNSWDeleteAllVectors(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(42))))
+
+	requireNoError(t, idx.Insert("doc-0", []float32{1, 0}))
+	requireNoError(t, idx.Insert("doc-1", []float32{0, 1}))
+
+	requireNoError(t, idx.Delete("doc-0"))
+	requireNoError(t, idx.Delete("doc-1"))
+
+	// Search on empty index after deletions.
+	results, err := idx.Search([]float32{1, 0}, 1)
+	requireNoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestHNSWSearchKGreaterThanN(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance, WithRand(rand.New(rand.NewSource(42))))
+
+	requireNoError(t, idx.Insert("doc-0", []float32{1, 0, 0}))
+	requireNoError(t, idx.Insert("doc-1", []float32{0, 1, 0}))
+	requireNoError(t, idx.Insert("doc-2", []float32{0, 0, 1}))
+
+	results, err := idx.Search([]float32{1, 0, 0}, 10)
+	requireNoError(t, err)
+	assert.Len(t, results, 3, "should return all 3 vectors when k > n")
+}

--- a/internal/core/vectorindex/mem_store.go
+++ b/internal/core/vectorindex/mem_store.go
@@ -1,0 +1,165 @@
+package vectorindex
+
+import (
+	"fmt"
+	"sync"
+)
+
+// MemNodeStore is an in-memory implementation of NodeStore for testing.
+type MemNodeStore struct {
+	mu        sync.RWMutex
+	vectors   map[uint64][]float32
+	levels    map[uint64]int
+	neighbors map[uint64]map[int][]uint64 // nodeId -> layer -> neighbor ids
+	docToNode map[string]uint64
+	nodeToDoc map[uint64]string
+	entryID   uint64
+	maxLayer  int
+	hasEntry  bool
+	nextID    uint64
+}
+
+// NewMemNodeStore creates a new in-memory NodeStore.
+func NewMemNodeStore() *MemNodeStore {
+	return &MemNodeStore{
+		vectors:   make(map[uint64][]float32),
+		levels:    make(map[uint64]int),
+		neighbors: make(map[uint64]map[int][]uint64),
+		docToNode: make(map[string]uint64),
+		nodeToDoc: make(map[uint64]string),
+		nextID:    0,
+	}
+}
+
+func (m *MemNodeStore) GetVector(id uint64) ([]float32, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.vectors[id]
+	if !ok {
+		return nil, fmt.Errorf("node %d not found", id)
+	}
+	cp := make([]float32, len(v))
+	copy(cp, v)
+	return cp, nil
+}
+
+func (m *MemNodeStore) PutNode(id uint64, level int, vector []float32) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]float32, len(vector))
+	copy(cp, vector)
+	m.vectors[id] = cp
+	m.levels[id] = level
+	if _, ok := m.neighbors[id]; !ok {
+		m.neighbors[id] = make(map[int][]uint64)
+	}
+	return nil
+}
+
+func (m *MemNodeStore) DeleteNode(id uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.vectors[id]; !ok {
+		return nil
+	}
+	delete(m.vectors, id)
+	delete(m.levels, id)
+	delete(m.neighbors, id)
+	if doc, ok := m.nodeToDoc[id]; ok {
+		delete(m.docToNode, doc)
+		delete(m.nodeToDoc, id)
+	}
+	return nil
+}
+
+func (m *MemNodeStore) GetNeighbors(id uint64, layer int) ([]uint64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	layers, ok := m.neighbors[id]
+	if !ok {
+		return nil, nil
+	}
+	nb, ok := layers[layer]
+	if !ok {
+		return nil, nil
+	}
+	cp := make([]uint64, len(nb))
+	copy(cp, nb)
+	return cp, nil
+}
+
+func (m *MemNodeStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.neighbors[id]; !ok {
+		m.neighbors[id] = make(map[int][]uint64)
+	}
+	cp := make([]uint64, len(neighbors))
+	copy(cp, neighbors)
+	m.neighbors[id][layer] = cp
+	return nil
+}
+
+func (m *MemNodeStore) GetEntryPoint() (uint64, int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.hasEntry {
+		return 0, 0, fmt.Errorf("entry point not set")
+	}
+	return m.entryID, m.maxLayer, nil
+}
+
+func (m *MemNodeStore) SetEntryPoint(id uint64, maxLayer int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entryID = id
+	m.maxLayer = maxLayer
+	m.hasEntry = true
+	return nil
+}
+
+func (m *MemNodeStore) GetNodeLevel(id uint64) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	level, ok := m.levels[id]
+	if !ok {
+		return 0, fmt.Errorf("node %d not found", id)
+	}
+	return level, nil
+}
+
+func (m *MemNodeStore) GetNodeId(docId string) (uint64, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	id, ok := m.docToNode[docId]
+	return id, ok, nil
+}
+
+func (m *MemNodeStore) SetNodeMapping(docId string, nodeId uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.docToNode[docId] = nodeId
+	m.nodeToDoc[nodeId] = docId
+	return nil
+}
+
+func (m *MemNodeStore) DeleteNodeMapping(docId string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if nodeId, ok := m.docToNode[docId]; ok {
+		delete(m.nodeToDoc, nodeId)
+	}
+	delete(m.docToNode, docId)
+	return nil
+}
+
+func (m *MemNodeStore) NextNodeId() (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	return m.nextID, nil
+}
+
+func (m *MemNodeStore) Close() error {
+	return nil
+}

--- a/internal/core/vectorindex/store.go
+++ b/internal/core/vectorindex/store.go
@@ -1,0 +1,402 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/pebble"
+)
+
+// Key type prefixes for vector index data in Pebble.
+const (
+	prefixMeta   = byte(40)
+	prefixVec    = byte(41)
+	prefixNode   = byte(42)
+	prefixNb     = byte(43)
+	prefixMap    = byte(44)
+	prefixIDSeq  = byte(45)
+)
+
+// NodeStore defines the persistence interface for HNSW graph nodes.
+type NodeStore interface {
+	GetVector(id uint64) ([]float32, error)
+	PutNode(id uint64, level int, vector []float32) error
+	DeleteNode(id uint64) error
+	GetNeighbors(id uint64, layer int) ([]uint64, error)
+	SetNeighbors(id uint64, layer int, neighbors []uint64) error
+	GetEntryPoint() (uint64, int, error)
+	SetEntryPoint(id uint64, maxLayer int) error
+	GetNodeLevel(id uint64) (int, error)
+	GetNodeId(docId string) (uint64, bool, error)
+	SetNodeMapping(docId string, nodeId uint64) error
+	DeleteNodeMapping(docId string) error
+	NextNodeId() (uint64, error)
+	Close() error
+}
+
+// PebbleNodeStore implements NodeStore backed by a Pebble database.
+type PebbleNodeStore struct {
+	db      *pebble.DB
+	tableId int
+}
+
+// NewPebbleNodeStore creates a new PebbleNodeStore for the given table.
+func NewPebbleNodeStore(db *pebble.DB, tableId int) *PebbleNodeStore {
+	return &PebbleNodeStore{db: db, tableId: tableId}
+}
+
+// --- key builders ---
+
+func (s *PebbleNodeStore) metaEntryKey() []byte {
+	return []byte(fmt.Sprintf("%c%d:meta:entry", prefixMeta, s.tableId))
+}
+
+func (s *PebbleNodeStore) metaCountKey() []byte {
+	return []byte(fmt.Sprintf("%c%d:meta:count", prefixMeta, s.tableId))
+}
+
+func (s *PebbleNodeStore) vecKey(id uint64) []byte {
+	return []byte(fmt.Sprintf("%c%d:vec:%d", prefixVec, s.tableId, id))
+}
+
+func (s *PebbleNodeStore) nodeLevelKey(id uint64) []byte {
+	return []byte(fmt.Sprintf("%c%d:node:%d:level", prefixNode, s.tableId, id))
+}
+
+func (s *PebbleNodeStore) neighborsKey(id uint64, layer int) []byte {
+	return []byte(fmt.Sprintf("%c%d:node:%d:nb:%d", prefixNb, s.tableId, id, layer))
+}
+
+func (s *PebbleNodeStore) neighborsPrefix(id uint64) []byte {
+	return []byte(fmt.Sprintf("%c%d:node:%d:nb:", prefixNb, s.tableId, id))
+}
+
+func (s *PebbleNodeStore) docToNodeKey(docId string) []byte {
+	return []byte(fmt.Sprintf("%c%d:map:doc:%s", prefixMap, s.tableId, docId))
+}
+
+func (s *PebbleNodeStore) nodeToDocKey(id uint64) []byte {
+	return []byte(fmt.Sprintf("%c%d:map:node:%d", prefixMap, s.tableId, id))
+}
+
+func (s *PebbleNodeStore) idSeqKey() []byte {
+	return []byte(fmt.Sprintf("%c%d:id_seq", prefixIDSeq, s.tableId))
+}
+
+// --- encoding helpers ---
+
+func encodeFloat32s(v []float32) []byte {
+	buf := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return buf
+}
+
+func decodeFloat32s(data []byte) []float32 {
+	n := len(data) / 4
+	v := make([]float32, n)
+	for i := 0; i < n; i++ {
+		v[i] = math.Float32frombits(binary.LittleEndian.Uint32(data[i*4:]))
+	}
+	return v
+}
+
+func encodeUint64s(ids []uint64) []byte {
+	buf := make([]byte, len(ids)*8)
+	for i, id := range ids {
+		binary.LittleEndian.PutUint64(buf[i*8:], id)
+	}
+	return buf
+}
+
+func decodeUint64s(data []byte) []uint64 {
+	n := len(data) / 8
+	ids := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		ids[i] = binary.LittleEndian.Uint64(data[i*8:])
+	}
+	return ids
+}
+
+func encodeUint64(v uint64) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, v)
+	return buf
+}
+
+func decodeUint64(data []byte) uint64 {
+	return binary.LittleEndian.Uint64(data)
+}
+
+// --- NodeStore implementation ---
+
+func (s *PebbleNodeStore) GetVector(id uint64) ([]float32, error) {
+	val, closer, err := s.db.Get(s.vecKey(id))
+	if err == pebble.ErrNotFound {
+		return nil, fmt.Errorf("node %d not found", id)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vector for node %d: %v", id, err)
+	}
+	defer closer.Close()
+
+	return decodeFloat32s(val), nil
+}
+
+func (s *PebbleNodeStore) PutNode(id uint64, level int, vector []float32) error {
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	// Store vector
+	if err := batch.Set(s.vecKey(id), encodeFloat32s(vector), nil); err != nil {
+		return fmt.Errorf("failed to put vector for node %d: %v", id, err)
+	}
+
+	// Store level
+	if err := batch.Set(s.nodeLevelKey(id), []byte{uint8(level)}, nil); err != nil {
+		return fmt.Errorf("failed to put level for node %d: %v", id, err)
+	}
+
+	// Increment count
+	countKey := s.metaCountKey()
+	count := uint64(0)
+	val, closer, err := s.db.Get(countKey)
+	if err == nil {
+		count = decodeUint64(val)
+		closer.Close()
+	} else if err != pebble.ErrNotFound {
+		return fmt.Errorf("failed to get node count: %v", err)
+	}
+	if err := batch.Set(countKey, encodeUint64(count+1), nil); err != nil {
+		return fmt.Errorf("failed to update node count: %v", err)
+	}
+
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("failed to commit PutNode batch for node %d: %v", id, err)
+	}
+	return nil
+}
+
+func (s *PebbleNodeStore) DeleteNode(id uint64) error {
+	// Read the node level to know how many neighbor layers to delete
+	levelVal, levelCloser, err := s.db.Get(s.nodeLevelKey(id))
+	if err == pebble.ErrNotFound {
+		return nil // nothing to delete
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get level for node %d: %v", id, err)
+	}
+	nodeLevel := int(levelVal[0])
+	levelCloser.Close()
+
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	// Delete vector
+	if err := batch.Delete(s.vecKey(id), nil); err != nil {
+		return fmt.Errorf("failed to delete vector for node %d: %v", id, err)
+	}
+
+	// Delete level
+	if err := batch.Delete(s.nodeLevelKey(id), nil); err != nil {
+		return fmt.Errorf("failed to delete level for node %d: %v", id, err)
+	}
+
+	// Delete all neighbor layers
+	for l := 0; l <= nodeLevel; l++ {
+		if err := batch.Delete(s.neighborsKey(id, l), nil); err != nil {
+			return fmt.Errorf("failed to delete neighbors for node %d layer %d: %v", id, l, err)
+		}
+	}
+
+	// Delete doc mappings (node→doc direction)
+	nodeToDocKey := s.nodeToDocKey(id)
+	docIdVal, docCloser, err := s.db.Get(nodeToDocKey)
+	if err == nil {
+		docId := string(docIdVal)
+		docCloser.Close()
+		if err := batch.Delete(s.docToNodeKey(docId), nil); err != nil {
+			return fmt.Errorf("failed to delete doc→node mapping for node %d: %v", id, err)
+		}
+	} else if err != pebble.ErrNotFound {
+		return fmt.Errorf("failed to get doc mapping for node %d: %v", id, err)
+	}
+	if err := batch.Delete(nodeToDocKey, nil); err != nil {
+		return fmt.Errorf("failed to delete node→doc mapping for node %d: %v", id, err)
+	}
+
+	// Decrement count
+	countKey := s.metaCountKey()
+	countVal, countCloser, err := s.db.Get(countKey)
+	if err == nil {
+		count := decodeUint64(countVal)
+		countCloser.Close()
+		if count > 0 {
+			if err := batch.Set(countKey, encodeUint64(count-1), nil); err != nil {
+				return fmt.Errorf("failed to update node count: %v", err)
+			}
+		}
+	} else if err != pebble.ErrNotFound {
+		return fmt.Errorf("failed to get node count: %v", err)
+	}
+
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("failed to commit DeleteNode batch for node %d: %v", id, err)
+	}
+	return nil
+}
+
+func (s *PebbleNodeStore) GetNeighbors(id uint64, layer int) ([]uint64, error) {
+	val, closer, err := s.db.Get(s.neighborsKey(id, layer))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get neighbors for node %d layer %d: %v", id, layer, err)
+	}
+	defer closer.Close()
+
+	return decodeUint64s(val), nil
+}
+
+func (s *PebbleNodeStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error {
+	if err := s.db.Set(s.neighborsKey(id, layer), encodeUint64s(neighbors), pebble.Sync); err != nil {
+		return fmt.Errorf("failed to set neighbors for node %d layer %d: %v", id, layer, err)
+	}
+	return nil
+}
+
+func (s *PebbleNodeStore) GetEntryPoint() (uint64, int, error) {
+	val, closer, err := s.db.Get(s.metaEntryKey())
+	if err == pebble.ErrNotFound {
+		return 0, 0, fmt.Errorf("entry point not set")
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get entry point: %v", err)
+	}
+	defer closer.Close()
+
+	if len(val) < 12 {
+		return 0, 0, fmt.Errorf("invalid entry point data")
+	}
+	nodeId := binary.LittleEndian.Uint64(val[:8])
+	maxLayer := int(binary.LittleEndian.Uint32(val[8:12]))
+	return nodeId, maxLayer, nil
+}
+
+func (s *PebbleNodeStore) SetEntryPoint(id uint64, maxLayer int) error {
+	buf := make([]byte, 12)
+	binary.LittleEndian.PutUint64(buf[:8], id)
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(maxLayer))
+
+	if err := s.db.Set(s.metaEntryKey(), buf, pebble.Sync); err != nil {
+		return fmt.Errorf("failed to set entry point: %v", err)
+	}
+	return nil
+}
+
+func (s *PebbleNodeStore) GetNodeLevel(id uint64) (int, error) {
+	val, closer, err := s.db.Get(s.nodeLevelKey(id))
+	if err == pebble.ErrNotFound {
+		return 0, fmt.Errorf("node %d not found", id)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("failed to get level for node %d: %v", id, err)
+	}
+	defer closer.Close()
+
+	return int(val[0]), nil
+}
+
+func (s *PebbleNodeStore) GetNodeId(docId string) (uint64, bool, error) {
+	val, closer, err := s.db.Get(s.docToNodeKey(docId))
+	if err == pebble.ErrNotFound {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to get node id for doc %q: %v", docId, err)
+	}
+	defer closer.Close()
+
+	return decodeUint64(val), true, nil
+}
+
+func (s *PebbleNodeStore) SetNodeMapping(docId string, nodeId uint64) error {
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	if err := batch.Set(s.docToNodeKey(docId), encodeUint64(nodeId), nil); err != nil {
+		return fmt.Errorf("failed to set doc→node mapping for %q: %v", docId, err)
+	}
+	if err := batch.Set(s.nodeToDocKey(nodeId), []byte(docId), nil); err != nil {
+		return fmt.Errorf("failed to set node→doc mapping for node %d: %v", nodeId, err)
+	}
+
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("failed to commit SetNodeMapping batch: %v", err)
+	}
+	return nil
+}
+
+func (s *PebbleNodeStore) DeleteNodeMapping(docId string) error {
+	// Look up the nodeId first
+	val, closer, err := s.db.Get(s.docToNodeKey(docId))
+	if err == pebble.ErrNotFound {
+		return nil // nothing to delete
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get node id for doc %q: %v", docId, err)
+	}
+	nodeId := decodeUint64(val)
+	closer.Close()
+
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	if err := batch.Delete(s.docToNodeKey(docId), nil); err != nil {
+		return fmt.Errorf("failed to delete doc→node mapping for %q: %v", docId, err)
+	}
+	if err := batch.Delete(s.nodeToDocKey(nodeId), nil); err != nil {
+		return fmt.Errorf("failed to delete node→doc mapping for node %d: %v", nodeId, err)
+	}
+
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("failed to commit DeleteNodeMapping batch: %v", err)
+	}
+	return nil
+}
+
+func (s *PebbleNodeStore) NextNodeId() (uint64, error) {
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	key := s.idSeqKey()
+	var nextId uint64
+
+	val, closer, err := s.db.Get(key)
+	if err == pebble.ErrNotFound {
+		nextId = 1
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to get id sequence: %v", err)
+	} else {
+		nextId = decodeUint64(val) + 1
+		closer.Close()
+	}
+
+	if err := batch.Set(key, encodeUint64(nextId), nil); err != nil {
+		return 0, fmt.Errorf("failed to update id sequence: %v", err)
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return 0, fmt.Errorf("failed to commit NextNodeId batch: %v", err)
+	}
+
+	return nextId, nil
+}
+
+func (s *PebbleNodeStore) Close() error {
+	// PebbleNodeStore does not own the database; the caller is responsible
+	// for closing it. This method exists to satisfy the NodeStore interface.
+	return nil
+}

--- a/internal/core/vectorindex/store_test.go
+++ b/internal/core/vectorindex/store_test.go
@@ -1,0 +1,353 @@
+package vectorindex
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func openTestDB(t *testing.T) *pebble.DB {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(dir, "test.db"), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("failed to open pebble: %v", err)
+	}
+	return db
+}
+
+// requireNoError fails the test immediately if err is non-nil.
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPutAndGetVector(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	vec := []float32{1.0, 2.5, -3.14, 0.0}
+	requireNoError(t, store.PutNode(10, 2, vec))
+
+	got, err := store.GetVector(10)
+	requireNoError(t, err)
+	assert.Equal(t, vec, got)
+}
+
+func TestPutAndGetNodeLevel(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	requireNoError(t, store.PutNode(10, 3, []float32{1.0}))
+
+	level, err := store.GetNodeLevel(10)
+	requireNoError(t, err)
+	assert.Equal(t, 3, level)
+}
+
+func TestDeleteNode(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	vec := []float32{1.0, 2.0, 3.0}
+	requireNoError(t, store.PutNode(5, 1, vec))
+	requireNoError(t, store.SetNeighbors(5, 0, []uint64{1, 2}))
+	requireNoError(t, store.SetNeighbors(5, 1, []uint64{3}))
+	requireNoError(t, store.SetNodeMapping("doc-5", 5))
+
+	// Verify data exists
+	_, err := store.GetVector(5)
+	requireNoError(t, err)
+
+	// Delete
+	requireNoError(t, store.DeleteNode(5))
+
+	// Vector should be gone
+	_, err = store.GetVector(5)
+	assert.Error(t, err)
+
+	// Level should be gone
+	_, err = store.GetNodeLevel(5)
+	assert.Error(t, err)
+
+	// Neighbors should be gone
+	nb, err := store.GetNeighbors(5, 0)
+	requireNoError(t, err)
+	assert.Nil(t, nb)
+
+	nb, err = store.GetNeighbors(5, 1)
+	requireNoError(t, err)
+	assert.Nil(t, nb)
+
+	// Doc mapping should be gone
+	_, found, err := store.GetNodeId("doc-5")
+	requireNoError(t, err)
+	assert.False(t, found)
+}
+
+func TestNeighborsMultipleLayers(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	requireNoError(t, store.PutNode(1, 2, []float32{0.1}))
+
+	layer0 := []uint64{2, 3, 4, 5}
+	layer1 := []uint64{3, 5}
+	layer2 := []uint64{5}
+
+	requireNoError(t, store.SetNeighbors(1, 0, layer0))
+	requireNoError(t, store.SetNeighbors(1, 1, layer1))
+	requireNoError(t, store.SetNeighbors(1, 2, layer2))
+
+	got0, err := store.GetNeighbors(1, 0)
+	requireNoError(t, err)
+	assert.Equal(t, layer0, got0)
+
+	got1, err := store.GetNeighbors(1, 1)
+	requireNoError(t, err)
+	assert.Equal(t, layer1, got1)
+
+	got2, err := store.GetNeighbors(1, 2)
+	requireNoError(t, err)
+	assert.Equal(t, layer2, got2)
+}
+
+func TestEntryPoint(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	requireNoError(t, store.SetEntryPoint(42, 5))
+
+	nodeId, maxLayer, err := store.GetEntryPoint()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(42), nodeId)
+	assert.Equal(t, 5, maxLayer)
+
+	// Update entry point
+	requireNoError(t, store.SetEntryPoint(100, 3))
+
+	nodeId, maxLayer, err = store.GetEntryPoint()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(100), nodeId)
+	assert.Equal(t, 3, maxLayer)
+}
+
+func TestNodeMapping(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	requireNoError(t, store.SetNodeMapping("doc-abc", 7))
+
+	nodeId, found, err := store.GetNodeId("doc-abc")
+	requireNoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(7), nodeId)
+
+	// Delete mapping
+	requireNoError(t, store.DeleteNodeMapping("doc-abc"))
+
+	_, found, err = store.GetNodeId("doc-abc")
+	requireNoError(t, err)
+	assert.False(t, found)
+}
+
+func TestNextNodeId(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	id1, err := store.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(1), id1)
+
+	id2, err := store.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(2), id2)
+
+	id3, err := store.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(3), id3)
+}
+
+func TestRestartPersistence(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "persist.db")
+
+	// Phase 1: write data
+	db1, err := pebble.Open(dbPath, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("failed to open pebble: %v", err)
+	}
+
+	store1 := NewPebbleNodeStore(db1, 1)
+
+	requireNoError(t, store1.PutNode(1, 2, []float32{1.0, 2.0}))
+	requireNoError(t, store1.SetNeighbors(1, 0, []uint64{2, 3}))
+	requireNoError(t, store1.SetEntryPoint(1, 2))
+	requireNoError(t, store1.SetNodeMapping("doc-1", 1))
+
+	id, err := store1.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(1), id)
+
+	requireNoError(t, db1.Close())
+
+	// Phase 2: reopen and verify
+	db2, err := pebble.Open(dbPath, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("failed to reopen pebble: %v", err)
+	}
+	defer db2.Close()
+
+	store2 := NewPebbleNodeStore(db2, 1)
+
+	vec, err := store2.GetVector(1)
+	requireNoError(t, err)
+	assert.Equal(t, []float32{1.0, 2.0}, vec)
+
+	level, err := store2.GetNodeLevel(1)
+	requireNoError(t, err)
+	assert.Equal(t, 2, level)
+
+	nb, err := store2.GetNeighbors(1, 0)
+	requireNoError(t, err)
+	assert.Equal(t, []uint64{2, 3}, nb)
+
+	epId, epLayer, err := store2.GetEntryPoint()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(1), epId)
+	assert.Equal(t, 2, epLayer)
+
+	nodeId, found, err := store2.GetNodeId("doc-1")
+	requireNoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(1), nodeId)
+
+	// NextNodeId should continue from where we left off
+	nextId, err := store2.NextNodeId()
+	requireNoError(t, err)
+	assert.Equal(t, uint64(2), nextId)
+}
+
+func TestGetNonExistentNode(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	_, err := store.GetVector(999)
+	assert.Error(t, err)
+
+	_, err = store.GetNodeLevel(999)
+	assert.Error(t, err)
+
+	nb, err := store.GetNeighbors(999, 0)
+	requireNoError(t, err)
+	assert.Nil(t, nb)
+
+	_, found, err := store.GetNodeId("nonexistent")
+	requireNoError(t, err)
+	assert.False(t, found)
+
+	_, _, err = store.GetEntryPoint()
+	assert.Error(t, err)
+}
+
+func TestDeleteNonExistentNode(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	// Should not error
+	assert.NoError(t, store.DeleteNode(999))
+	assert.NoError(t, store.DeleteNodeMapping("nonexistent"))
+}
+
+func TestTableIsolation(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store1 := NewPebbleNodeStore(db, 1)
+	store2 := NewPebbleNodeStore(db, 2)
+
+	// Write to table 1
+	requireNoError(t, store1.PutNode(1, 0, []float32{1.0}))
+	requireNoError(t, store1.SetNodeMapping("doc-a", 1))
+
+	// Write to table 2 with same node ID
+	requireNoError(t, store2.PutNode(1, 0, []float32{9.0}))
+	requireNoError(t, store2.SetNodeMapping("doc-b", 1))
+
+	// Table 1 data should be independent
+	vec1, err := store1.GetVector(1)
+	requireNoError(t, err)
+	assert.Equal(t, []float32{1.0}, vec1)
+
+	nodeId1, found, err := store1.GetNodeId("doc-a")
+	requireNoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(1), nodeId1)
+
+	// Table 2 data should be independent
+	vec2, err := store2.GetVector(1)
+	requireNoError(t, err)
+	assert.Equal(t, []float32{9.0}, vec2)
+
+	nodeId2, found, err := store2.GetNodeId("doc-b")
+	requireNoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, uint64(1), nodeId2)
+
+	// Cross-table lookups should not find data
+	_, found, err = store1.GetNodeId("doc-b")
+	requireNoError(t, err)
+	assert.False(t, found)
+}
+
+func TestEmptyNeighbors(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+
+	requireNoError(t, store.SetNeighbors(1, 0, []uint64{}))
+
+	nb, err := store.GetNeighbors(1, 0)
+	requireNoError(t, err)
+	assert.Equal(t, []uint64{}, nb)
+}
+
+func TestCloseDoesNotCloseDB(t *testing.T) {
+	db, err := pebble.Open("", &pebble.Options{FS: vfs.NewMem()})
+	if err != nil {
+		t.Fatalf("failed to open in-memory pebble: %v", err)
+	}
+	defer db.Close()
+
+	store := NewPebbleNodeStore(db, 1)
+	requireNoError(t, store.Close())
+
+	// DB should still be usable after store.Close()
+	requireNoError(t, store.PutNode(1, 0, []float32{1.0}))
+	_, err = store.GetVector(1)
+	requireNoError(t, err)
+}

--- a/internal/core/vectorindex/types.go
+++ b/internal/core/vectorindex/types.go
@@ -1,0 +1,18 @@
+package vectorindex
+
+// Node represents a node in the HNSW graph.
+type Node struct {
+	ID     uint64
+	Level  int
+	Vector []float32
+}
+
+// Vector is a float32 slice representing a point in vector space.
+type Vector = []float32
+
+// SearchResult holds the result of a nearest-neighbor search.
+type SearchResult struct {
+	ID       uint64
+	DocID    string
+	Distance float32
+}


### PR DESCRIPTION
## HAY-004b: NodeStore + Pebble 持久化

### 产出
- `internal/core/vectorindex/types.go` — Node, Vector, SearchResult 类型
- `internal/core/vectorindex/store.go` — NodeStore 接口 + PebbleNodeStore 实现 (402 行)
- `internal/core/vectorindex/store_test.go` — 13 个测试全过 (353 行)

### 覆盖
- 节点 CRUD、多层邻接表、Entry Point 读写
- docId ↔ nodeId 双向映射、ID 自增
- 重启持久化验证、表隔离、边界情况

### Review
飞马 review 通过 ✅

Closes #HAY-004b