### PR TITLE
fix(vectorindex): upsert semantics for Insert (HAY-005)

### DIFF
--- a/docs/tasks/BOARD.md
+++ b/docs/tasks/BOARD.md
@@ -20,7 +20,9 @@
 
 
 ## Backlog 📋
-（空）
+| ID | 任务 | Owner | 优先级 | 说明 |
+|----|------|-------|--------|------|
+| HAY-004g | HNSW Insert upsert 修补（重复 docId 孤儿节点） | Dev | P1 | Insert 开头 GetNodeId 检查，存在则先 Delete 再 Insert；小改无需设计文档 |
 
 ## 设计文档
 - [HAY-004 HNSW 设计](HAY-004-hnsw/design.md)

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -2,6 +2,7 @@ package vectorindex
 
 import (
 	"container/heap"
+	"fmt"
 	"math"
 	"math/rand"
 	"sort"
@@ -100,6 +101,16 @@ func (h *HNSWIndex) randomLevel() int {
 func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Upsert: if docId already exists, delete the old node first to avoid
+	// orphan nodes and inconsistent mappings (HAY-005).
+	if existingId, found, err := h.store.GetNodeId(docId); err != nil {
+		return fmt.Errorf("failed to check existing docId %q: %v", docId, err)
+	} else if found {
+		if err := h.deleteNodeLocked(existingId, docId); err != nil {
+			return fmt.Errorf("failed to delete existing node for docId %q: %v", docId, err)
+		}
+	}
 
 	// If the store supports batching, wrap this insert in a batch.
 	// Nested calls (e.g. from InsertBatch) just increment depth.
@@ -401,6 +412,11 @@ func (h *HNSWIndex) Delete(docId string) error {
 		return nil
 	}
 
+	return h.deleteNodeLocked(nodeId, docId)
+}
+
+// deleteNodeLocked removes a node from the HNSW graph. Caller must hold h.mu.
+func (h *HNSWIndex) deleteNodeLocked(nodeId uint64, docId string) error {
 	level, err := h.store.GetNodeLevel(nodeId)
 	if err != nil {
 		return err

--- a/internal/core/vectorindex/hnsw_test.go
+++ b/internal/core/vectorindex/hnsw_test.go
@@ -600,3 +600,53 @@ func TestHNSWSearchKGreaterThanN(t *testing.T) {
 	requireNoError(t, err)
 	assert.Len(t, results, 3, "should return all 3 vectors when k > n")
 }
+
+func TestHNSWInsertUpsert(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance)
+
+	// Insert a vector
+	err := idx.Insert("doc1", []float32{1, 0, 0})
+	assert.NoError(t, err)
+
+	// Insert same docId with different vector (upsert)
+	err = idx.Insert("doc1", []float32{0, 1, 0})
+	assert.NoError(t, err)
+
+	// Search for the updated vector — should find it with near-zero distance
+	results, err := idx.Search([]float32{0, 1, 0}, 1)
+	assert.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.InDelta(t, 0.0, results[0].Distance, 0.01)
+
+	// Search broadly — should only have 1 node total (no orphan from old insert)
+	results2, err := idx.Search([]float32{1, 0, 0}, 10)
+	assert.NoError(t, err)
+	assert.Len(t, results2, 1, "should have exactly 1 node after upsert, no orphans")
+}
+
+func TestHNSWInsertUpsertMultiple(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, CosineDistance)
+
+	// Insert 5 vectors
+	for i := 0; i < 5; i++ {
+		v := make([]float32, 3)
+		v[i%3] = 1.0
+		err := idx.Insert(fmt.Sprintf("doc%d", i), v)
+		assert.NoError(t, err)
+	}
+
+	// Update doc0 three times
+	for j := 0; j < 3; j++ {
+		v := make([]float32, 3)
+		v[j] = float32(j + 1)
+		err := idx.Insert("doc0", v)
+		assert.NoError(t, err)
+	}
+
+	// Search for all — should get exactly 5 results, no orphans from repeated upserts
+	results, err := idx.Search([]float32{1, 1, 1}, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(results), "should have exactly 5 nodes, no orphans from upsert")
+}


### PR DESCRIPTION
## HAY-005: Insert 重复 docId 导致孤儿节点

### 问题
Insert 不检查 docId 是否已存在，重复插入导致旧 nodeId 的反向映射和图结构不清理，变成孤儿节点。

### 修复
- Insert 开头先 GetNodeId 检查 docId 是否存在
- 存在则先调 deleteNodeLocked 清理旧节点
- 提取 deleteNodeLocked 内部方法（从 Delete 重构），避免重复获取锁

### 测试
- TestHNSWInsertUpsert: 单次 upsert，验证旧节点被清理
- TestHNSWInsertUpsertMultiple: 多次 upsert 同一 docId，验证无孤儿节点