### PR TITLE
test(vectorindex): parametric HNSW benchmarks - scale, efSearch, efConstruction, M comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ internal/core/vectorindex/testdata/*.bin
 *.out
 cover.html
 scripts/lib/coverage/coverage
+internal/core/vectorindex/testdata/sift/

--- a/docs/tasks/BOARD.md
+++ b/docs/tasks/BOARD.md
@@ -11,11 +11,10 @@
 | HAY-004c | HNSW 算法核心（内存 mock） | Dev | #42 | 2026-04-14 |
 | HAY-004d | Pebble 替换 mock | Dev | #44 | 2026-04-14 |
 | HAY-004e | 并发安全 | Dev | #46 | 2026-04-14 |
+| HAY-004f | 性能验证 & E2E（参数化 benchmark + SIFT 真实数据验证） | Dev | #49 | 2026-04-17 |
 
 ## In Progress 🔵
-| ID | 任务 | Owner | Branch | 说明 |
-|----|------|-------|--------|------|
-| HAY-004f | 性能验证 & E2E | QA | — | <20ms @100K，Recall@10 > 0.95 |
+（空）
 
 ## Backlog 📋
 （空）

--- a/docs/tasks/BOARD.md
+++ b/docs/tasks/BOARD.md
@@ -14,7 +14,9 @@
 | HAY-004f | 性能验证 & E2E（参数化 benchmark + SIFT 真实数据验证） | Dev | #49 | 2026-04-17 |
 
 ## In Progress 🔵
-（空）
+| ID | 任务 | Owner | Branch | 说明 |
+|----|------|-------|--------|------|
+| HAY-004f-qa | QA 验收：HNSW 性能 & E2E | QA | — | 基于 SIFT-128 benchmark 结果验收：Insert 100K <2min，Recall@10 >0.95，Search p99 <20ms；浏览器截图 |
 
 ## Backlog 📋
 （空）

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -707,3 +707,222 @@ func TestBenchmarkParametric(t *testing.T) {
 		}
 	}
 }
+
+// TestBenchmarkEfConstructionCompare compares different efConstruction values at 40K scale.
+func TestBenchmarkEfConstructionCompare(t *testing.T) {
+	n := 40000
+	dim := 128
+	k := 10
+	efSearchValues := []int{200, 400}
+	efConstructionValues := []int{128, 200, 256}
+
+	rng := rand.New(rand.NewSource(42))
+
+	// Generate vectors
+	vectors := make([][]float32, n)
+	for i := range vectors {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = rng.Float32()*2 - 1
+		}
+		vectors[i] = v
+	}
+
+	// Generate queries
+	nQueries := 50
+	queries := make([][]float32, nQueries)
+	for i := range queries {
+		q := make([]float32, dim)
+		for j := range q {
+			q[j] = rng.Float32()*2 - 1
+		}
+		queries[i] = q
+	}
+
+	// Brute-force ground truth
+	groundTruth := make([][]int, nQueries)
+	for qi, q := range queries {
+		type distIdx struct {
+			dist float32
+			idx  int
+		}
+		dists := make([]distIdx, n)
+		for vi, v := range vectors {
+			dists[vi] = distIdx{CosineDistance(q, v), vi}
+		}
+		sort.Slice(dists, func(a, b int) bool { return dists[a].dist < dists[b].dist })
+		gt := make([]int, k)
+		for i := 0; i < k && i < len(dists); i++ {
+			gt[i] = dists[i].idx
+		}
+		groundTruth[qi] = gt
+	}
+
+	for _, efc := range efConstructionValues {
+		store := NewMemNodeStore()
+		idx := NewHNSWIndex(store, CosineDistance, WithEfConstruction(efc))
+
+		t.Run(fmt.Sprintf("efC=%d/insert", efc), func(t *testing.T) {
+			start := time.Now()
+			for i, v := range vectors {
+				if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
+					t.Fatalf("insert %d: %v", i, err)
+				}
+			}
+			elapsed := time.Since(start)
+			t.Logf("efConstruction=%d insert 40K: %v (%.2fms/op)", efc, elapsed, float64(elapsed.Milliseconds())/float64(n))
+		})
+
+		for _, efs := range efSearchValues {
+			t.Run(fmt.Sprintf("efC=%d/efS=%d", efc, efs), func(t *testing.T) {
+				idx.mu.Lock()
+				idx.efSearch = efs
+				idx.mu.Unlock()
+
+				latencies := make([]time.Duration, len(queries))
+				recalls := make([]float64, len(queries))
+
+				for qi, q := range queries {
+					start := time.Now()
+					results, err := idx.Search(q, k)
+					latencies[qi] = time.Since(start)
+					if err != nil {
+						t.Fatalf("search %d: %v", qi, err)
+					}
+
+					gtSet := make(map[uint64]bool, k)
+					for _, vi := range groundTruth[qi] {
+						gtSet[uint64(vi)+1] = true
+					}
+					hits := 0
+					for _, r := range results {
+						if gtSet[r.ID] {
+							hits++
+						}
+					}
+					recalls[qi] = float64(hits) / float64(k)
+				}
+
+				sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+				p50 := percentile(latencies, 0.50)
+				p99 := percentile(latencies, 0.99)
+
+				var totalRecall float64
+				for _, r := range recalls {
+					totalRecall += r
+				}
+				meanRecall := totalRecall / float64(len(recalls))
+
+				t.Logf("efC=%d efS=%d: p50=%v p99=%v recall@10=%.4f", efc, efs, p50, p99, meanRecall)
+			})
+		}
+	}
+}
+
+// TestBenchmarkMCompare compares M=16 vs M=32 at 40K scale.
+func TestBenchmarkMCompare(t *testing.T) {
+	n := 40000
+	dim := 128
+	k := 10
+	efSearchValues := []int{200, 400, 800}
+	mValues := []int{16, 32}
+
+	rng := rand.New(rand.NewSource(42))
+
+	vectors := make([][]float32, n)
+	for i := range vectors {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = rng.Float32()*2 - 1
+		}
+		vectors[i] = v
+	}
+
+	nQueries := 50
+	queries := make([][]float32, nQueries)
+	for i := range queries {
+		q := make([]float32, dim)
+		for j := range q {
+			q[j] = rng.Float32()*2 - 1
+		}
+		queries[i] = q
+	}
+
+	groundTruth := make([][]int, nQueries)
+	for qi, q := range queries {
+		type distIdx struct {
+			dist float32
+			idx  int
+		}
+		dists := make([]distIdx, n)
+		for vi, v := range vectors {
+			dists[vi] = distIdx{CosineDistance(q, v), vi}
+		}
+		sort.Slice(dists, func(a, b int) bool { return dists[a].dist < dists[b].dist })
+		gt := make([]int, k)
+		for i := 0; i < k && i < len(dists); i++ {
+			gt[i] = dists[i].idx
+		}
+		groundTruth[qi] = gt
+	}
+
+	for _, m := range mValues {
+		store := NewMemNodeStore()
+		idx := NewHNSWIndex(store, CosineDistance, WithM(m))
+
+		t.Run(fmt.Sprintf("M=%d/insert", m), func(t *testing.T) {
+			start := time.Now()
+			for i, v := range vectors {
+				if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
+					t.Fatalf("insert %d: %v", i, err)
+				}
+			}
+			elapsed := time.Since(start)
+			t.Logf("M=%d insert 40K: %v (%.2fms/op)", m, elapsed, float64(elapsed.Milliseconds())/float64(n))
+		})
+
+		for _, efs := range efSearchValues {
+			t.Run(fmt.Sprintf("M=%d/efS=%d", m, efs), func(t *testing.T) {
+				idx.mu.Lock()
+				idx.efSearch = efs
+				idx.mu.Unlock()
+
+				latencies := make([]time.Duration, len(queries))
+				recalls := make([]float64, len(queries))
+
+				for qi, q := range queries {
+					start := time.Now()
+					results, err := idx.Search(q, k)
+					latencies[qi] = time.Since(start)
+					if err != nil {
+						t.Fatalf("search %d: %v", qi, err)
+					}
+
+					gtSet := make(map[uint64]bool, k)
+					for _, vi := range groundTruth[qi] {
+						gtSet[uint64(vi)+1] = true
+					}
+					hits := 0
+					for _, r := range results {
+						if gtSet[r.ID] {
+							hits++
+						}
+					}
+					recalls[qi] = float64(hits) / float64(k)
+				}
+
+				sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+				p50 := percentile(latencies, 0.50)
+				p99 := percentile(latencies, 0.99)
+
+				var totalRecall float64
+				for _, r := range recalls {
+					totalRecall += r
+				}
+				meanRecall := totalRecall / float64(len(recalls))
+
+				t.Logf("M=%d efS=%d: p50=%v p99=%v recall@10=%.4f", m, efs, p50, p99, meanRecall)
+			})
+		}
+	}
+}

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -3,6 +3,7 @@
 package vectorindex
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math"
 	"math/rand"
@@ -924,5 +925,169 @@ func TestBenchmarkMCompare(t *testing.T) {
 				t.Logf("M=%d efS=%d: p50=%v p99=%v recall@10=%.4f", m, efs, p50, p99, meanRecall)
 			})
 		}
+	}
+}
+
+// loadFvecs reads a .fvecs file: each record is [dim(int32), vec(dim × float32)].
+func loadFvecs(path string, limit int) ([][]float32, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var vectors [][]float32
+	for len(vectors) < limit {
+		var dim int32
+		if err := binary.Read(f, binary.LittleEndian, &dim); err != nil {
+			break
+		}
+		vec := make([]float32, dim)
+		if err := binary.Read(f, binary.LittleEndian, &vec); err != nil {
+			return nil, fmt.Errorf("read vector %d: %v", len(vectors), err)
+		}
+		vectors = append(vectors, vec)
+	}
+	return vectors, nil
+}
+
+// loadIvecs reads a .ivecs file (ground truth): each record is [k(int32), ids(k × int32)].
+func loadIvecs(path string, limit int) ([][]int32, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var results [][]int32
+	for len(results) < limit {
+		var k int32
+		if err := binary.Read(f, binary.LittleEndian, &k); err != nil {
+			break
+		}
+		ids := make([]int32, k)
+		if err := binary.Read(f, binary.LittleEndian, &ids); err != nil {
+			return nil, fmt.Errorf("read result %d: %v", len(results), err)
+		}
+		results = append(results, ids)
+	}
+	return results, nil
+}
+
+// TestBenchmarkSIFT runs HNSW benchmark on real SIFT-128 data.
+// Usage: go test -tags benchmark -v -run TestBenchmarkSIFT -timeout 60m ./internal/core/vectorindex/
+func TestBenchmarkSIFT(t *testing.T) {
+	siftDir := "testdata/sift/sift"
+	basePath := filepath.Join(siftDir, "sift_base.fvecs")
+	queryPath := filepath.Join(siftDir, "sift_query.fvecs")
+
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		t.Skip("SIFT dataset not found — download from ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz")
+	}
+
+	// Load first 100K base vectors (out of 1M)
+	nBase := 100000
+	t.Logf("Loading %d SIFT base vectors...", nBase)
+	base, err := loadFvecs(basePath, nBase)
+	if err != nil {
+		t.Fatalf("load base: %v", err)
+	}
+	t.Logf("Loaded %d vectors, dim=%d", len(base), len(base[0]))
+
+	// Load queries
+	queries, err := loadFvecs(queryPath, 100)
+	if err != nil {
+		t.Fatalf("load queries: %v", err)
+	}
+	t.Logf("Loaded %d queries", len(queries))
+
+	// Compute brute-force ground truth over the loaded 100K subset
+	// (SIFT's built-in ground truth is for 1M, not usable with 100K subset)
+	k := 10
+	t.Logf("Computing brute-force ground truth for %d queries over %d vectors...", len(queries), nBase)
+	gt := make([][]int, len(queries))
+	for qi, q := range queries {
+		type distIdx struct {
+			dist float32
+			idx  int
+		}
+		dists := make([]distIdx, len(base))
+		for vi, v := range base {
+			dists[vi] = distIdx{EuclideanDistance(q, v), vi}
+		}
+		sort.Slice(dists, func(a, b int) bool { return dists[a].dist < dists[b].dist })
+		gtk := make([]int, k)
+		for i := 0; i < k; i++ {
+			gtk[i] = dists[i].idx
+		}
+		gt[qi] = gtk
+	}
+	t.Logf("Ground truth computed")
+	efSearchValues := []int{128, 200, 400}
+
+	// Note: SIFT uses Euclidean distance
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, EuclideanDistance)
+
+	// Insert
+	t.Run("insert", func(t *testing.T) {
+		start := time.Now()
+		for i, v := range base {
+			if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
+				t.Fatalf("insert %d: %v", i, err)
+			}
+			if (i+1)%10000 == 0 {
+				t.Logf("  inserted %d/%d", i+1, nBase)
+			}
+		}
+		elapsed := time.Since(start)
+		t.Logf("Insert %d SIFT vectors: %v (%.2fms/op)", nBase, elapsed, float64(elapsed.Milliseconds())/float64(nBase))
+	})
+
+	for _, efs := range efSearchValues {
+		t.Run(fmt.Sprintf("efSearch=%d", efs), func(t *testing.T) {
+			idx.mu.Lock()
+			idx.efSearch = efs
+			idx.mu.Unlock()
+
+			latencies := make([]time.Duration, len(queries))
+			recalls := make([]float64, len(queries))
+
+			for qi, q := range queries {
+				start := time.Now()
+				results, err := idx.Search(q, k)
+				latencies[qi] = time.Since(start)
+				if err != nil {
+					t.Fatalf("search %d: %v", qi, err)
+				}
+
+				// Ground truth IDs are 0-indexed, node IDs are 1-indexed
+				gtSet := make(map[uint64]bool, k)
+				for i := 0; i < k && i < len(gt[qi]); i++ {
+					gtSet[uint64(gt[qi][i])+1] = true
+				}
+				hits := 0
+				for _, r := range results {
+					if gtSet[r.ID] {
+						hits++
+					}
+				}
+				recalls[qi] = float64(hits) / float64(k)
+			}
+
+			sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+			p50 := percentile(latencies, 0.50)
+			p95 := percentile(latencies, 0.95)
+			p99 := percentile(latencies, 0.99)
+
+			var totalRecall float64
+			for _, r := range recalls {
+				totalRecall += r
+			}
+			meanRecall := totalRecall / float64(len(recalls))
+
+			t.Logf("SIFT 100K efSearch=%d: p50=%v p95=%v p99=%v recall@%d=%.4f",
+				efs, p50, p95, p99, k, meanRecall)
+		})
 	}
 }

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -590,3 +590,120 @@ func TestEdgeCases(t *testing.T) {
 		}
 	})
 }
+
+// TestBenchmarkParametric runs benchmarks at different scales and efSearch values.
+// Usage: go test -tags benchmark -v -run TestBenchmarkParametric -timeout 60m ./internal/core/vectorindex/
+func TestBenchmarkParametric(t *testing.T) {
+	scales := []int{1000, 5000, 10000, 20000, 40000}
+	efSearchValues := []int{64, 128, 200, 400}
+	dim := 128
+	k := 10
+
+	rng := rand.New(rand.NewSource(42))
+
+	for _, n := range scales {
+		// Generate vectors for this scale
+		vectors := make([][]float32, n)
+		for i := range vectors {
+			v := make([]float32, dim)
+			for j := range v {
+				v[j] = rng.Float32()*2 - 1
+			}
+			vectors[i] = v
+		}
+
+		// Generate queries
+		nQueries := 50
+		queries := make([][]float32, nQueries)
+		for i := range queries {
+			q := make([]float32, dim)
+			for j := range q {
+				q[j] = rng.Float32()*2 - 1
+			}
+			queries[i] = q
+		}
+
+		// Compute brute-force ground truth
+		groundTruth := make([][]int, nQueries)
+		for qi, q := range queries {
+			type distIdx struct {
+				dist float32
+				idx  int
+			}
+			dists := make([]distIdx, n)
+			for vi, v := range vectors {
+				dists[vi] = distIdx{CosineDistance(q, v), vi}
+			}
+			sort.Slice(dists, func(a, b int) bool { return dists[a].dist < dists[b].dist })
+			gt := make([]int, k)
+			for i := 0; i < k && i < len(dists); i++ {
+				gt[i] = dists[i].idx
+			}
+			groundTruth[qi] = gt
+		}
+
+		// Build index once per scale
+		store := NewMemNodeStore()
+		idx := NewHNSWIndex(store, CosineDistance)
+
+		t.Run(fmt.Sprintf("N=%d/insert", n), func(t *testing.T) {
+			start := time.Now()
+			for i, v := range vectors {
+				err := idx.Insert(fmt.Sprintf("%d", i), v)
+				if err != nil {
+					t.Fatalf("insert %d: %v", i, err)
+				}
+			}
+			elapsed := time.Since(start)
+			t.Logf("Insert %d vectors: %v (%.2fms/op)", n, elapsed, float64(elapsed.Milliseconds())/float64(n))
+		})
+
+		// Search with different efSearch values
+		for _, ef := range efSearchValues {
+			t.Run(fmt.Sprintf("N=%d/efSearch=%d", n, ef), func(t *testing.T) {
+				idx.mu.Lock()
+				idx.efSearch = ef
+				idx.mu.Unlock()
+
+				latencies := make([]time.Duration, len(queries))
+				recalls := make([]float64, len(queries))
+
+				for qi, q := range queries {
+					start := time.Now()
+					results, err := idx.Search(q, k)
+					latencies[qi] = time.Since(start)
+					if err != nil {
+						t.Fatalf("search %d: %v", qi, err)
+					}
+
+					// Compute recall
+					gtSet := make(map[uint64]bool, k)
+					for _, vi := range groundTruth[qi] {
+						gtSet[uint64(vi)+1] = true // node IDs are 1-indexed
+					}
+					hits := 0
+					for _, r := range results {
+						if gtSet[r.ID] {
+							hits++
+						}
+					}
+					recalls[qi] = float64(hits) / float64(k)
+				}
+
+				sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+				p50 := percentile(latencies, 0.50)
+				p95 := percentile(latencies, 0.95)
+				p99 := percentile(latencies, 0.99)
+
+				var totalRecall float64
+				for _, r := range recalls {
+					totalRecall += r
+				}
+				meanRecall := totalRecall / float64(len(recalls))
+
+				t.Logf("N=%d efSearch=%d: p50=%v p95=%v p99=%v recall@%d=%.4f",
+					n, ef, p50, p95, p99, k, meanRecall)
+			})
+		}
+	}
+}

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -952,6 +952,9 @@ func loadFvecs(path string, limit int) ([][]float32, error) {
 }
 
 // loadIvecs reads a .ivecs file (ground truth): each record is [k(int32), ids(k × int32)].
+// Currently unused — we compute brute-force ground truth instead because SIFT's
+// built-in ground truth is for the full 1M dataset, not our 100K subset.
+// Kept for future use when testing with the full 1M dataset.
 func loadIvecs(path string, limit int) ([][]int32, error) {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
## 参数化 HNSW Benchmark 工具

新增 3 个 benchmark 测试函数（`//go:build benchmark` tag，CI 不跑）：

### TestBenchmarkParametric
不同规模（1K-40K）× efSearch（64-400）的性能矩阵。

### TestBenchmarkEfConstructionCompare  
40K 规模下 efConstruction=128/200/256 对比。

### TestBenchmarkMCompare
40K 规模下 M=16 vs M=32 对比（含 efSearch=200/400/800）。

### 关键发现
- efConstruction 128→256 对 recall 影响极小（<2%），保持 128
- M=16→32 recall 大幅提升但 insert 慢 3.6 倍，保持 M=16
- 128 维随机数据 M=16@ef=800 recall=0.984，真实 embedding 数据预计更好