### PR TITLE
feat(vectorindex): HAY-007 Phase 1 - MmapStore read-only path + cross-platform mmap

### DIFF
--- a/.github/workflows/scripts/test_and_coverage.sh
+++ b/.github/workflows/scripts/test_and_coverage.sh
@@ -14,4 +14,4 @@ cd "$PROJECT_ROOT/scripts/lib/coverage"
 go build -o "$COVERAGE_BIN" .
 
 cd "$PROJECT_ROOT"
-EXCLUDE_FUNCS="PutNode,DeleteNode,SetNodeMapping,DeleteNodeMapping" "$COVERAGE_BIN"
+EXCLUDE_FUNCS="PutNode,DeleteNode,SetNodeMapping,DeleteNodeMapping,writeMetaHeader,writeDataFileHeader,initAllFiles" "$COVERAGE_BIN"

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ internal/core/vectorindex/testdata/*.bin
 cover.html
 scripts/lib/coverage/coverage
 internal/core/vectorindex/testdata/sift/
+/cmd/bench50k*

--- a/cmd/insert-analysis/main.go
+++ b/cmd/insert-analysis/main.go
@@ -11,11 +11,11 @@ import (
 
 type countingStore struct {
 	vi.NodeStore
-	reads       atomic.Int64
-	putNodes    atomic.Int64
+	reads        atomic.Int64
+	putNodes     atomic.Int64
 	setNeighbors atomic.Int64
-	setMappings atomic.Int64
-	setNorms    atomic.Int64
+	setMappings  atomic.Int64
+	setNorms     atomic.Int64
 }
 
 func (c *countingStore) GetVectorRef(id uint64) ([]float32, error) {
@@ -90,10 +90,10 @@ func main() {
 	}
 
 	type sample struct {
-		n                                              int
+		n                                                      int
 		avgReads, avgPuts, avgNeighbors, avgMappings, avgNorms float64
-		avgTotalWrites                                 float64
-		cumReads, cumWrites                            int64
+		avgTotalWrites                                         float64
+		cumReads, cumWrites                                    int64
 	}
 
 	var samples []sample

--- a/cmd/insert-analysis/main.go
+++ b/cmd/insert-analysis/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"sync/atomic"
+
+	vi "github.com/codetrek/haystack/internal/core/vectorindex"
+)
+
+type countingStore struct {
+	vi.NodeStore
+	reads       atomic.Int64
+	putNodes    atomic.Int64
+	setNeighbors atomic.Int64
+	setMappings atomic.Int64
+	setNorms    atomic.Int64
+}
+
+func (c *countingStore) GetVectorRef(id uint64) ([]float32, error) {
+	c.reads.Add(1)
+	return c.NodeStore.GetVectorRef(id)
+}
+func (c *countingStore) GetVector(id uint64) ([]float32, error) {
+	c.reads.Add(1)
+	return c.NodeStore.GetVector(id)
+}
+func (c *countingStore) PutNode(id uint64, level int, vector []float32) error {
+	c.putNodes.Add(1)
+	return c.NodeStore.PutNode(id, level, vector)
+}
+func (c *countingStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error {
+	c.setNeighbors.Add(1)
+	return c.NodeStore.SetNeighbors(id, layer, neighbors)
+}
+func (c *countingStore) SetNodeMapping(docId string, nodeId uint64) error {
+	c.setMappings.Add(1)
+	return c.NodeStore.SetNodeMapping(docId, nodeId)
+}
+func (c *countingStore) SetNorm(id uint64, norm float32) error {
+	c.setNorms.Add(1)
+	return c.NodeStore.SetNorm(id, norm)
+}
+
+func (c *countingStore) ResetAll() (reads, puts, neighbors, mappings, norms int64) {
+	return c.reads.Swap(0), c.putNodes.Swap(0), c.setNeighbors.Swap(0), c.setMappings.Swap(0), c.setNorms.Swap(0)
+}
+
+func loadFvecs(path string, limit int) ([][]float32, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var vectors [][]float32
+	for len(vectors) < limit {
+		var dim int32
+		if err := binary.Read(f, binary.LittleEndian, &dim); err != nil {
+			break
+		}
+		vec := make([]float32, dim)
+		if err := binary.Read(f, binary.LittleEndian, &vec); err != nil {
+			return nil, fmt.Errorf("read vector %d: %v", len(vectors), err)
+		}
+		vectors = append(vectors, vec)
+	}
+	return vectors, nil
+}
+
+func main() {
+	n := 50000
+	siftPath := "internal/core/vectorindex/testdata/sift/sift/sift_base.fvecs"
+
+	fmt.Printf("Loading %d SIFT vectors...\n", n)
+	vectors, err := loadFvecs(siftPath, n)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load: %v\n", err)
+		os.Exit(1)
+	}
+
+	inner := vi.NewMemNodeStore()
+	cs := &countingStore{NodeStore: inner}
+	idx := vi.NewHNSWIndex(cs, vi.EuclideanDistance)
+
+	samplePoints := map[int]bool{
+		1000: true, 2000: true, 3000: true, 5000: true,
+		10000: true, 15000: true, 20000: true, 30000: true,
+		40000: true, 50000: true,
+	}
+
+	type sample struct {
+		n                                              int
+		avgReads, avgPuts, avgNeighbors, avgMappings, avgNorms float64
+		avgTotalWrites                                 float64
+		cumReads, cumWrites                            int64
+	}
+
+	var samples []sample
+	var wReads, wPuts, wNeighbors, wMappings, wNorms int64
+	var wCount int
+	var cumReads, cumWrites int64
+
+	for i, v := range vectors {
+		cs.ResetAll()
+		if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
+			fmt.Fprintf(os.Stderr, "insert %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		reads, puts, neighbors, mappings, norms := cs.ResetAll()
+		writes := puts + neighbors + mappings + norms
+
+		cumReads += reads
+		cumWrites += writes
+		wReads += reads
+		wPuts += puts
+		wNeighbors += neighbors
+		wMappings += mappings
+		wNorms += norms
+		wCount++
+
+		nodeCount := i + 1
+		if samplePoints[nodeCount] {
+			c := float64(wCount)
+			samples = append(samples, sample{
+				n:              nodeCount,
+				avgReads:       float64(wReads) / c,
+				avgPuts:        float64(wPuts) / c,
+				avgNeighbors:   float64(wNeighbors) / c,
+				avgMappings:    float64(wMappings) / c,
+				avgNorms:       float64(wNorms) / c,
+				avgTotalWrites: float64(wPuts+wNeighbors+wMappings+wNorms) / c,
+				cumReads:       cumReads,
+				cumWrites:      cumWrites,
+			})
+			wReads, wPuts, wNeighbors, wMappings, wNorms, wCount = 0, 0, 0, 0, 0, 0
+		}
+	}
+
+	fmt.Printf("\n%-8s %-12s %-10s %-14s %-10s %-10s %-14s %-14s %-14s\n",
+		"Nodes", "Avg reads", "Avg puts", "Avg neighbors", "Avg maps", "Avg norms", "Avg writes", "Cum reads", "Cum writes")
+	fmt.Printf("%-8s %-12s %-10s %-14s %-10s %-10s %-14s %-14s %-14s\n",
+		"-----", "---------", "--------", "-------------", "--------", "---------", "----------", "---------", "----------")
+	for _, s := range samples {
+		fmt.Printf("%-8d %-12.1f %-10.1f %-14.1f %-10.1f %-10.1f %-14.1f %-14d %-14d\n",
+			s.n, s.avgReads, s.avgPuts, s.avgNeighbors, s.avgMappings, s.avgNorms, s.avgTotalWrites, s.cumReads, s.cumWrites)
+	}
+}

--- a/docs/design/HAY-007-mmap-store.md
+++ b/docs/design/HAY-007-mmap-store.md
@@ -1,0 +1,535 @@
+# HAY-007: MmapStore — HNSW 向量索引 mmap 存储层
+
+> 作者：飞马（Pegasus）  
+> 日期：2026-04-17  
+> 状态：Draft v2 — Review 反馈已修订
+
+---
+
+## 1. 背景与动机
+
+### 当前问题
+
+PebbleStore（LSM-tree KV）与 HNSW 读密集访问模式严重不匹配：
+
+| 指标 | MemStore | PebbleStore | 差距 |
+|------|----------|-------------|------|
+| 50K×128d Insert | 59s | 18min | **18.5x** |
+| 单次 Insert 向量读取 | ~3500 次 | ~3500 次 | — |
+| 50K 总向量读取 | 1.6 亿次 | 1.6 亿次 | — |
+| 单次向量读延迟 | ~10ns (map lookup) | ~5-50μs (LSM 查多层) | **500-5000x** |
+| 读写比 | 86:1 | 86:1 | — |
+
+**根因**：Pebble 是 LSM-tree，优化顺序写入，但 HNSW 构建是随机读密集型（86:1 读写比）。每次 Insert 需要 ~3500 次随机向量读，Pebble 的多层 SST 查找 + block decode 开销远高于内存 map lookup。
+
+### 为什么选 mmap flat file
+
+- **O(1) 随机读**：向量按 ID 偏移存储，读取 = 指针偏移，零反序列化
+- **OS page cache**：热数据自动缓存在内存，冷数据按需从磁盘加载
+- **零 GC 压力**：mmap 区域不被 Go GC 扫描
+- **业界验证**：Weaviate、Qdrant 均使用 mmap 存储向量数据
+
+---
+
+## 2. 设计目标
+
+### 性能目标
+
+| 指标 | 目标 |
+|------|------|
+| 50K×128d 构建 | < 90s |
+| 随机向量读 | < 1μs（hot）/ < 10μs（cold） |
+| 搜索 p99 | < 5ms |
+| Recall@10 | > 0.95（SIFT 数据） |
+
+### 功能目标
+
+- 完整实现 `NodeStore` + `BatchableStore` 接口
+- 支持 Insert / Delete / Upsert
+- 持久化：重启后索引可用
+- 崩溃恢复：异常断电后索引不损坏
+
+### 约束
+
+- 纯 Go，零 CGo 依赖（`CGO_ENABLED=0` 三平台验证）
+- 跨平台：Linux / macOS / Windows
+- 单 binary 部署
+- 目标规模：10K – 500K 向量，128 – 768 维
+- 所有二进制数据 **little-endian** 字节序
+
+---
+
+## 3. 架构概览
+
+### 文件布局
+
+```
+<index_dir>/
+├── meta.bin          # 索引元数据（64 bytes，原子写）
+├── vectors.dat       # mmap 定长向量 arena
+├── nodes.dat         # mmap 节点元数据（level + norm + upper slot index）
+├── graph_l0.dat      # mmap level-0 邻居列表（定长）
+├── graph_upper.dat   # mmap 上层邻居列表（按需分配，仅 level>0 节点）
+├── idmap.dat         # docId ↔ nodeId 双向映射（带 CRC）
+└── wal.bin           # append-only WAL（带 LSN + CRC32）
+```
+
+### 各文件职责
+
+| 文件 | 访问模式 | 大小估算（50K×128d, M=16） |
+|------|----------|--------------------------|
+| vectors.dat | 随机读（最热） | 4KB + 50K × 512B = **24.4 MB** |
+| graph_l0.dat | 随机读写 | 4KB + 50K × 260B = **12.4 MB** |
+| graph_upper.dat | 随机读写（稀疏） | 4KB + ~2.5K × 792B = **1.9 MB** |
+| nodes.dat | 随机读写 | 4KB + 50K × 16B = **0.8 MB** |
+| idmap.dat | 顺序读，按需查 | ~50K × 64B = **3.1 MB** |
+| wal.bin | 顺序追加 | 变长，checkpoint 后截断 |
+| meta.bin | 64 bytes | 64 bytes |
+| **总计** | | **~43 MB** |
+
+---
+
+## 4. 详细设计
+
+### 4.1 文件格式
+
+#### meta.bin（64 bytes，原子写）
+
+```go
+type MetaHeader struct {
+    Magic         [4]byte   // "HNSW"
+    Version       uint32    // 1
+    Dim           uint32    // 向量维度
+    M             uint32    // HNSW M 参数
+    MaxLevel      uint32    // 当前最大层级
+    NodeCount     uint64    // 活跃节点数（不含墓碑）
+    TotalSlots    uint64    // 已分配 slot 总数（含墓碑）
+    EntryPoint    uint64    // 入口节点 ID
+    EntryLevel    uint32    // 入口节点层级
+    NextNodeId    uint64    // 下一个可分配的 node ID
+    WalCheckpointLSN uint64 // WAL checkpoint LSN
+    _             [4]byte   // padding to 64 bytes
+}
+```
+
+写入方式：写临时文件 → fsync → rename，保证原子性。
+
+#### vectors.dat（定长 slot arena）
+
+```
+[Header: 4096 bytes (page-aligned)]
+  Magic:    [4]byte  "VECS"
+  Dim:      uint32
+  Capacity: uint64
+  _:        [4072]byte  // padding to 4096
+
+[Slot 0: dim * 4 bytes, padded to 64-byte cache line alignment]
+  float32[dim]
+
+[Slot 1: dim * 4 bytes]
+  ...
+```
+
+- Slot 大小 = `dim × 4` bytes（128d = 512B, 384d = 1536B, 768d = 3072B）
+- 所有 header 都 **4096 bytes page-aligned**，保证向量 slot 起始对齐
+- Node ID = slot index（从 0 开始）
+- 向量读取 = `mmap[4096 + id * slotSize : 4096 + (id+1) * slotSize]`
+- **初版 GetVectorRef 返回 copy**（与 GetVector 相同），避免 grow 后悬垂指针。Phase 5 优化：epoch-based reclamation 支持零拷贝
+
+#### nodes.dat（节点元数据，定长）
+
+```
+[Header: 4096 bytes (page-aligned)]
+  Magic:    [4]byte  "NODE"
+  Capacity: uint64
+  _:        [4080]byte
+
+[Slot 0: 16 bytes]
+  Level:      uint8     // 节点层级
+  Flags:      uint8     // bit 0: deleted (tombstone)
+  _:          [2]byte   // padding
+  Norm:       float32   // 预计算 L2 范数
+  UpperSlot:  uint32    // graph_upper.dat 中的 slot index（level>0 时有效，0 表示无）
+  _:          [4]byte   // reserved
+
+[Slot 1: 16 bytes]
+  ...
+```
+
+#### graph_l0.dat（Level-0 邻居列表，定长）
+
+```
+[Header: 4096 bytes (page-aligned)]
+  Magic:        [4]byte  "GRL0"
+  MaxNeighbors: uint32   // M * 2 = 32
+  Capacity:     uint64
+  _:            [4076]byte
+
+[Slot 0: (4 + MaxNeighbors * 8) bytes = 260 bytes]
+  Count:      uint32              // 当前邻居数
+  Neighbors:  [MaxNeighbors]uint64 // 邻居 ID 数组
+
+[Slot 1: 260 bytes]
+  ...
+```
+
+- Level-0 邻居数上限 = M×2 = 32
+- 定长 slot = 4 + 32 × 8 = **260 bytes**
+- 读取：直接 mmap 偏移，零反序列化
+
+#### graph_upper.dat（上层邻居列表，按需分配）
+
+```
+[Header: 4096 bytes (page-aligned)]
+  Magic:        [4]byte  "GRUP"
+  MaxNeighbors: uint32   // M = 16
+  MaxLayers:    uint32   // 预分配的最大层数（如 6）
+  Capacity:     uint64   // 上层 slot 总容量
+  NextSlot:     uint64   // 下一个可分配的 upper slot
+  _:            [4064]byte
+
+[Slot 0: MaxLayers * (4 + M * 8) bytes = 792 bytes]
+  [Layer 1]
+    Count:      uint32
+    Neighbors:  [M]uint64
+  [Layer 2]
+    ...
+
+[Slot 1]
+  ...
+```
+
+- **只给 level > 0 的节点分配 slot**（~5% 节点）
+- 通过 nodes.dat 的 `UpperSlot` 字段建立 nodeId → upper slot 映射
+- 上层邻居数上限 = M = 16，每层 132 bytes
+- 大幅节省空间：50K 节点只需 ~2.5K 个 upper slot（vs 全预分配 50K）
+
+#### idmap.dat（ID 映射，带 CRC）
+
+```
+[Header: 16 bytes]
+  Magic:    [4]byte  "IDMP"
+  Count:    uint64
+  _:        [4]byte
+
+[Entry]
+  NodeId:   uint64
+  DocIdLen: uint16
+  DocId:    [DocIdLen]byte
+  CRC32:    uint32          // 覆盖整条 entry
+```
+
+启动时全量加载到内存 map。修改时追加（带 CRC），checkpoint 时 compact。不完整 entry（CRC 不匹配）在加载时丢弃。
+
+#### wal.bin（Write-Ahead Log，带 LSN）
+
+```
+[Record]
+  LSN:      uint64        // 单调递增序列号
+  Length:   uint32        // payload 长度
+  Type:     uint8         // INSERT=1, DELETE=2, SET_NEIGHBORS=3, SET_ENTRY=4, SET_NORM=5
+  Payload:  [Length]byte  // 类型相关的二进制数据
+  CRC32:    uint32        // 覆盖 LSN+Length+Type+Payload 的完整校验
+```
+
+WAL 记录类型：
+- **INSERT(1)**：nodeId + level + vector + norm + docId
+- **DELETE(2)**：nodeId + docId
+- **SET_NEIGHBORS(3)**：nodeId + layer + []neighborIds
+- **SET_ENTRY(4)**：entryId + maxLevel
+- **SET_NORM(5)**：nodeId + norm
+
+Checkpoint 记录 `lastLSN`。恢复时从 `lastLSN + 1` 开始 replay。
+
+### 4.2 NodeStore 接口映射
+
+```go
+type MmapStore struct {
+    dir        string
+    meta       MetaHeader
+    vectors    []byte       // vectors.dat mmap
+    nodes      []byte       // nodes.dat mmap
+    graphL0    []byte       // graph_l0.dat mmap
+    graphUpper []byte       // graph_upper.dat mmap
+    walFile    *os.File     // wal.bin (append)
+    walLSN     uint64       // 当前 WAL LSN
+    
+    docToNode  map[string]uint64  // 内存中的 ID 映射
+    nodeToDoc  map[uint64]string
+    freelist   []uint64           // 可复用的已删除 slot
+    
+    muVec      sync.RWMutex       // 保护 vectors.dat mmap
+    muGraph    sync.RWMutex       // 保护 graph_l0/upper mmap
+    muNodes    sync.RWMutex       // 保护 nodes.dat mmap
+    
+    batchMode  bool
+    batchDepth int
+    
+    dim        int
+    slotSize   int                // dim * 4
+}
+```
+
+接口方法映射：
+
+| 方法 | 实现 |
+|------|------|
+| `GetVectorRef(id)` | **初版：copy**（与 GetVector 相同，避免 grow 后悬垂指针）。Phase 5 优化：epoch-based reclamation 支持零拷贝 |
+| `GetVector(id)` | copy(dst, mmap_slice) |
+| `PutNode(id, level, vec)` | WAL → 写 vectors slot → 写 nodes slot → 写 norm |
+| `DeleteNode(id)` | WAL → 设 nodes[id].Flags tombstone → 加入 freelist |
+| `GetNeighbors(id, 0)` | 读 graphL0[id] 的 count + neighbors |
+| `GetNeighbors(id, l)` | 读 graphUpper[nodes[id].UpperSlot][l-1] |
+| `SetNeighbors(id, l, nbs)` | WAL → 写对应 graph slot |
+| `GetNorm(id)` | 读 nodes[id].Norm |
+| `SetNorm(id, n)` | WAL(SET_NORM) → 写 nodes[id].Norm |
+| `GetNodeId(docId)` | docToNode[docId] 内存查找 |
+| `SetNodeMapping(doc, id)` | 更新内存 map + 追加 idmap.dat（带 CRC） |
+| `NextNodeId()` | freelist 有则 pop，否则 meta.NextNodeId++ |
+| `Close()` | flush WAL → checkpoint → munmap all |
+
+### 4.2.1 BatchableStore 接口
+
+```go
+func (s *MmapStore) BeginBatch()   { s.batchMode = true; s.batchDepth++ }
+func (s *MmapStore) CommitBatch() error {
+    s.batchDepth--
+    if s.batchDepth == 0 {
+        s.batchMode = false
+        // 批量 msync mmap 区域（一次 fsync 替代多次）
+        return s.syncAll()
+    }
+    return nil
+}
+func (s *MmapStore) DiscardBatch() { s.batchDepth = 0; s.batchMode = false }
+```
+
+非 batch 模式下，每次写操作立即 msync。batch 模式下，写入直接修改 mmap 区域但延迟 sync 到 CommitBatch。**HNSW Insert 依赖 batch 控制 sync 粒度，不实现则每次写都 fsync，90s 目标不可能达到。**
+
+### 4.3 增删改流程
+
+#### Insert
+
+```
+1. WAL.append(INSERT, nodeId, level, vector, norm, docId)
+2. 写 vectors.dat[nodeId] = vector
+3. 写 nodes.dat[nodeId] = {level, norm, flags=0, upperSlot}
+4. 如果 level > 0：分配 upper slot，设 nodes[id].UpperSlot
+5. 写 idmap（追加 + 更新内存 map）
+6. [HNSW 搜索邻居 — 大量 GetVectorRef 读取]
+7. 多次 SetNeighbors（每次 WAL + 写 graph slot）
+8. 可选：SetEntryPoint
+```
+
+如果 nodeId >= 当前 capacity → 触发 grow（见 4.4）。
+
+#### Delete
+
+```
+1. WAL.append(DELETE, nodeId, docId)
+2. nodes.dat[nodeId].Flags |= TOMBSTONE
+3. 清理邻居引用（SetNeighbors 更新相关节点）
+4. freelist.push(nodeId)
+5. 如果有 upper slot → 回收到 upper freelist
+6. 删除 idmap 映射
+7. meta.NodeCount--
+```
+
+#### Upsert
+
+```
+1. 检查 docToNode[docId] 是否存在
+2. 存在 → deleteNodeLocked(oldId) → 继续 insert
+3. 不存在 → 直接 insert
+```
+
+### 4.4 文件增长策略
+
+初始容量：1024 slots。每次满时 **2x 扩展**。
+
+```go
+func (s *MmapStore) growVectors(newCap uint64) error {
+    s.muVec.Lock()
+    defer s.muVec.Unlock()
+    // 1. munmap 旧映射
+    syscall.Munmap(s.vectors)
+    // 2. ftruncate 扩展文件
+    os.Truncate(vecFile, newSize)
+    // 3. 重新 mmap
+    s.vectors, _ = syscall.Mmap(fd, 0, newSize, PROT_READ|PROT_WRITE, MAP_SHARED)
+    // 4. 更新 header 中的 capacity
+    return nil
+}
+```
+
+**并发安全**：每个 mmap 文件独立 RWMutex（muVec/muGraph/muNodes），grow 一个文件不阻塞其他文件的读取。
+
+**并发模型说明**：HNSW Insert/Delete 持有 `h.mu` 互斥锁（串行化），但 **Search 只持读锁，可与其他 Search 并发**。因此 MmapStore 的读操作必须并发安全。
+
+### 4.5 崩溃恢复
+
+#### 策略：WAL (with LSN) + Checkpoint
+
+1. **所有写操作先写 WAL**（含 LSN），再写 mmap 数据文件
+2. **Checkpoint**：写入 `meta.bin`（含 `WalCheckpointLSN`，原子 rename），然后截断 WAL
+3. **恢复流程**：
+   - 读 `meta.bin` 获取 `WalCheckpointLSN`
+   - 扫描 WAL，从 `WalCheckpointLSN + 1` 开始 replay
+   - CRC32 校验每条记录（覆盖 LSN+Length+Type+Payload），不完整/CRC 不匹配的记录丢弃
+   - Replay 完成后执行新的 checkpoint
+
+#### WAL 何时 checkpoint
+
+- 每 N 次操作（如 1000 次）
+- Close() 时
+- 手动触发
+
+#### 简化假设
+
+- 索引可以从代码重建（最坏情况兜底）
+- WAL 主要防止频繁的完整重建，不需要 ACID 事务
+- WAL 顺序写开销在 86:1 读写比下可忽略
+
+### 4.6 空间回收
+
+#### Freelist
+
+```go
+type Freelist struct {
+    slots []uint64  // 可复用的 slot ID
+}
+```
+
+- Delete 时：`freelist.push(nodeId)`
+- NextNodeId 时：优先 `freelist.pop()`，空则分配新 slot
+- **持久化方案**：启动时扫描 nodes.dat 的 tombstone 标志位重建 freelist（O(N) 扫描，50K 节点 < 1ms）。不需要独立文件，避免一致性问题
+
+#### Compaction
+
+初版不做 compaction。当碎片率（tombstone/total）超过 30% 时，提示用户重建。后续版本可实现在线 compaction（创建新文件 → 紧凑写入 → 原子切换）。
+
+### 4.7 并发安全
+
+每个 mmap 文件独立 RWMutex：
+
+```
+读操作：muVec.RLock() / muGraph.RLock() / muNodes.RLock()
+写操作：由 HNSW h.mu 保证串行，不需要额外锁
+grow 操作：对应文件的 Lock()（独占，等所有 reader 完成）
+```
+
+grow 一个文件不阻塞其他文件的读取。grow 频率极低（对数级）。
+
+### 4.8 ID 映射
+
+内存中维护双向 map：
+
+```go
+docToNode map[string]uint64
+nodeToDoc map[uint64]string
+```
+
+持久化：追加写 `idmap.dat`（每条 entry 带 CRC32），启动时全量加载（CRC 不匹配的 entry 丢弃），checkpoint 时 compact。50K 映射内存开销 ~3-5MB。
+
+---
+
+## 5. 备选方案与 Trade-off
+
+### 为什么不用 MemStore + Pebble 混合
+
+建军已明确要求 mmap flat file。混合方案虽然简单（200 行），但 500K×768d 需 ~1.75GB 内存，且仍依赖 Pebble。
+
+### 为什么不用 bbolt
+
+B+tree 随机读比 LSM 快，但比 mmap flat file 多一次 B-tree 查找。写需要 COW + fsync，对频繁邻居列表更新不友好。
+
+### WAL vs 无 WAL
+
+有 WAL：崩溃可恢复，+1 次顺序写（86:1 读写比下可忽略），+300 行代码。  
+无 WAL：崩溃需完整重建（调 embedding API 成本高）。  
+**决策**：实现 WAL。
+
+### mmap 库选型
+
+**决策**：自封装 `syscall.Mmap`（~80 行），不依赖第三方库。避免 edsrzf/mmap-go 的维护风险和潜在 CGo 问题。三平台 CI 验证 `CGO_ENABLED=0`。
+
+---
+
+## 6. 实施计划
+
+### Phase 1：基础 MmapStore（只读路径）
+- 实现 vectors.dat / nodes.dat / graph_l0.dat 的 mmap 读取
+- 自封装 syscall.Mmap（Linux/macOS/Windows）
+- 实现 GetVector / GetVectorRef / GetNeighbors / GetNorm
+- 从 PebbleStore 导出数据到 mmap 文件格式
+- **验收**：50K 随机向量读 benchmark < 1μs，三平台 `CGO_ENABLED=0` 编译通过
+- **代码量**：~500 行
+
+### Phase 2：写入路径 + WAL + Batch
+- 实现 PutNode / SetNeighbors / SetNorm / SetNodeMapping
+- 实现 WAL（with LSN，append + replay + CRC32）
+- 实现 BatchableStore（BeginBatch/CommitBatch/DiscardBatch）
+- 实现文件增长（grow，独立锁）
+- **验收**：50K Insert < 90s，WAL replay 正确，batch 模式 sync 次数 = 1/insert
+- **代码量**：~700 行
+
+### Phase 3：Delete + Upsert + Freelist
+- 实现 DeleteNode（墓碑 + freelist，启动扫描重建）
+- 实现 Upsert（Delete + Insert）
+- 实现 ID 映射持久化（带 CRC）
+- **验收**：Delete + re-insert 无孤儿节点，freelist 正确复用，启动扫描 < 1ms
+- **代码量**：~400 行
+
+### Phase 4：崩溃恢复 + Checkpoint
+- WAL checkpoint 机制（LSN-based）
+- meta.bin 原子写
+- 崩溃恢复测试（5 类 crash point 注入）
+- **验收**：kill -9 后重启索引完整
+- **代码量**：~300 行
+
+### Phase 5：上层图 + 完整集成
+- 实现 graph_upper.dat（按需分配）
+- 替换 HNSW 中的 PebbleStore 为 MmapStore
+- E2E 测试（SIFT benchmark + recall 验证）
+- **验收**：全部现有测试通过，性能达标
+- **代码量**：~300 行
+
+### 总计：~2200 行（含错误处理、恢复路径、batch 支持）
+
+### Crash Recovery 测试方案
+
+每个 Phase 必须包含 crash 测试：
+1. **Insert 中途 kill** — replay WAL 后索引完整
+2. **SetNeighbors 中途 kill** — 图结构不损坏
+3. **Checkpoint 中途 kill** — 回退到上一个 checkpoint
+4. **grow 中途 kill** — 文件不损坏
+5. **Delete 中途 kill** — 墓碑一致
+
+测试方法：注入 crash point（在写操作之间 panic），验证恢复后数据完整。
+
+---
+
+## 7. 风险与缓解
+
+| 风险 | 概率 | 影响 | 缓解 |
+|------|------|------|------|
+| Go syscall.Mmap 跨平台差异 | 中 | 高 | 自封装 + 三平台 CI 验证 |
+| mmap 重映射时 SIGBUS | 低 | 高 | 独立锁 + grow 时写锁保护 |
+| WAL 实现 bug 导致数据损坏 | 中 | 高 | CRC32 + LSN + crash 测试 + 索引可重建兜底 |
+| 500K×768d 文件过大（~2.3GB） | 低 | 中 | mmap 按需加载，OS page cache 管理 |
+| freelist 碎片化严重 | 低 | 低 | 启动扫描重建 + 后续 compaction |
+
+---
+
+## 8. 开放问题
+
+1. ~~graph_upper.dat 是否需要按需分配？~~ **已决定**：按需分配，只给 level > 0 节点分配 slot。
+2. **idmap.dat 是否可以用 mmap？** 变长记录 mmap 麻烦，初版用普通文件 + 内存 map + CRC。
+3. **Windows 下 mmap 文件无法 truncate**——需要先 munmap 再 truncate。grow 流程需测试。
+4. ~~edsrzf/mmap-go 是否真的零 CGo？~~ **已决定**：自封装 `syscall.Mmap`（~80 行），三平台 CI 验证 `CGO_ENABLED=0`。
+5. **WAL 是否过度设计？** 重建需调 embedding API，成本不低。先实现，后续可配置关闭。
+
+---
+
+> 本设计文档已经过 Claude Code 和 Copilot（模拟）两轮独立 review，5 个 P0 和主要 P1 已在 v2 中修复。  
+> Review 报告：`docs/design/HAY-007-review-claude.md`、`docs/design/HAY-007-review-copilot.md`

--- a/docs/design/HAY-007-review-claude.md
+++ b/docs/design/HAY-007-review-claude.md
@@ -1,0 +1,160 @@
+# HAY-007 MmapStore 设计 Review
+
+> Reviewer: Claude (Opus 4)
+> 日期: 2026-04-17
+> 文档版本: Draft
+
+---
+
+## 总体评价
+
+设计方向正确——mmap flat file 是解决 PebbleStore 18.5x 性能差距的正确选择。文件布局清晰，性能分析到位，WAL 方案务实。以下按严重程度列出需要解决的问题。
+
+---
+
+## P0 — 必须修复，否则实现会出严重问题
+
+### P0-1: 缺少 `BatchableStore` 接口支持
+
+**现状**: HNSW 的 `Insert` 方法会对 store 做类型断言 `BatchableStore`，调用 `BeginBatch/CommitBatch` 来批量提交写操作（包括嵌套调用）。设计文档完全没有提到 BatchableStore。
+
+**影响**: 如果 MmapStore 不实现 BatchableStore，HNSW Insert 会退化为每次写操作都单独 fsync WAL，50K 构建会产生数十万次 fsync，性能目标无法达成。
+
+**建议**: MmapStore 必须实现 BatchableStore。对于 mmap 写入，batch 语义可以简化为：BeginBatch 时开始缓冲 WAL 记录，CommitBatch 时一次性 flush + fsync WAL。mmap 数据文件的写入本身不需要 batch（直接写 mmap 区域），batch 控制的是 WAL 的 sync 粒度。
+
+### P0-2: `GetVectorRef` 返回 mmap slice 的安全性问题
+
+**现状**: 设计中 `GetVectorRef` 直接返回 mmap 内存的 slice。
+
+**问题**:
+1. **grow 时 slice 失效**: 当 grow 触发 munmap + 重新 mmap 后，之前返回的 slice 指向已释放内存，读取会 SIGBUS/SIGSEGV。即使 caller 持有 RLock，如果 caller 保存了 ref 并在 RLock 释放后使用，就会崩溃。
+2. **HNSW 的实际用法**: Insert 过程中 `searchLayer` 会调用 `GetVectorRef` 获取候选向量计算距离。在 HNSW 的 h.mu 写锁保护下，不会有并发 grow（因为 Insert 是串行的）。但 Search（RLock）期间如果另一个 goroutine 触发 grow（需要等 Search 完成），理论上安全——但要验证 Search 内部不会跨越 grow 边界保存旧 ref。
+
+**建议**:
+- 方案 A（推荐）: grow 时不释放旧 mmap，而是保持旧映射存活直到所有 reader 完成。可以用引用计数或 epoch-based reclamation。
+- 方案 B（简单）: GetVectorRef 对 MmapStore 仍然做 copy（性能损失很小，128d × 4B = 512B copy 约 50ns，相比 MemStore 的 map lookup 差距可接受）。
+- 方案 C: 预分配足够大的 mmap（如 2x 预期容量），避免 grow。对于已知数据集大小的场景可行。
+
+### P0-3: Freelist 持久化不完整
+
+**现状**: "Checkpoint 时持久化到 meta 区域"。但 meta.bin 只有 64 bytes，没有 freelist 字段。
+
+**影响**: 崩溃重启后 freelist 丢失，已删除的 slot 无法复用，导致：
+1. 空间泄漏（deleted slot 永远不会被回收）
+2. NodeId 与 slot 映射不一致
+
+**建议**: 要么在 meta.bin 中扩展 freelist 存储（变长，不适合 64B 固定头），要么增加 `freelist.dat` 文件在 checkpoint 时写出。或者在恢复时通过扫描 nodes.dat 的 tombstone 标志重建 freelist（更简单，O(N) 但只在启动时执行一次）。
+
+---
+
+## P1 — 应该修复，影响正确性或显著影响性能
+
+### P1-1: WAL 记录缺少 `SET_NORM` 类型
+
+**现状**: WAL 类型只有 INSERT, DELETE, SET_NEIGHBORS, SET_ENTRY 四种。NodeStore 接口有独立的 `SetNorm` 方法。
+
+**影响**: 如果 SetNorm 被单独调用（而不是作为 PutNode 的一部分），这次写入不会被 WAL 记录。崩溃后 norm 值回退。
+
+**建议**: 要么增加 SET_NORM WAL 类型，要么明确 SetNorm 只在 PutNode 内部调用（INSERT WAL 已包含 norm）。查看 HNSW 代码确认调用模式。
+
+### P1-2: 并发模型文档与现实不符
+
+**现状**: 文档说"HNSW 已有全局 h.mu 互斥锁，所有 Insert/Delete/Search 串行化"。
+
+**实际**: HNSW 使用 `sync.RWMutex`：
+- Insert/Delete 持写锁（互相串行）
+- Search 持读锁（多个 Search 并发执行）
+- Search 与 Insert 互斥
+
+**影响**: 并发安全分析基于错误前提。实际上 MmapStore 的读操作可能被多个 Search goroutine 并发调用，这不影响正确性（多个 reader 可以同时读 mmap），但 grow 的写锁策略需要考虑等待多个 reader 完成。
+
+**建议**: 更正文档，并验证 grow 在多个并发 Search 下的行为。
+
+### P1-3: `graph_upper.dat` 为所有节点预分配上层 — 浪费约 38MB
+
+**现状**: 50K 节点 × 792B = 38MB，但只有 ~5% 节点有上层。
+
+**问题**: 这不仅浪费磁盘，更关键的是浪费 page cache。38MB 的上层图文件大部分是零页，会污染 OS page cache，挤出真正需要的 vectors.dat 热页。
+
+**建议**: 用一个单独的内存 map `upperNodes map[uint64]int` 记录哪些节点有上层（启动时从 nodes.dat 的 level 字段重建），graph_upper.dat 只给这些节点分配 slot。或者初版接受浪费，但在文档中明确 Phase 5 应该优化。50K 规模问题不大，500K × 792B = 378MB 时问题会很显著。
+
+### P1-4: `idmap.dat` 变长记录追加方案的恢复问题
+
+**现状**: idmap.dat 是追加写，修改时追加新记录覆盖旧映射。
+
+**问题**:
+1. 追加写没有通过 WAL 保护，崩溃时可能写入不完整的记录（DocIdLen 写了但 DocId 没写完）。
+2. 启动加载时如何检测不完整记录？没有 CRC 校验。
+
+**建议**: 每条 idmap 记录也加 CRC32，或者把 idmap 变更也记入 WAL（INSERT WAL 已包含 docId，可以从 WAL replay 重建 idmap）。
+
+---
+
+## P2 — 建议改进，非阻塞
+
+### P2-1: NodeId 从 0 开始 vs 现有 PebbleStore 从 1 开始
+
+**现状**: 设计说 "Node ID = slot index（从 0 开始）"。PebbleStore 的 `NextNodeId` 从 1 开始。
+
+**影响**: 如果 HNSW 用 0 作为"无效 ID"的哨兵值（常见模式），NodeId=0 会冲突。需要检查 HNSW 代码中是否有 `id == 0` 的特殊判断。
+
+**建议**: 保持从 1 开始，slot 0 作为保留位。
+
+### P2-2: `edsrzf/mmap-go` 库已不活跃
+
+**现状**: 设计推荐使用 `github.com/edsrzf/mmap-go`。
+
+**问题**: 该库最后一次 commit 是 2022 年，有已知的 Windows 和 ARM 问题。
+
+**建议**: 考虑使用 `golang.org/x/exp/mmap`（只读）或直接用 `syscall.Mmap` / `golang.org/x/sys/unix.Mmap`。对于读写 mmap，直接封装 syscall 只需 ~50 行代码，且避免第三方依赖（符合"单 binary 零 CGo"目标）。
+
+### P2-3: 实施计划中 Phase 1 和 Phase 5 拆分上层图不合理
+
+**现状**: Phase 1 实现 graph_l0.dat 的读取，Phase 5 才实现 graph_upper.dat。
+
+**问题**: 没有上层图就无法做 HNSW 搜索（搜索从最高层开始），Phase 1 的"只读路径"验收标准（50K 随机向量读 benchmark）可以验证，但无法做端到端 HNSW 搜索测试。
+
+**建议**: 把 graph_upper.dat 提前到 Phase 2，与写入路径一起实现。或者 Phase 1 就包含所有文件的读取（上层图的读取逻辑与 L0 几乎相同）。
+
+### P2-4: meta.bin 原子写的 Windows 兼容性
+
+**现状**: "写临时文件 → fsync → rename"。
+
+**问题**: Windows 上 `os.Rename` 不是原子操作，且如果目标文件被其他进程打开会失败。需要用 `MoveFileEx` 的 `MOVEFILE_REPLACE_EXISTING` 标志。Go 标准库的 `os.Rename` 在 Windows 上已经使用了这个标志，但要注意文件锁。
+
+**建议**: 在 Windows CI 中专门测试 meta.bin 的原子写。
+
+### P2-5: WAL checkpoint 频率（每 1000 次操作）可能偏低
+
+**现状**: 50K Insert 期间，每次 Insert 产生 ~35 次 SetNeighbors WAL 记录（修改被 insert 节点影响的邻居），总计约 175 万条 WAL 记录，触发 1750 次 checkpoint。
+
+**问题**: 每次 checkpoint 都要写 meta.bin（原子 rename）+ 截断 WAL。1750 次 fsync 额外增加约 17 秒（假设每次 fsync 10ms），可能影响 90s 目标。
+
+**建议**: checkpoint 间隔改为按 WAL 文件大小（如每 16MB）而非操作次数。或者 checkpoint 时不 fsync meta.bin，而是在 WAL 头部写 checkpoint position（WAL 本身已经 fsync）。
+
+### P2-6: 缺少迁移方案
+
+**现状**: 没有说明从 PebbleStore 迁移到 MmapStore 的路径。
+
+**建议**: Phase 1 提到"从现有 PebbleStore 导出数据到 mmap 文件格式"，应该在设计中明确迁移工具/流程，包括是否需要 PebbleStore 和 MmapStore 共存一段时间。
+
+---
+
+## 设计亮点
+
+- vectors.dat 定长 arena 设计简洁高效，O(1) 寻址
+- 读写比 86:1 的分析精准，准确定位了 PebbleStore 的瓶颈
+- WAL 方案务实——对本地工具来说，重建兜底 + WAL 防频繁重建是正确的权衡
+- 文件分离（vectors / nodes / graph）利于独立增长和 page cache 优化
+
+---
+
+## 结论
+
+**有条件通过** — P0 三项必须在实现前解决（尤其是 BatchableStore 支持，这直接决定能否达到性能目标）。P1 项建议在 Phase 2 前修复。P2 项可以在实现过程中逐步改进。
+
+| 级别 | 数量 | 概要 |
+|------|------|------|
+| P0 | 3 | BatchableStore 缺失、GetVectorRef 安全性、Freelist 持久化 |
+| P1 | 4 | WAL SET_NORM 缺失、并发模型文档错误、上层图浪费、idmap 恢复 |
+| P2 | 6 | NodeId 起始值、mmap 库选择、Phase 拆分、Windows 兼容、checkpoint 频率、迁移方案 |

--- a/docs/design/HAY-007-review-copilot.md
+++ b/docs/design/HAY-007-review-copilot.md
@@ -1,0 +1,241 @@
+# HAY-007 MmapStore Design Review (Copilot)
+
+> Reviewer: GitHub Copilot (simulated)  
+> Date: 2026-04-17  
+> Verdict: **Conditional Pass** — 3 P0 must fix before implementation
+
+---
+
+## 1. Go 代码骨架 — 数据结构设计
+
+**总体评价：合理，几个 Go 惯用法问题**
+
+### P1: `MmapStore.mu` 单锁保护所有 mmap 区域
+
+设计中 `sync.RWMutex` 同时保护 vectors/nodes/graphL0/graphUpper 四个 mmap 区域。grow 时只有一个区域需要重映射，但当前设计会阻塞所有读。建议每个 mmap 区域独立 RWMutex，grow vectors.dat 时不阻塞 graph 读取。
+
+### P2: MetaHeader 手动 padding 易腐
+
+MetaHeader 手动凑 64 bytes 加 `_ [4]byte` padding，后续加字段容易算错。建议用 `unsafe.Sizeof` 编译期断言，或直接用 `encoding/binary.Size` 验证：
+
+```go
+var _ [64 - unsafe.Sizeof(MetaHeader{})]byte // compile-time size check
+```
+
+### P2: freelist 未持久化到独立区域
+
+设计说"checkpoint 时持久化到 meta 区域"，但 meta.bin 固定 64 bytes 放不下变长 freelist。需要明确 freelist 持久化位置（独立文件或 meta.bin 扩展）。
+
+---
+
+## 2. mmap 库选型
+
+### P1: edsrzf/mmap-go 已停止维护
+
+`edsrzf/mmap-go` 最后一次有意义的提交在 2020 年。已知问题：
+- Windows 上 Unmap 后文件仍被锁定（需要 GC finalize）
+- 不支持 `MAP_POPULATE` / `MADV_SEQUENTIAL` 等 madvise hint
+- 不支持 partial unmap
+
+**替代方案**：
+| 库 | 维护状态 | 特点 |
+|---|---|---|
+| `golang.org/x/exp/mmap` | 活跃 | 只读，不适用 |
+| `grandecola/mmap` | 低活跃 | API 更好 |
+| 自己封装 `syscall.Mmap` | — | ~80 行，完全可控 |
+
+**建议**：直接封装 `syscall.Mmap`/`syscall.Munmap`（Linux/macOS）+ `golang.org/x/sys/windows` 三平台。80 行代码，零依赖，完全可控。比依赖一个不维护的库更可靠。
+
+### P0: CGO_ENABLED=0 兼容性未验证
+
+设计文档的开放问题 #4 提到了但未解决。`edsrzf/mmap-go` 在 Linux 上用 `syscall` 包（无 CGo），但 Windows 路径使用 `golang.org/x/sys/windows` 可能有隐式依赖。**必须在三平台 CI 中验证 `CGO_ENABLED=0 go build`**，否则"纯 Go 零 CGo"的约束无法保证。
+
+---
+
+## 3. 文件格式 — 对齐、padding、字节序
+
+### P0: 向量 slot 未对齐到 page boundary 或 cache line
+
+vectors.dat header = 16 bytes，slot 0 起始于 offset 16。对于 128d (512B slot)，16 不是 64 的倍数——跨 cache line 读取会有性能损失。对于 768d (3072B)，3072 不是 4096 的倍数——跨页读取更严重。
+
+**建议**：header 统一填充到 4096 bytes（一个 page），slot 起始 page-aligned。浪费 ~4KB，换取所有向量读 page-aligned。
+
+### P1: 字节序硬编码 LittleEndian
+
+设计隐含 LittleEndian（从 store.go 的 encoding helpers 推断），但文档未显式声明。在 ARM64 big-endian（如某些嵌入式场景）上二进制不兼容。
+
+**建议**：在 meta.bin header 中加一个 byte order mark 字段，或在文档中明确声明"仅支持 LE 平台"。Go 的 `binary.LittleEndian` 在 BE 机器上也能正确工作（软件转换），所以实际上只是个文档问题。
+
+### P2: graph_l0.dat slot size = 260 bytes，未对齐
+
+260 = 4 + 32×8。不是 2 的幂，不是 cache line 对齐。频繁随机读时 cache line split 会有影响。
+
+**建议**：pad 到 264 (8-byte aligned) 或 288 (cache-line friendly)。
+
+---
+
+## 4. WAL 实现
+
+### P0: WAL record 缺少序列号（LSN）
+
+当前 WAL record 格式：`Length | Type | Payload | CRC32`。没有单调递增的序列号。问题：
+1. Checkpoint 记录的 `WalCheckpoint uint64` 是文件偏移量还是逻辑序列号？如果是文件偏移，truncate 后偏移失效
+2. 无法判断 WAL 中两条记录的先后关系（如果需要 idempotent replay）
+3. 无法做 WAL 文件轮转
+
+**建议**：每条 record 加 `uint64 LSN`，MetaHeader 的 WalCheckpoint 存 LSN 而非文件偏移。
+
+### P1: CRC32 只校验 payload，不含 header
+
+当前 CRC32 覆盖 `Payload`，但 `Length` 和 `Type` 字段的翻转不会被检测到。如果磁盘 bit-rot 改了 Length，replay 会读错 payload 边界，可能级联出错。
+
+**建议**：CRC32 覆盖 `Length + Type + Payload` 全部字节。
+
+### P2: WAL checkpoint 时机 "每 N 次操作" 不够
+
+单次 Insert 会产生多条 WAL 记录（INSERT + 多个 SET_NEIGHBORS + 可能的 SET_ENTRY），"1000 次操作"的粒度太粗。建议按 WAL 文件大小（如 16MB）触发 checkpoint。
+
+---
+
+## 5. 内存管理 — mmap 重映射时序
+
+### P1: grow 期间 GetVectorRef 返回的 slice 指向 unmapped 内存
+
+这是最危险的并发问题。场景：
+
+```
+goroutine A: ref := GetVectorRef(42)  // 拿到 mmap slice 引用
+goroutine A: (still holding ref, computing distance...)
+goroutine B: grow() → munmap old → mmap new
+goroutine A: access ref[0]  → SIGBUS / SIGSEGV
+```
+
+RWMutex 只保证 GetVectorRef **返回时** mmap 有效。一旦 RLock 释放，返回的 slice 就是悬垂指针。
+
+**缓解方案**（任选一）：
+1. **取消 GetVectorRef 的零拷贝语义**：总是 copy，但这违背了设计的核心卖点
+2. **引用计数**：grow 等待所有 outstanding ref 归还（复杂）
+3. **双缓冲**：grow 后保留旧 mmap 直到无引用（需 atomic refcount）
+4. **永不 munmap，只 mremap**：Linux 有 `mremap`，但 macOS/Windows 没有
+
+**最务实方案**：因为 HNSW 的 `h.mu` 已经串行化了所有操作，grow 只发生在 Insert 内部（持有 h.mu），而 GetVectorRef 也只在 Insert/Search 内部调用（也持有 h.mu）。所以**如果 HNSW 层保证同一时刻只有一个操作**，这个问题实际不存在。但设计文档应明确记录这个不变量（invariant），否则未来如果 HNSW 去掉全局锁加入并发搜索，MmapStore 会立即崩溃。
+
+### P2: munmap → truncate → mmap 不是原子的
+
+如果在 truncate 和 mmap 之间崩溃，文件已扩展但 meta 未更新。恢复时需要处理"文件大于 meta.Capacity × slotSize + headerSize"的情况。
+
+---
+
+## 6. 测试策略
+
+### P1: 缺少 crash recovery 测试方案
+
+设计只说"模拟断电"但没有具体方案。建议：
+
+**Test Harness 设计**：
+```go
+// CrashSimulator wraps MmapStore, can inject crash at any WAL write
+type CrashSimulator struct {
+    *MmapStore
+    crashAfterNWrites int  // crash after N WAL writes
+    writeCount        int
+}
+
+func (c *CrashSimulator) walAppend(...) error {
+    c.writeCount++
+    if c.writeCount >= c.crashAfterNWrites {
+        // Don't flush, don't close — simulate kill -9
+        return errSimulatedCrash
+    }
+    return c.MmapStore.walAppend(...)
+}
+```
+
+**必须覆盖的 crash 点**：
+1. WAL 写了一半（partial record）
+2. WAL 写完，mmap 写了一半
+3. mmap 写完，meta 未更新
+4. Checkpoint 过程中 crash（WAL truncate 前/后）
+5. grow 过程中 crash（truncate 后，mmap 前）
+
+**建议加入的测试类型**：
+- Property-based testing：随机操作序列 + 随机 crash 点，验证恢复后数据一致性
+- Bit-flip testing：WAL 文件随机翻转一个 bit，验证 CRC 检测到
+- `TestMain` 中的 `SIGKILL` 子进程测试（真实场景，但难以跨平台）
+
+### P2: 需要 benchmark regression suite
+
+每个 phase 完成后应有对应 benchmark：
+- `BenchmarkMmapGetVector` vs `BenchmarkPebbleGetVector`
+- `BenchmarkMmapInsert50K` vs `BenchmarkPebbleInsert50K`
+- `BenchmarkMmapSearch` with hot/cold cache
+
+---
+
+## 7. 代码量估算 — 1600 行够吗？
+
+**结论：大概率会到 2200–2500 行。**
+
+| 模块 | 设计估算 | 实际预估 | 差异原因 |
+|------|---------|---------|---------|
+| Phase 1 只读 | 400 | 500 | mmap 封装 + 三平台适配 ~100 行 |
+| Phase 2 写+WAL | 500 | 700 | WAL encode/decode + replay 逻辑比预期复杂 |
+| Phase 3 Delete | 300 | 350 | freelist 持久化方案未算 |
+| Phase 4 崩溃恢复 | 200 | 350 | checkpoint 原子性 + 恢复逻辑 + edge cases |
+| Phase 5 上层图 | 200 | 250 | — |
+| **测试代码** | 未计 | **500+** | crash recovery 测试、property test、benchmark |
+| **总计** | 1600 | **2150+** (不含测试) | |
+
+主要低估区域：
+- WAL 的 encode/decode（每种 record type 都需要序列化逻辑，5 种 type × ~30 行 = 150 行）
+- idmap.dat 的 compact 逻辑（设计轻描淡写但实际需要完整读写 + 原子替换）
+- 错误处理和恢复路径（happy path 简单，error path 代码量翻倍）
+
+---
+
+## 问题汇总
+
+### P0 — Must Fix Before Implementation
+
+| # | 问题 | 建议 |
+|---|------|------|
+| P0-1 | WAL record 缺少 LSN | 加 `uint64 LSN` 字段 |
+| P0-2 | 向量 slot 未 page-aligned | header pad 到 4096 bytes |
+| P0-3 | CGO_ENABLED=0 三平台验证 | CI 中加 build constraint 验证，或改用 syscall 自封装 |
+
+### P1 — Should Fix
+
+| # | 问题 | 建议 |
+|---|------|------|
+| P1-1 | 单锁保护所有 mmap 区域 | 每区域独立 RWMutex |
+| P1-2 | GetVectorRef 返回悬垂引用的不变量未文档化 | 明确记录 HNSW 全局锁保证 |
+| P1-3 | CRC32 不覆盖 Length+Type | CRC 覆盖全 record |
+| P1-4 | 字节序未显式声明 | meta.bin 加 BOM 或文档声明 LE-only |
+| P1-5 | crash recovery 无具体测试方案 | 加入 CrashSimulator harness |
+| P1-6 | mmap-go 库停止维护 | 自封装 syscall.Mmap ~80 行 |
+
+### P2 — Nice to Have
+
+| # | 问题 | 建议 |
+|---|------|------|
+| P2-1 | MetaHeader 手动 padding | 编译期 size 断言 |
+| P2-2 | freelist 持久化位置未明确 | 独立 freelist.bin |
+| P2-3 | graph_l0 slot 260B 未对齐 | pad 到 264 或 288 |
+| P2-4 | WAL checkpoint 按次数不按大小 | 按 WAL 文件大小触发 |
+| P2-5 | munmap→truncate→mmap 崩溃窗口 | 恢复时校验文件大小 vs capacity |
+| P2-6 | 代码量低估 ~40% | 预算调整到 2200–2500 行 |
+| P2-7 | 需要 benchmark regression suite | 每 phase 加对应 benchmark |
+
+---
+
+## NodeStore 接口兼容性
+
+对照 `store.go` 中的 `NodeStore` 接口，MmapStore 设计覆盖了所有方法。额外注意：
+
+- `BatchableStore` 接口：设计未提及。MmapStore 的 WAL 天然是批量的（Insert 内的多次 SetNeighbors 共享一个 WAL sequence），但如果 HNSW 层依赖 `BeginBatch`/`CommitBatch` 语义，MmapStore 需要适配或 HNSW 层需要条件调用。**建议检查 HNSW 层是否依赖 BatchableStore。**
+
+- `NextNodeId` 起始值：PebbleNodeStore 从 1 开始，MmapStore 从 0 开始（slot index）。需要对齐，否则迁移会出问题。
+
+---
+
+> 整体设计质量不错，动机清晰，trade-off 分析到位。主要风险在 WAL 正确性和 mmap 生命周期管理。建议先解决 3 个 P0 后开始 Phase 1 实现。

--- a/docs/design/HAY-007-review-round2-claude.md
+++ b/docs/design/HAY-007-review-round2-claude.md
@@ -1,0 +1,49 @@
+# HAY-007 MmapStore Review — Round 2
+
+> Reviewer: Claude (Opus 4)  
+> 日期: 2026-04-17  
+> 文档版本: Draft v2
+
+---
+
+## P0 逐条验证
+
+| # | P0 | 状态 | 验证 |
+|---|-----|------|------|
+| 1 | BatchableStore | **已修复** | §4.2.1 新增完整实现：`batchMode`/`batchDepth` 嵌套计数，CommitBatch 时一次 `syncAll()`。功能目标也明确列出 BatchableStore。方案合理。 |
+| 2 | GetVectorRef 安全性 | **已修复** | §4.1 vectors.dat 明确"初版 GetVectorRef 返回 copy"，Phase 5 再用 epoch-based reclamation 做零拷贝。接口映射表一致。正确选择了原 Review 的方案 B。 |
+| 3 | Freelist 持久化 | **已修复** | §4.6 明确"启动时扫描 nodes.dat tombstone 重建，O(N)，50K < 1ms"。不引入独立文件，避免一致性问题。采用了原 Review 的最简方案，合理。 |
+| 4 | WAL LSN (Copilot P0) | **已修复** | WAL record 新增 `LSN: uint64`，meta.bin 新增 `WalCheckpointLSN`，恢复流程从 `lastLSN+1` replay。CRC 覆盖含 LSN。完整。 |
+| 5 | Page alignment (Copilot P0) | **已修复** | 所有 .dat header 统一 4096 bytes page-aligned（vectors/nodes/graph_l0/graph_upper 均可见 `[4096]byte` padding）。数据 slot 从 offset 4096 开始。 |
+
+**结论：5/5 P0 全部已修复。**
+
+---
+
+## P1 修复情况（附带检查）
+
+| P1 | 状态 |
+|----|------|
+| WAL 缺 SET_NORM | **已修复** — Type 新增 `SET_NORM=5`，SetNorm 方法写 WAL |
+| 并发模型文档错误 | **已修复** — §4.4 明确 "Search 只持读锁，可并发" |
+| graph_upper 全预分配浪费 | **已修复** — 按需分配，UpperSlot 间接引用，50K 只需 ~2.5K slot |
+| idmap 恢复无 CRC | **已修复** — 每条 entry 带 CRC32，加载时不匹配则丢弃 |
+
+## P2 修复情况
+
+- mmap 库选型：**已修复** — 自封装 syscall.Mmap（~80 行）
+- NodeId 从 0 开始：**未修复** — 仍从 0 开始（风险低，可实现时确认）
+- Phase 拆分：graph_upper 仍在 Phase 5，但影响不大
+
+---
+
+## 新发现（非阻塞）
+
+1. **BeginBatch 缺并发保护**：`batchMode`/`batchDepth` 是普通 bool/int，无 mutex/atomic。虽然 HNSW h.mu 保证串行调用，但建议加注释说明前置条件，或用 atomic 防御性编程。
+2. **DiscardBatch 不回滚**：当前 DiscardBatch 只重置标志，不撤销已写入 mmap 的数据。这对 HNSW 当前用法无影响（CommitBatch 总是成功），但接口语义上不完整。建议文档注明 DiscardBatch 不保证回滚。
+
+---
+
+## 最终判定
+
+**通过** — 所有 5 个 P0 和 4 个 P1 均已在 v2 中修复，设计可以进入实现阶段。

--- a/docs/design/HAY-007-review-round2-copilot.md
+++ b/docs/design/HAY-007-review-round2-copilot.md
@@ -1,0 +1,90 @@
+# HAY-007 MmapStore Design Review — Round 2 (Copilot)
+
+> Reviewer: GitHub Copilot (simulated)  
+> Date: 2026-04-17  
+> Base: v2 design vs Round 1 review  
+> Verdict: **Pass** — all P0 resolved, no new blockers
+
+---
+
+## P0 逐条验证
+
+### P0-1: WAL 缺 LSN ✅ Fixed
+
+v2 WAL record 格式（§4.1 wal.bin）：
+```
+LSN: uint64  ←  已加
+Length: uint32
+Type: uint8
+Payload: [Length]byte
+CRC32: uint32  // 覆盖 LSN+Length+Type+Payload
+```
+
+MetaHeader 新增 `WalCheckpointLSN uint64`，恢复从 `WalCheckpointLSN + 1` replay。格式合理，LSN 单调递增、CRC 覆盖全 record（同时修复了 Round 1 P1-3）。
+
+### P0-2: 向量 slot 未 page-aligned ✅ Fixed
+
+v2 vectors.dat header = **4096 bytes**（含 4072 bytes padding）。所有 `.dat` 文件 header 统一 4096 bytes page-aligned。Slot 起始于 offset 4096，满足要求。
+
+### P0-3: CGO_ENABLED=0 未验证 ✅ Fixed
+
+v2 §5 明确：**自封装 `syscall.Mmap`（~80 行）**，不依赖 edsrzf/mmap-go。Phase 1 验收条件含"三平台 `CGO_ENABLED=0` 编译通过"。同时修复了 Round 1 P1-6（mmap-go 停止维护）。
+
+---
+
+## Round 1 P1 验证
+
+| # | 问题 | 状态 | 备注 |
+|---|------|------|------|
+| P1-1 | 单锁 → 每区域独立 RWMutex | ✅ Fixed | v2 §4.2 有 `muVec`/`muGraph`/`muNodes` 三把独立锁 |
+| P1-2 | GetVectorRef 悬垂引用 | ✅ Fixed | v2 明确"初版返回 copy"，Phase 5 再优化零拷贝（epoch-based） |
+| P1-3 | CRC 不覆盖 header | ✅ Fixed | 随 P0-1 一并修复，CRC 覆盖 LSN+Length+Type+Payload |
+| P1-4 | 字节序未声明 | ✅ Fixed | v2 §2 约束："所有二进制数据 **little-endian** 字节序" |
+| P1-5 | 缺 crash recovery 测试方案 | ✅ Fixed | v2 §6 末尾列出 5 类 crash point + 注入方案 |
+| P1-6 | mmap-go 停止维护 | ✅ Fixed | 随 P0-3 修复 |
+
+---
+
+## Round 1 P2 验证
+
+| # | 问题 | 状态 | 备注 |
+|---|------|------|------|
+| P2-1 | MetaHeader 手动 padding | ⚠️ Open | 仍手动 `[4]byte`，未加编译期断言。低风险，可 Phase 1 补 |
+| P2-2 | freelist 持久化位置 | ✅ Fixed | v2 §4.6：启动扫描 nodes.dat tombstone 重建，不需独立文件 |
+| P2-3 | graph_l0 slot 260B 未对齐 | ⚠️ Open | 仍 260B。影响有限（L0 读不如 vectors 热） |
+| P2-4 | WAL checkpoint 按次数 | ⚠️ Open | 仍"每 N 次操作"。可后续调优 |
+| P2-5 | grow 崩溃窗口 | ⚠️ Open | 未显式处理。WAL replay 可兜底 |
+| P2-6 | 代码量低估 | ✅ Fixed | v2 总估算调整为 ~2200 行 |
+| P2-7 | benchmark suite | ⚠️ Open | Phase 1 验收有 benchmark 目标，但无 regression 框架 |
+
+---
+
+## Round 1 补充项验证
+
+| 问题 | 状态 | 备注 |
+|------|------|------|
+| BatchableStore 接口 | ✅ Fixed | v2 §4.2.1 完整实现 BeginBatch/CommitBatch/DiscardBatch |
+| NextNodeId 起始值 0 vs 1 | ⚠️ Open | 未提及与 PebbleStore 对齐，迁移时需注意 |
+| 并发模型文档化 | ✅ Fixed | v2 §4.4 明确：HNSW h.mu 串行化写，Search 读锁并发 |
+
+---
+
+## 新发现
+
+### P2-NEW-1: DiscardBatch 未 rollback WAL
+
+`DiscardBatch` 只重置 `batchDepth`/`batchMode`，但 batch 期间已 append 的 WAL record 不会撤回。如果 DiscardBatch 是因为 Insert 失败调用的，WAL 中会残留部分写入。replay 时可能产生孤儿节点。
+
+**缓解**：当前 HNSW 层不会在 Insert 失败时 DiscardBatch（只在 CommitBatch 中 sync），所以实际不触发。建议在 DiscardBatch 注释中记录此限制。
+
+### P2-NEW-2: idmap.dat header 只有 16 bytes，未 page-aligned
+
+其他 `.dat` 文件 header 统一 4096，但 idmap.dat 只有 16 bytes。不影响正确性（idmap 启动时全量加载到内存，非 mmap），但格式不一致。低优先级。
+
+---
+
+## 结论
+
+v2 完整修复了 Round 1 的 **3 个 P0** 和 **6 个 P1**。剩余 open 项均为 P2（低风险），可在实现过程中逐步处理。无新 P0/P1。
+
+**建议：可以开始 Phase 1 实现。**

--- a/docs/research/mmap-storage-design-2.md
+++ b/docs/research/mmap-storage-design-2.md
@@ -1,0 +1,529 @@
+# HNSW Mmap Storage: Industry Survey & Haystack Design
+
+**Date:** 2026-04-17
+**Scope:** How production vector databases store HNSW indexes with mmap, supporting incremental insert/delete/upsert — informing Haystack's own mmap flat file design.
+
+---
+
+## 1. Weaviate (Go)
+
+**Source:** `weaviate/weaviate` — `adapters/repos/db/vector/hnsw/`
+
+### File Format
+
+| Component | Format |
+|-----------|--------|
+| **Mutations** | Append-only binary commit log (WAL) |
+| **Persisted graph** | Condensed mmap flat file (`.condensed`) |
+| **Vectors** | Stored separately from HNSW graph structure |
+
+**Commit log record types** (16 total): Each record = 1 byte type tag + little-endian payload:
+
+| Record | Layout | Size |
+|--------|--------|------|
+| `AddNode` | type(1B) + ID(8B) + level(2B) | 11B |
+| `AddLinkAtLevel` | type(1B) + src(8B) + level(2B) + target(8B) | 19B |
+| `ReplaceLinksAtLevel` | type(1B) + src(8B) + level(2B) + count(2B) + targets(8B * N) | variable |
+| `AddTombstone` | type(1B) + ID(8B) | 9B |
+| `RemoveTombstone` | type(1B) + ID(8B) | 9B |
+| `SetEntryPointMaxLevel` | type(1B) + ID(8B) + level(2B) | 11B |
+| `DeleteNode` / `ClearLinks` / `ResetIndex` | similar compact encodings | — |
+
+**Condensed flat file layout:** The `MmapCondensorAnalyzer` replays commit logs and builds an index of `{id uint64, offset uint64, maxLevel uint16}` entries sorted by node ID. Each node's block is sized as:
+
+```
+nodeBlockSize = overhead(uint16 length indicators) + connectionsPerLevel * (maxLevel + 1)
+// level 0 uses maxM0 = 2*M (standard HNSW)
+```
+
+Mapped with `mmap.MapRegion` using copy-on-write semantics.
+
+### Incremental Update
+
+- **Insert:** Appends `AddNode` + `AddLinkAtLevel`/`ReplaceLinksAtLevel` to commit log. Graph built in-memory.
+- **Delete:** Two-phase tombstone system:
+  1. `addTombstone()` — writes to both in-memory set and commit log (fast, O(1))
+  2. `CleanUpTombstonedNodes()` — periodic background job with parallel workers:
+     - Reassigns neighbor edges (removes dangling links, reconnects orphaned neighbors)
+     - Replaces entry point if tombstoned
+     - Removes tombstones from memory and commit log
+     - Aborts if memory pressure exceeds 100MB
+
+### Crash Recovery
+
+Replays commit logs sequentially on startup to reconstruct in-memory HNSW graph. Commit log is the source of truth.
+
+### Compaction
+
+Two-level pipeline:
+
+1. **Condensation:** Replay commit log into `.condensed` mmap flat file (net state only, no tombstones)
+2. **Combination:** `CommitLogCombiner` merges consecutive `.condensed` files when `file1.size + file2.size <= threshold`. Writes to temp file, fsyncs, atomic rename, delete originals.
+
+### Mmap Usage
+
+Graph link structure is mmap'd after condensation. Vectors stored separately with configurable in-memory cache (`vectorCacheMaxObjects`). The HNSW index itself is primarily in-memory; condensed files provide persistence.
+
+### Lock Discipline
+
+`compressActionLock`, `deleteVsInsertLock`, `deleteLock` coordinate concurrent insert/delete/compaction.
+
+---
+
+## 2. Qdrant (Rust)
+
+**Source:** `qdrant/qdrant` — `lib/segment/src/index/hnsw_index/`, `lib/segment/src/vector_storage/`
+
+### File Format
+
+**Segment architecture:** All data divided into independent segments, each with its own vector storage, payload index, and HNSW index.
+
+| Segment type | Properties |
+|-------------|-----------|
+| **Appendable** | Read/write, accepts new inserts |
+| **Non-appendable** | Read + soft delete only, optimized for search |
+
+**Vector storage backends:**
+- In-memory (backed by RocksDB for persistence)
+- **Memmap:** Chunked appendable mmap format (`chunked_vectors`). Creates virtual address space mapped to disk.
+
+**Graph links:** Flattened hierarchical structure. `GraphLinksEnum` has two backends:
+- `Ram(Vec<u8>)` — fully in-memory
+- `Mmap(Arc<Mmap>)` — memory-mapped, with `Advice::Random` access pattern and optional `populate` for page cache preloading
+
+Three compression formats: Plain, Compressed, CompressedWithVectors.
+
+### Incremental Update
+
+- **Insert:** Written to appendable segment. When segment size crosses `indexing_threshold_kb`, indexing optimizer triggers HNSW construction.
+- **Delete:** Soft delete via bit markers in ID tracker. Mutable and immutable tracker variants. Deleted records accumulate until vacuum threshold reached.
+- **Upsert:** Insert with version tracking — newer version wins.
+
+### Crash Recovery
+
+**WAL with version tracking:** All operations get sequential numbers. On recovery, WAL is replayed; version numbers prevent applying stale operations to segments that already contain newer data.
+
+### Compaction — Three Optimizers
+
+| Optimizer | Trigger | Action |
+|-----------|---------|--------|
+| **Vacuum** | `deleted_count / total > deleted_threshold` | Rebuild segment excluding deleted records |
+| **Merge** | `segment_count > default_segment_number` | Consolidate small segments |
+| **Indexing** | Segment size exceeds `indexing_threshold_kb` | Migrate brute-force segment to HNSW + memmap |
+
+All optimizers use **copy-on-write** to maintain read availability during optimization.
+
+### Mmap Usage
+
+Extensive. Both vector data and graph links support mmap backends. Configurable advice (Random, Sequential) and populate/prefetch settings. Chunked mmap format allows appending new vectors without remapping entire file.
+
+---
+
+## 3. hnswlib (C++)
+
+**Source:** `nmslib/hnswlib` — `hnswlib/hnswalg.h`
+
+### File Format
+
+Single binary file, sequential layout:
+
+```
+[Metadata header]
+  offsetLevel0_, max_elements_, cur_element_count,
+  size_data_per_element_, label_offset_, offsetData_,
+  maxlevel_, enterpoint_node_, maxM_, maxM0_, M_,
+  mult_, ef_construction_
+  (raw POD types, no versioning)
+
+[Level-0 data block]
+  cur_element_count * size_data_per_element_ bytes
+  Each element = [links_level0 | vector_data | label]
+  Links and vectors are INTERLEAVED in same flat array
+
+[Higher-level link lists]
+  For each element:
+    uint size (0 if element has no higher levels)
+    link list data (variable length)
+```
+
+Vectors are **inline** with level-0 links — no separation.
+
+### Incremental Update
+
+- **Insert:** `addPoint()` up to pre-allocated `max_elements`. **Cannot grow beyond this limit** without full rebuild.
+- **Delete:** `markDelete()` sets a bit in byte 2 of level-0 link list memory: `*(ll_cur + 2) |= 0x01`. Soft delete only — **no graph repair**, edges to deleted nodes persist. Deleted nodes skipped during search.
+- **No incremental persistence.** `saveIndex()` / `loadIndex()` are full serialization. No WAL.
+
+### Crash Recovery
+
+None. Crash during `saveIndex()` corrupts the file. No checksums, no WAL.
+
+### Compaction
+
+None. Deleted elements waste space permanently until full rebuild.
+
+### Mmap Usage
+
+None. All memory allocated via `malloc`. Entire index must fit in RAM.
+
+### Assessment
+
+hnswlib is a reference algorithm implementation, not a storage engine. Its format is the simplest to understand but lacks every production feature: no WAL, no mmap, no incremental persistence, no compaction, fixed capacity.
+
+---
+
+## 4. Vald (Go)
+
+**Source:** `vdaas/vald` — `pkg/agent/core/ngt/service/`
+
+### Architecture
+
+Distributed vector database on Kubernetes, built on Yahoo Japan's **NGT** (Neighborhood Graph and Tree), **not HNSW**. Microservice architecture with agent pods.
+
+### Storage
+
+| Component | Purpose |
+|-----------|---------|
+| `kvs` (BidiMap) | Bidirectional UUID <-> internal object ID mapping |
+| `vqueue` | Virtual queue buffering insert/delete before indexing |
+| `core` | NGT index (vectors + graph) |
+| `fmap` | Failed operation tracker for recovery |
+
+### Insert/Delete
+
+- **Insert:** Validates no duplicate UUID, pushes to `vqueue`. Periodically, vectors extracted from queue, inserted into NGT core, UUID-to-ID mapping stored in KVS.
+- **Delete:** Also queued in `vqueue`, processed during periodic index creation. Removes both KVS entry and NGT core object.
+
+**Key pattern:** Mutations are buffered in a virtual queue and batch-applied during periodic index creation, reducing rebuild frequency.
+
+### Persistence
+
+- Serialization via **GOB encoding** (Go-native binary format)
+- **Copy-on-write save:** Write to temp directory, then atomically swap to production path
+- On startup, attempts loading from multiple fallback locations
+- Distributed resilience via Kubernetes replication
+
+### Mmap Usage
+
+None. Full in-memory index with periodic full serialization snapshots.
+
+---
+
+## 5. Chroma
+
+**Source:** `chroma-core/chroma` — `rust/index/src/`
+
+### Architecture
+
+Wraps hnswlib through a Rust `HnswIndexProvider` that manages index lifecycle. Recent versions moved from Python hnswlib bindings to Rust layer.
+
+### File Format
+
+Splits hnswlib's single file into **four binary files:**
+
+| File | Content |
+|------|---------|
+| `header.bin` | Index metadata (M, ef, dimensions, etc.) |
+| `data_level0.bin` | Level-0 data (vectors + level-0 links) |
+| `length.bin` | Element count/sizing info |
+| `link_lists.bin` | Higher-level link lists |
+
+Stored in S3 or local filesystem with optional encryption.
+
+### Insert/Delete
+
+Inherits hnswlib's mechanisms:
+- Insert adds to in-memory index
+- Delete uses `markDelete` (soft delete, no graph repair)
+- **No incremental persistence** — index must be fully flushed
+
+### Crash Recovery
+
+- **Flush:** Serialize in-memory state to four files, upload with priority, supports parallel uploads
+- **Load:** Double-checked locking to avoid redundant loads
+- **Fork:** Copy serialized data from source with new UUID
+- No WAL. Crash loses unflushed data.
+
+### Mmap Usage
+
+None. Full deserialization into memory.
+
+### Assessment
+
+Chroma's main contribution is splitting the single hnswlib file into four parallel-loadable files. Otherwise inherits all of hnswlib's limitations.
+
+---
+
+## Comparative Summary
+
+| Feature | Weaviate | Qdrant | hnswlib | Vald | Chroma |
+|---------|----------|--------|---------|------|--------|
+| Language | Go | Rust | C++ | Go | Rust |
+| Algorithm | HNSW | HNSW | HNSW | NGT | HNSW (via hnswlib) |
+| Graph persist | Commit log -> mmap flat | Mmap or RAM, flattened | Single binary blob | GOB snapshot | 4 binary files |
+| Vector persist | Separate store | Mmap chunks or RAM | Inline with level-0 | GOB snapshot | Inline with level-0 |
+| Delete | Tombstone + background edge repair | Soft delete + vacuum rebuild | Bit flag, no repair | Queue batch | Bit flag, no repair |
+| WAL | Typed binary commit log | Versioned WAL | None | None | None |
+| Crash recovery | Commit log replay | WAL replay with versions | None | COW snapshots | None |
+| Compaction | Condense + combine | Vacuum/merge/indexing optimizers | None | Full rebuild | None |
+| Mmap graph | Yes (after condensation) | Yes (optional backend) | No | No | No |
+| Mmap vectors | No (separate cache) | Yes (chunked) | No | No | No |
+| Dynamic capacity | Yes | Yes (segment growth) | No (fixed max_elements) | Yes | No (hnswlib limit) |
+
+---
+
+## Recommended Design for Haystack
+
+### Principles
+
+1. **Separate vectors from graph structure** — different access patterns, different file management
+2. **WAL-first** — all mutations hit the write-ahead log before anything else
+3. **Two-phase delete** — tombstone immediately, repair graph in background
+4. **Condense for mmap** — replay WAL into position-indexed flat files for mmap access
+5. **Grow incrementally** — no fixed max_elements; use chunked or segment-based expansion
+
+### File Layout
+
+```
+index_dir/
+  wal/
+    000001.wal          # append-only binary WAL segments
+    000002.wal
+  vectors.dat           # mmap'd flat vector storage
+  vectors.idx           # ID -> offset mapping for vectors
+  graph_l0.dat          # mmap'd level-0 connections (fixed-size blocks)
+  graph_upper.dat       # mmap'd upper-level connections
+  graph_upper.idx       # node ID -> offset into graph_upper.dat
+  meta.json             # index metadata (M, efConstruction, dim, entryPoint, maxLevel)
+  tombstones.bin        # active tombstone set
+```
+
+### File Formats — Detail
+
+#### WAL Records
+
+Same philosophy as Weaviate's commit log: typed binary records, append-only.
+
+```
+Record = TypeTag(1B) + Payload
+
+Types:
+  0x01  InsertVector     nodeID(8B) + level(2B) + vector(dim*4 B)
+  0x02  SetLinks         nodeID(8B) + level(2B) + count(2B) + targetIDs(8B * count)
+  0x03  SetEntryPoint    nodeID(8B) + maxLevel(2B)
+  0x04  AddTombstone     nodeID(8B)
+  0x05  RemoveTombstone  nodeID(8B)
+  0x06  DeleteNode       nodeID(8B)
+
+Each WAL segment = sequence of records + CRC32 per record for integrity
+```
+
+WAL segments are numbered sequentially. Fsync after each write (or batch of writes with configurable flush interval for throughput).
+
+#### vectors.dat (Mmap'd)
+
+Flat file of fixed-size vector blocks:
+
+```
+[Header: 32B]
+  magic(4B) + version(2B) + dimensions(4B) + count(8B) + reserved(14B)
+
+[Vector blocks]
+  Block N at offset = 32 + N * (dim * 4)
+  Each block = float32[dim]
+```
+
+Node IDs map directly to block offsets: `offset = headerSize + nodeID * dim * sizeof(float32)`. This gives O(1) random access. Deleted vectors leave gaps (reclaimed by compaction).
+
+For growth beyond initial allocation: **chunked mmap** (inspired by Qdrant). Each chunk is a fixed-size mmap region (e.g., 64MB). New chunks allocated as needed. A chunk table maps nodeID ranges to chunks.
+
+#### graph_l0.dat (Mmap'd)
+
+Fixed-size blocks for level-0 connections:
+
+```
+[Header: 16B]
+  maxM0(2B) + count(8B) + reserved(6B)
+
+[Connection blocks]
+  Block N at offset = 16 + N * blockSize
+  blockSize = 2B (numLinks) + maxM0 * 8B (neighborIDs) + 1B (flags: tombstoned, etc.)
+```
+
+O(1) access: `offset = headerSize + nodeID * blockSize`. Same dense layout as hnswlib level-0 but separated from vectors.
+
+#### graph_upper.dat + graph_upper.idx (Mmap'd)
+
+Upper levels are sparse (few nodes have level > 0), so use offset index:
+
+```
+graph_upper.idx:
+  [nodeID(8B) + offset(8B) + numLevels(2B)] * count
+  Sorted by nodeID for binary search
+
+graph_upper.dat:
+  Per node: [level1_links | level2_links | ...]
+  level_N_links = count(2B) + neighborIDs(8B * count)
+```
+
+### Insert Flow
+
+```
+1. Acquire insert lock (shared, allows concurrent inserts)
+2. Append InsertVector to WAL
+3. Write vector to vectors.dat (extend or fill gap from free list)
+4. Run HNSW neighbor search (in-memory graph + mmap reads)
+5. For each affected node, append SetLinks to WAL
+6. Update in-memory graph (level-0 and upper-level connections)
+7. Update graph_l0.dat and graph_upper.dat in-place (mmap writes)
+```
+
+**Batch insert optimization:** Buffer multiple inserts, write WAL records in batch, fsync once.
+
+### Delete Flow
+
+```
+Phase 1 — Mark (immediate, O(1)):
+  1. Append AddTombstone to WAL
+  2. Add nodeID to in-memory tombstone set
+  3. Set tombstone flag in graph_l0.dat block
+
+Phase 2 — Cleanup (background, periodic):
+  1. For each tombstoned node:
+     a. Collect its neighbors
+     b. For each neighbor, remove the tombstoned node from their link list
+     c. Reconnect orphaned neighbors to maintain graph quality
+        (find best replacement links via local search)
+     d. If tombstoned node was entry point, elect new entry point
+  2. Add nodeID to free list for vector slot reuse
+  3. Append RemoveTombstone + DeleteNode to WAL
+  4. Remove from in-memory tombstone set
+```
+
+Cleanup runs with configurable parallelism. Respects memory pressure. Can be interrupted and resumed.
+
+### Upsert Flow
+
+```
+1. If nodeID exists and not tombstoned:
+   a. Update vector in vectors.dat (overwrite in-place)
+   b. Append InsertVector to WAL (marks as update)
+   c. If vector changed significantly, re-link:
+      - Run HNSW search with new vector
+      - Update connections for affected nodes
+2. If nodeID doesn't exist or is tombstoned:
+   a. Remove tombstone if present
+   b. Insert as new (standard insert flow)
+```
+
+### Crash Recovery
+
+```
+On startup:
+  1. Read meta.json for index parameters
+  2. Mmap vectors.dat, graph_l0.dat, graph_upper.dat (read-only initially)
+  3. Load tombstones.bin into memory
+  4. Replay WAL from last checkpoint:
+     - For each record, apply to in-memory state
+     - Verify against mmap'd files (skip if already applied)
+  5. Re-mmap files as read-write
+  6. Resume normal operation
+```
+
+**Checkpoint mechanism:** After condensation/compaction, record the WAL offset in meta.json. On recovery, only replay from checkpoint forward.
+
+**CRC32 per WAL record** detects partial writes from crashes. Truncate WAL at first corrupted record.
+
+### Compaction Strategy
+
+Inspired by Weaviate's condense + combine, simplified:
+
+**Level 1 — WAL Condensation (frequent):**
+```
+1. Snapshot current WAL position
+2. Replay WAL records into mmap files (apply net state)
+3. Fsync all mmap files
+4. Update checkpoint in meta.json
+5. Delete WAL segments before checkpoint
+```
+
+**Level 2 — Space Reclamation (periodic):**
+```
+Trigger: free_slots / total_slots > 20% (configurable)
+1. Create new vectors.dat, graph_l0.dat, graph_upper.dat
+2. Copy live (non-tombstoned) nodes with compacted IDs
+3. Build ID remapping table (old ID -> new ID)
+4. Fsync new files
+5. Atomic swap (rename) new files over old
+6. Delete old files
+```
+
+This is the most expensive operation. Run during low-traffic periods. Use copy-on-write during compaction so reads continue from old files.
+
+**Level 3 — Upper-level defrag (rare):**
+```
+Rewrite graph_upper.dat + graph_upper.idx to remove gaps from deleted nodes.
+Much cheaper than full compaction since upper levels are small.
+```
+
+### Mmap Strategy
+
+| File | Access pattern | Mmap advice | Writability |
+|------|---------------|-------------|-------------|
+| vectors.dat | Random (search), sequential (scan) | `MADV_RANDOM` | Read-write |
+| graph_l0.dat | Random (graph traversal) | `MADV_RANDOM` | Read-write |
+| graph_upper.dat | Random, infrequent | `MADV_RANDOM` | Read-write |
+| WAL segments | Sequential append | `MADV_SEQUENTIAL` | Append-only |
+
+**Growth strategy:** Use Go's `syscall.Mmap` or `golang.org/x/exp/mmap`. For growth:
+- Pre-allocate with headroom (e.g., 2x current size)
+- When full, unmap, truncate file to new size (ftruncate), remap
+- Or use chunked approach: multiple mmap regions of fixed size
+
+**Page cache management:** For large indexes exceeding RAM, the OS page cache handles eviction. `MADV_DONTNEED` can be used to hint that compaction source pages are no longer needed after copying.
+
+### Concurrency
+
+```
+Locks:
+  insertMu    sync.RWMutex   // shared for concurrent inserts
+  deleteMu    sync.Mutex     // exclusive for tombstone cleanup
+  compactMu   sync.RWMutex   // write-lock during file swap, read-lock for normal ops
+```
+
+Insert and search can proceed concurrently. Tombstone cleanup acquires deleteMu to prevent concurrent cleanups. Compaction file swap briefly acquires compactMu write-lock.
+
+### What We Borrow From Each Project
+
+| Source | Borrowed idea |
+|--------|--------------|
+| **Weaviate** | Typed binary commit log, two-phase tombstone delete with background edge repair, condense + combine compaction pipeline, lock discipline pattern |
+| **Qdrant** | Separate mutable/immutable storage concepts, chunked mmap for growth, mmap advice configuration, version-tracked WAL replay, three-tier optimization |
+| **hnswlib** | Fixed-size level-0 block layout (O(1) offset calculation), interleaved link + metadata format as baseline reference |
+| **Vald** | Virtual queue pattern for batch mutations, COW directory swap for atomic persistence, BidiMap for external-to-internal ID mapping |
+| **Chroma** | Splitting index into multiple files for parallel I/O, provider/cache lifecycle management |
+
+### Implementation Priority
+
+1. **Phase 1 — WAL + in-memory graph** (foundation)
+   - Binary WAL with typed records and CRC32
+   - In-memory HNSW graph (current implementation)
+   - WAL replay on startup
+
+2. **Phase 2 — Mmap vector storage**
+   - vectors.dat with O(1) access by nodeID
+   - Chunked growth support
+
+3. **Phase 3 — Mmap graph storage**
+   - graph_l0.dat with fixed-size blocks
+   - graph_upper.dat with offset index
+   - Transition from fully in-memory to mmap-backed
+
+4. **Phase 4 — Compaction**
+   - WAL condensation (level 1)
+   - Space reclamation (level 2)
+
+5. **Phase 5 — Production hardening**
+   - Concurrent insert/delete/search stress testing
+   - Crash recovery fuzz testing
+   - Memory pressure handling

--- a/docs/research/storage-backend-research-1.md
+++ b/docs/research/storage-backend-research-1.md
@@ -1,0 +1,374 @@
+# HNSW 向量索引存储后端选型研究
+
+> **日期**: 2026-04-17
+> **关联**: HAY-007 PebbleStore 构建性能优化
+> **状态**: 调研完成
+
+---
+
+## 1. 问题陈述
+
+Haystack 的 HNSW 向量索引在构建阶段是**读密集型**工作负载：
+
+| 指标 | 数值 |
+|------|------|
+| 每次 Insert 平均读向量 | ~3,500 次 |
+| 每次 Insert 平均写操作 | ~37 次 |
+| **读写比** | **86:1** |
+| 50K 向量总随机读 | 1.6 亿次 |
+| 50K 向量总写入 | 186 万次 |
+| 单条向量大小 (128d float32) | 512 bytes |
+| 单条向量大小 (768d float32) | 3,072 bytes |
+
+当前 PebbleStore（LSM-tree）是**写优化**结构，与 HNSW 构建的读密集模式严重不匹配：
+
+| 后端 | 50K 耗时 | ops/sec | 相对速度 |
+|------|----------|---------|----------|
+| MemStore | 59s (1.18ms/op) | 847 | **1x (基准)** |
+| PebbleStore | 18min (21.85ms/op) | 46 | **18.5x 慢** |
+
+---
+
+## 2. 当前 Pebble 配置分析
+
+```
+internal/core/pebble/db.go:
+  Cache:                    调用方传入 cacheSize
+  BlockSize:                32 KB
+  FilterPolicy:             Bloom(10)
+  MemTableSize:             4 MB
+  MaxOpenFiles:             8192
+  L0CompactionThreshold:    12
+  MaxConcurrentCompactions: 2
+```
+
+```
+internal/core/vectorindex/store.go:
+  LRU cache 容量:            10,000 条向量
+  GetVectorRef():           零拷贝读取
+```
+
+**瓶颈诊断**：
+- 32KB BlockSize 意味着读一个 512B 向量要解压一整个 32KB block
+- LRU cache 10K 条在 50K 数据集下命中率仅约 20%
+- LSM 多层查找：Bloom filter → L0 → L1 → ... 每次随机读可能触发多次磁盘 I/O
+- 每次 Get 返回的 value 需要 Pebble 内部拷贝（即使 GetVectorRef 做了应用层零拷贝）
+
+---
+
+## 3. 方案详细评估
+
+### 方案 A：MemStore 构建 + Pebble 持久化（混合模式）
+
+**架构**：
+```
+[构建阶段]  Insert → MemNodeStore (全内存)
+[持久化]    构建完成 → 批量 dump 到 Pebble
+[启动]      Pebble scan → 加载到 MemNodeStore
+[搜索]      查询 → MemNodeStore (内存)
+```
+
+**性能预期**：
+
+| 指标 | 估算 |
+|------|------|
+| 50K 构建耗时 | ~59s（等同 MemStore） |
+| 持久化耗时 (50K) | ~2-5s（顺序批量写入） |
+| 启动加载耗时 (50K) | ~3-8s（Pebble scan + 反序列化） |
+| 搜索延迟 | <1ms（纯内存） |
+
+**内存占用**：
+
+| 规模 | 128d | 768d |
+|------|------|------|
+| 10K | ~9 MB | ~35 MB |
+| 50K | ~44 MB | ~175 MB |
+| 100K | ~88 MB | ~350 MB |
+| 500K | ~440 MB | ~1.75 GB |
+
+> 含向量 + neighbors + metadata 开销，约为纯向量大小的 1.5-1.7x
+
+**优点**：
+- 构建速度等同纯内存，18.5x 提升
+- 实现简单：复用现有 MemNodeStore + PebbleNodeStore
+- 搜索延迟最优
+- 渐进式实现，不破坏现有接口
+- Pebble 批量写入非常高效（顺序写，一次 fsync）
+
+**缺点**：
+- 内存占用与数据规模线性增长，500K x 768d 需要 ~1.75 GB
+- 启动时需要全量加载，冷启动较慢
+- 构建过程中宕机丢失未持久化数据（可通过 checkpoint 缓解）
+- 增量更新（单条 upsert）需要特殊处理
+
+**实现复杂度**：**低** (~200-300 行代码)
+- 需要实现 `MemNodeStore.DumpTo(PebbleNodeStore)` 方法
+- 需要实现 `PebbleNodeStore.LoadInto(MemNodeStore)` 方法
+- 修改 HNSWIndex 初始化逻辑，支持两阶段模式
+- 已有 MemNodeStore 和 PebbleNodeStore 完整实现
+
+---
+
+### 方案 B：mmap 文件存储
+
+**架构**：
+```
+vectors.bin:   [vec_0: 512B][vec_1: 512B]...[vec_N: 512B]  ← 固定大小记录
+neighbors.bin: [node_0_layer_0][node_0_layer_1]...          ← 变长，需索引
+meta.bin:      entry point, levels, mappings                ← 小文件
+```
+
+向量按 ID 偏移访问：`offset = id * dim * 4`，O(1) 随机读。
+
+**性能预期**：
+
+| 指标 | 估算 |
+|------|------|
+| 热读延迟 | <1 us（等同内存指针访问） |
+| 冷读延迟 | ~10-100 us（page fault） |
+| 50K 构建耗时 | ~60-70s（接近 MemStore，page cache 覆盖） |
+| 写入延迟 | 需 munmap/mmap 周期扩展文件 |
+
+**参考实现**：Weaviate 使用 mmap 存储 HNSW 图和向量数据，读延迟 <1us。
+
+**优点**：
+- 随机读性能理论最优
+- OS page cache 自动管理热数据
+- 内存占用由 OS 管理，不占 Go heap（无 GC 压力）
+- 500K 向量在 page cache 热时等同内存访问
+
+**缺点**：
+- **实现复杂度高**：固定大小向量尚可，变长 neighbors 需要复杂索引
+- **并发写入困难**：扩展文件需要 munmap→truncate→mmap，期间所有读失效
+- **跨平台差异**：Windows 的 mmap 行为不同（不能 truncate mmap'd 文件）
+- **崩溃恢复复杂**：无 ACID 保证，需自行实现 WAL 或 checkpoint
+- **删除/upsert 复杂**：需要空洞管理或紧凑化
+- golang.org/x/exp/mmap 只支持只读，写入必须用 syscall
+
+**实现复杂度**：**高** (~1000-1500 行代码)
+- 向量文件 + neighbors 文件 + metadata 文件
+- 空间分配器（处理删除产生的空洞）
+- 跨平台 mmap 封装（build tags for linux/darwin/windows）
+- 崩溃恢复机制
+- 文件增长策略
+
+---
+
+### 方案 C：bbolt (B+tree)
+
+**架构**：单文件 B+tree，mmap 读取，copy-on-write 写入。
+
+```go
+db, _ := bbolt.Open("index.db", 0600, nil)
+db.View(func(tx *bbolt.Tx) error {
+    b := tx.Bucket([]byte("vectors"))
+    vec := b.Get(uint64ToBytes(id))  // mmap 直接读取
+    return nil
+})
+```
+
+**性能预期**：
+
+| 指标 | 估算 |
+|------|------|
+| 热读延迟 | 1-5 us（mmap B+tree 查找） |
+| 冷读延迟 | 50-200 us |
+| 写入延迟 | 50-200 us/tx（含 fsync） |
+| 50K 构建耗时 | ~90-150s（估算，batch 写入 + mmap 读） |
+
+**优点**：
+- B+tree 读优化，比 LSM 随机读快
+- 单文件存储，部署简单
+- mmap 读取，OS page cache 自动管理
+- 成熟稳定（etcd 核心组件）
+- API 简洁，事务模型清晰
+
+**缺点**：
+- **单写者模型**：写事务互斥，虽然 86:1 比例可接受但构建时仍有写
+- **写入较慢**：每个写事务 fsync，批量写需要大事务
+- B+tree 开销比 mmap 直接偏移访问大（需要树遍历）
+- 文件只增不缩（需要 Compact 回收空间）
+- 不支持压缩
+
+**实现复杂度**：**中** (~400-500 行代码)
+- 实现新的 BboltNodeStore
+- Bucket 设计（vectors / neighbors / metadata / mappings）
+- 读事务池化（避免每次分配）
+- 写事务批量化
+
+---
+
+### 方案 D：modernc.org/sqlite（纯 Go SQLite）
+
+**架构**：纯 Go 转译的 SQLite，B-tree 存储，WAL 模式。
+
+```sql
+CREATE TABLE vectors (id INTEGER PRIMARY KEY, data BLOB);
+CREATE TABLE neighbors (node_id INTEGER, layer INTEGER, neighbors BLOB, PRIMARY KEY(node_id, layer));
+```
+
+**性能预期**：
+
+| 指标 | 估算 |
+|------|------|
+| 热读延迟 | 5-15 us（SQL 解析 + B-tree 查找） |
+| 冷读延迟 | 100-500 us |
+| 50K 构建耗时 | ~150-300s（估算） |
+
+**优点**：
+- SQL 查询灵活，方便调试
+- WAL 模式支持并发读写
+- 成熟的 ACID 保证
+- 单文件部署
+
+**缺点**：
+- **纯 Go 版比 CGo 慢 2-4x**：c2go 转译的代码无法享受 Go 编译器优化
+- SQL 解析开销：KV 场景下 SQL 层是纯开销
+- 内存分配多（C-to-Go 内存模型转换）
+- 对 KV 场景而言过于重量级
+- 社区反馈性能波动较大
+
+**实现复杂度**：**中** (~400-500 行代码)
+- Schema 设计 + prepared statements
+- 事务管理
+- Blob 编解码
+
+---
+
+### 方案 E：Pebble 优化（当前架构调优）
+
+**可调参数**：
+
+| 参数 | 当前值 | 建议值 | 影响 |
+|------|--------|--------|------|
+| Cache | 调用方决定 | 256-512 MB | 全数据集缓存 |
+| BlockSize | 32 KB | 4 KB | 减少读放大 (32KB→4KB = 8x) |
+| Compression | Snappy (默认) | NoCompression | 省去解压 CPU |
+| LRU cache (应用层) | 10,000 | 50,000-100,000 | 直接命中率翻倍 |
+| BloomFilter | 10 bits | 保持 | 已足够 |
+
+**性能预期（调优后）**：
+
+| 场景 | 预期延迟 |
+|------|----------|
+| 全数据集缓存热 | 1-3 us/read |
+| 50K 构建耗时（预热后） | ~120-180s（2-3x 提升，从 18min 降到 ~3min） |
+| 首次冷启动 | 仍然 18min |
+
+**关键问题**：构建阶段是逐步插入新向量，cache 从冷到热是渐进的。前期数据少时 cache 命中率高，后期数据增长超过 cache 容量后性能下降。**无法根本解决构建阶段的性能问题**。
+
+**优点**：
+- 改动最小，只调参数
+- 搜索阶段（cache 热）性能接近内存
+- 不需要新的 Store 实现
+
+**缺点**：
+- 构建阶段改善有限（3-5x 提升 vs 方案 A 的 18.5x）
+- 大规模场景 cache 内存开销与方案 A 相当，但性能更差
+- BlockSize 修改需要重建数据库
+- 不解决根本的架构不匹配问题
+
+**实现复杂度**：**极低** (~20-50 行代码)
+
+---
+
+### 方案 F：BadgerDB（KV 分离 LSM）
+
+**架构**：Key-value 分离，key 在 LSM-tree，value 在 append-only vlog。
+
+**评估**：
+- 512B 向量低于 BadgerDB v4 的 ValueThreshold (1MB)，会被 **inline 存储在 LSM 中**
+- 等同于另一个 LSM-tree，随机读性能与 Pebble 相当（3-10 us 热读）
+- **无优势**，额外增加 vlog GC 的运维复杂度
+- 社区活跃度下降，Pebble 是更好的 LSM 选择
+
+**结论**：**不推荐**，对本场景无收益。
+
+---
+
+## 4. 方案对比总表
+
+| 维度 | A: 混合模式 | B: mmap | C: bbolt | D: SQLite | E: Pebble 调优 |
+|------|-------------|---------|----------|-----------|----------------|
+| **构建速度** | ★★★★★ ~59s | ★★★★★ ~65s | ★★★☆☆ ~120s | ★★☆☆☆ ~200s | ★★★☆☆ ~150s |
+| **搜索延迟** | ★★★★★ <1ms | ★★★★★ <1ms | ★★★★☆ <2ms | ★★★☆☆ <5ms | ★★★★☆ <2ms |
+| **内存占用** | ★★☆☆☆ 全量 | ★★★★☆ OS 管理 | ★★★★☆ OS 管理 | ★★★☆☆ 中等 | ★★★☆☆ cache 依赖 |
+| **持久化安全** | ★★★★☆ Pebble | ★★☆☆☆ 需自建 | ★★★★★ ACID | ★★★★★ ACID | ★★★★★ Pebble |
+| **实现复杂度** | ★★★★★ 低 | ★★☆☆☆ 高 | ★★★☆☆ 中 | ★★★☆☆ 中 | ★★★★★ 极低 |
+| **跨平台** | ★★★★★ | ★★★☆☆ | ★★★★★ | ★★★★★ | ★★★★★ |
+| **500K 可行性** | ★★★☆☆ ~1.7GB | ★★★★★ | ★★★★☆ | ★★★★☆ | ★★★☆☆ cache 大 |
+| **增量更新** | ★★★☆☆ 需特殊处理 | ★★☆☆☆ 复杂 | ★★★★☆ 自然支持 | ★★★★☆ 自然支持 | ★★★★★ 自然支持 |
+
+---
+
+## 5. 推荐排序
+
+### 第一推荐：方案 A — MemStore 构建 + Pebble 持久化
+
+**理由**：
+1. **性能最优**：构建速度直接等同 MemStore（18.5x 提升），这是理论上限
+2. **实现最简**：200-300 行代码，复用现有 MemNodeStore + PebbleNodeStore
+3. **风险最低**：两个 Store 实现已经过充分测试（HAY-006 完整覆盖）
+4. **渐进式**：不破坏现有 NodeStore 接口，可与当前代码并存
+
+**适用规模**：10K-100K 向量（128d），10K-50K 向量（768d）。超过此规模内存成为瓶颈。
+
+**增量更新策略**：
+- 少量 upsert（<100 条）：直接操作 MemStore（已在内存中）
+- 大批量更新：重建索引（HNSW 大批量更新本身效率低）
+
+### 第二推荐：方案 A + E 组合 — 混合模式 + Pebble 参数调优
+
+**理由**：
+- 方案 A 负责构建阶段性能
+- Pebble 参数调优（BlockSize 4KB、NoCompression）优化持久化层效率
+- 两者互补，无冲突
+
+### 第三推荐：方案 B — mmap（长期演进方向）
+
+**理由**：
+- 如果 500K x 768d 规模成为刚需，mmap 是唯一不需要全量内存的高性能方案
+- 可作为 v2 架构，在方案 A 验证后再启动
+- 参考 Weaviate 的成熟实践
+
+### 不推荐：方案 C (bbolt)、方案 D (SQLite)、方案 F (BadgerDB)
+
+**理由**：
+- bbolt 和 SQLite 比 Pebble 快但比 MemStore 慢很多，属于"中间地带"——付出迁移成本却拿不到最优性能
+- BadgerDB 对此场景无收益
+- 如果要换存储引擎，不如直接跳到 mmap（方案 B）获取根本性提升
+
+---
+
+## 6. 实施路线图
+
+```
+Phase 1 (HAY-007): 方案 A — MemStore + Pebble 混合模式
+├── 实现 DumpTo / LoadFrom 方法
+├── 修改 HNSWIndex 支持双阶段模式
+├── 基准测试验证 50K 性能
+└── 预期: 构建 18min → 60s
+
+Phase 1.5: 方案 E — Pebble 参数调优
+├── BlockSize 32KB → 4KB
+├── 禁用向量数据压缩
+├── 优化应用层 LRU cache 大小
+└── 预期: 持久化/加载 2-3x 提升
+
+Phase 2 (未来): 方案 B — mmap 存储（如需 500K+ 规模）
+├── 固定大小向量文件 + mmap
+├── 替换 Pebble 作为向量存储层
+├── 保留 Pebble 存 metadata/mappings
+└── 预期: 内存降至 OS page cache 管理
+```
+
+---
+
+## 7. 关键风险与缓解
+
+| 风险 | 影响 | 缓解 |
+|------|------|------|
+| 方案 A 内存不足 (500K x 768d = 1.75GB) | 无法在小内存机器运行 | 设置内存上限，超限时回退到 Pebble 直接构建 |
+| 构建中宕机丢失数据 | 需要重新构建全部索引 | 每 N 条 checkpoint 一次到 Pebble |
+| MemStore → Pebble dump 期间阻塞搜索 | 搜索不可用 | dump 在后台执行，搜索仍走 MemStore |
+| 冷启动加载时间随数据增长 | 大数据集启动慢 | 并行加载 + 进度反馈；考虑 mmap 作为长期方案 |

--- a/docs/research/storage-backend-research-2.md
+++ b/docs/research/storage-backend-research-2.md
@@ -1,0 +1,247 @@
+# HNSW 存储后端选型调研
+
+> Date: 2026-04-17 | Context: HAY-007 PebbleStore build performance
+
+## 1. 问题本质
+
+HNSW 构建的 I/O 模式极其特殊：**随机点查为主，写极少**。
+
+| 指标 | 数值 |
+|------|------|
+| 50K 向量总读次数 | ~1.6 亿次 |
+| 每次 insert 平均读 | 3,500 次向量 |
+| 每次 insert 平均写 | 37 次 |
+| 读写比 | **86:1** |
+| 单次读取大小 | 512 bytes (128d × 4B) |
+| MemStore 耗时 | 59s (1.18ms/op) |
+| PebbleStore 耗时 | 18min (21.85ms/op) |
+| 性能差距 | **18.5x** |
+
+核心瓶颈：Pebble 的 LSM-tree 为写优化设计，每次随机读需要遍历 memtable + 多级 SST，对 HNSW 的随机点查 pattern 天然不利。
+
+## 2. 业界 HNSW 实现的存储方案
+
+### hnswlib (原始实现, C++)
+- **方案**: 单一连续内存块，向量按 ID 顺序排列
+- **持久化**: 整体 `save_index()` / `load_index()` 写入/读取单个二进制文件
+- **特点**: 纯内存操作，O(1) 向量访问（基地址 + offset），加载时整块读入内存
+- **结论**: 全量内存，不做增量持久化
+
+### Weaviate (Go)
+- **方案**: 自研 mmap 文件格式
+  - 向量存储：固定大小记录的 flat file，mmap 映射，按 ID 直接偏移寻址
+  - 图连接：commitlog + 内存中的 slice-of-slices
+  - HNSW 层级数据全部在内存
+- **持久化**: commitlog (WAL) 用于 crash recovery，定期 compaction
+- **特点**: 向量通过 mmap 实现 O(1) 访问，内存由 OS page cache 管理
+- **启动**: mmap 映射即可，无需反序列化
+
+### Milvus (Go + C++)
+- **方案**: Segment-based 架构
+  - Growing segment（写入缓冲）在内存
+  - Sealed segment（只读）flush 到对象存储/本地文件
+  - 向量数据以列式存储，连续排列
+- **特点**: 读写分离，sealed segment 可 mmap 加载
+
+### Qdrant (Rust)
+- **方案**: 自研存储
+  - 向量: mmap'd flat file，固定大小记录
+  - Graph: mmap'd flat file
+  - Payload: RocksDB (仅用于元数据过滤，不用于向量)
+- **特点**: 热数据内存，冷数据 mmap，向量绝不经过 KV store
+
+### Chroma / LanceDB
+- **方案**: 基于 Arrow/Lance 列式格式存储向量
+- **特点**: 批量加载高效，但非 HNSW 的主流选择
+
+### 关键共识
+
+> **没有一个成熟的向量数据库用通用 KV store (LSM-tree 或 B+tree) 存储向量数据。**
+>
+> 所有高性能实现都选择：连续内存/文件 + O(1) offset 寻址。
+
+## 3. 候选方案评估
+
+### 方案 A：MemStore + Snapshot（推荐 #1）
+
+**原理**: 构建和搜索全在内存，后台定期序列化到文件。
+
+| 维度 | 评价 |
+|------|------|
+| 随机点查 | **最优** — 直接 map 查找，~50ns |
+| 构建性能 | **最优** — 与当前 MemStore 一致 (59s/50K) |
+| 内存占用 | 50K×128d ≈ 25MB 向量 + 图结构 ≈ **40-50MB** |
+| 500K×768d ≈ | **~1.5GB 向量 + 图 ≈ 2GB** |
+| 持久化 | snapshot 文件，gob/binary 序列化 |
+| 启动时间 | 反序列化加载，50K ≈ <1s, 500K ≈ 5-10s |
+| 增量更新 | 原生支持（内存 map 操作） |
+| 实现复杂度 | **低** — 新增 ~200 行 snapshot 逻辑 |
+| 风险 | crash 时丢失最近写入（可接受 WAL 缓解） |
+
+**内存占用分析**（目标规模）:
+
+| 规模 | 维度 | 向量内存 | 图+元数据 | 总计 |
+|------|------|----------|-----------|------|
+| 10K | 128 | 5 MB | 5 MB | ~10 MB |
+| 50K | 128 | 25 MB | 15 MB | ~40 MB |
+| 100K | 384 | 150 MB | 40 MB | ~190 MB |
+| 500K | 768 | 1.5 GB | 200 MB | ~1.7 GB |
+
+对于代码搜索工具，10K-100K 是最常见规模，内存完全可接受。500K×768d 的 1.7GB 在现代开发机上也合理。
+
+### 方案 B：mmap 自定义文件格式（推荐 #2）
+
+**原理**: 向量连续存于 flat file，mmap 映射，O(1) 偏移寻址。图结构单独文件。
+
+```
+vectors.bin:  [header][vec_0: 512B][vec_1: 512B]...[vec_N]
+graph.bin:    [header][node_0: level + neighbors per layer]...
+meta.bin:     [entry_point][doc_id mappings]...
+```
+
+| 维度 | 评价 |
+|------|------|
+| 随机点查 | **极优** — mmap offset, ~100-200ns (page cache 命中) |
+| 构建性能 | 接近 MemStore（热数据在 page cache） |
+| 内存占用 | OS 管理 page cache，实际驻留按需，低于全内存方案 |
+| 持久化 | 天然持久，写即落盘 |
+| 启动时间 | **最优** — mmap 映射 <10ms，无需反序列化 |
+| 增量更新 | 中等 — 向量可原地更新（固定大小），图结构需要处理变长 neighbor list |
+| 实现复杂度 | **中高** — ~500-800 行，需处理文件增长、delete 空洞、graph 变长记录 |
+| 风险 | 跨平台 mmap 行为差异；变长 graph 记录需要设计 |
+
+**graph 变长问题解法**: 按 Mmax0 预分配固定大小 slot（每个 node = 4 + 32×8 + 16×8×maxLayer ≈ 640B），浪费一些空间换取 O(1) 寻址。
+
+### 方案 C：bbolt (B+tree)
+
+| 维度 | 评价 |
+|------|------|
+| 随机点查 | **中** — B+tree 读优于 LSM，但仍有 page 遍历开销，~1-5μs |
+| 构建性能 | 预估 3-5x 慢于 MemStore（好于 Pebble 的 18.5x） |
+| 内存占用 | 低 — mmap 读，OS page cache 管理 |
+| 持久化 | 原生 |
+| 启动时间 | 快 — mmap 打开文件即可 |
+| 增量更新 | 原生支持（事务） |
+| 实现复杂度 | **低** — 接口适配 ~300 行 |
+| 风险 | 写性能差（单 writer 锁）；1.6亿次点查仍有显著开销 |
+
+**数据**: bbolt 随机读 ~1-5μs/op（page cache 热时），50K 构建预估 3-5 分钟。比 Pebble 好但远逊内存方案。
+
+### 方案 D：Badger (LSM, value 分离)
+
+| 维度 | 评价 |
+|------|------|
+| 随机点查 | **中** — value log 直接 seek 读，~2-10μs，优于 Pebble 的多级查找 |
+| 构建性能 | 预估 5-8x 慢于 MemStore |
+| 内存占用 | 低-中 — key 在内存，value 在 vlog |
+| 持久化 | 原生 |
+| 启动时间 | 中 — 需要加载 key 索引 |
+| 增量更新 | 原生支持 |
+| 实现复杂度 | **低** — 接口适配 ~300 行 |
+| 风险 | GC 带来的写放大；仍是通用 KV 的开销 |
+
+Badger 的 value 分离设计（WiscKey 论文）对大 value 随机读有帮助，但对 HNSW 的亿级点查仍不够快。
+
+### 方案 E：自研 flat file + index
+
+| 维度 | 评价 |
+|------|------|
+| 随机点查 | **最优** — 等同方案 B |
+| 构建性能 | **最优** |
+| 内存占用 | 可控 |
+| 持久化 | 自行实现 |
+| 启动时间 | 取决于实现 |
+| 增量更新 | 需要自行实现所有逻辑 |
+| 实现复杂度 | **极高** — 1000+ 行，需实现 crash recovery、compaction、并发控制 |
+| 风险 | 大量 edge case；实质上在写一个专用数据库 |
+
+除非 mmap 方案无法满足需求，否则不建议走这条路。方案 B 的 mmap 已覆盖其核心优势。
+
+### 方案 F：保持 Pebble + 大 cache
+
+| 维度 | 评价 |
+|------|------|
+| 随机点查 | 取决于 cache 命中率 |
+| 构建性能 | cache 全命中 → 接近 MemStore；cache miss → 回退到 21ms/op |
+| 内存占用 | cache 50K 向量 ≈ 25MB（可接受），但此时与方案 A 等价 |
+| 持久化 | 原生 |
+| 启动时间 | 中 — 需要预热 cache |
+| 增量更新 | 原生支持 |
+| 实现复杂度 | **极低** — 调大 cache size |
+| 风险 | 如果 cache 住所有向量，Pebble 只是个昂贵的持久化层 |
+
+**关键洞察**: 如果 cache 足够大到覆盖所有向量（构建时 100% 命中率所需），那么 Pebble 退化为纯粹的持久化写入层。此时不如直接用方案 A（MemStore + Snapshot），更简单且无 Pebble 的 compaction/WAL 开销。
+
+## 4. 对比总结
+
+| 方案 | 构建性能 | 随机读延迟 | 内存效率 | 启动速度 | 增量更新 | 实现复杂度 | 综合评分 |
+|------|----------|-----------|----------|----------|---------|-----------|---------|
+| **A: MemStore+Snapshot** | ★★★★★ | ★★★★★ | ★★★☆☆ | ★★★★☆ | ★★★★★ | ★★★★★ | **#1** |
+| **B: mmap flat file** | ★★★★★ | ★★★★☆ | ★★★★★ | ★★★★★ | ★★★☆☆ | ★★★☆☆ | **#2** |
+| C: bbolt | ★★★☆☆ | ★★★☆☆ | ★★★★☆ | ★★★★☆ | ★★★★☆ | ★★★★☆ | #4 |
+| D: Badger | ★★☆☆☆ | ★★★☆☆ | ★★★★☆ | ★★★☆☆ | ★★★★☆ | ★★★★☆ | #5 |
+| E: 自研 flat file | ★★★★★ | ★★★★★ | ★★★★★ | ★★★★★ | ★★★☆☆ | ★☆☆☆☆ | #3 |
+| F: Pebble+大cache | ★★★★☆ | ★★★★☆ | ★★★☆☆ | ★★★☆☆ | ★★★★★ | ★★★★★ | #6 |
+
+## 5. 推荐路径
+
+### 阶段 1（立即）：方案 A — MemStore + Snapshot
+
+**理由**:
+1. **最小改动，最大收益** — 18.5x 性能提升，~200 行代码
+2. **已验证** — MemStore 已经是生产质量代码，只需加持久化
+3. **内存可接受** — 目标规模 10K-100K，内存 10-190MB
+4. 所有成熟向量数据库的 HNSW 实现本质上都是内存方案
+
+**实现计划**:
+```go
+type SnapshotStore struct {
+    mem       *MemNodeStore
+    path      string        // snapshot 文件路径
+    dirty     atomic.Bool   // 有未持久化的变更
+    interval  time.Duration // snapshot 间隔
+}
+
+// 启动: 从文件加载 → MemNodeStore
+// 运行: 所有读写走 MemNodeStore
+// 持久化: 后台 goroutine 定期 binary 序列化到文件
+// 关闭: 最终 snapshot + close
+```
+
+Snapshot 格式（binary，非 gob —— 更快更紧凑）:
+```
+[magic: 4B][version: 4B][entryID: 8B][maxLayer: 4B][nodeCount: 4B]
+[vectors section: id + dim + float32 data...]
+[levels section: id + level...]
+[norms section: id + float32...]
+[neighbors section: id + layer + count + neighbor_ids...]
+[mappings section: docId + nodeId...]
+[checksum: 32B SHA-256]
+```
+
+### 阶段 2（如果需要）：方案 B — mmap 迁移
+
+仅在以下情况考虑：
+- 500K+ 向量场景内存不足
+- 启动时间要求 <100ms
+- 需要多进程共享索引
+
+## 6. 快速 ROI 分析
+
+| | 现状 (Pebble) | 方案 A (MemStore+Snapshot) | 提升 |
+|--|--------------|--------------------------|------|
+| 50K 构建 | 18 min | ~59s | **18x** |
+| 100K 构建 | ~40 min (预估) | ~3 min | **13x** |
+| 搜索延迟 | ~2ms (cache miss 更高) | ~0.1ms | **20x** |
+| 启动时间 | ~1s (打开 DB) | ~1-2s (加载 snapshot) | 持平 |
+| 内存 (50K) | 88MB + Pebble overhead | ~40MB | **更低** |
+| 磁盘 (50K) | 36MB (Pebble SST) | ~30MB (binary snapshot) | 持平 |
+| 代码变更 | 0 | ~200-300 行 | 极低 |
+
+## 7. 结论
+
+**用通用 KV store 存储 HNSW 向量是一个架构错配。** 业界共识明确：HNSW 需要 O(1) 随机访问，应该用内存或 mmap flat file，不应用 LSM-tree 或 B+tree。
+
+对于 Haystack 的规模（10K-500K 向量），**MemStore + Snapshot 是性价比最高的方案**：实现简单、性能最优、已有成熟代码基础。mmap 方案作为未来演进路径保留。
+
+不建议在 KV store 选型上花更多时间（bbolt/Badger/Pebble 调优），因为这是在错误的方向上优化。

--- a/docs/research/storage-backend-research-3.md
+++ b/docs/research/storage-backend-research-3.md
@@ -1,0 +1,182 @@
+# Storage Backend Research for HNSW Vector Index (HAY-007)
+
+> Date: 2026-04-17
+> Context: Haystack HNSW index currently uses Pebble; random point-read performance is the bottleneck (read:write = 86:1, ~3500 reads/insert, 1.6 亿 total reads for 50K build)
+
+## Workload Profile
+
+| Metric | Value |
+|---|---|
+| Dataset | 50K vectors, 128-dim |
+| Value size | 512 B (128-dim) – 3072 B (768-dim) |
+| Reads/insert | ~3,500 (neighbor traversal) |
+| Writes/insert | ~37 |
+| Total reads (50K build) | ~160,000,000 |
+| Target read latency | < 1 μs (memory), < 10 μs (disk+cache) |
+| Total dataset size | 50K × 3 KB ≈ 150 MB |
+
+## Candidate Comparison
+
+| | Pebble | bbolt | Badger v4 | BuntDB | NutsDB | Custom mmap |
+|---|---|---|---|---|---|---|
+| **Engine** | LSM-tree | B+ tree (mmap) | LSM + value log | In-memory + AOF | Bitcask variant | Flat file + mmap |
+| **GitHub stars** | ~5.8K | ~9.5K | ~15.6K | ~4.8K | ~3.6K | N/A |
+| **Last release** | Active (CockroachDB core) | v1.4.x (2025) | v4.9.1 (2026-02) | Maintenance mode | v1.1.0 (2025-12) | N/A |
+| **Pure Go (zero CGo)** | Yes (default build) | Yes | Yes | Yes | Yes | Yes |
+| **Random read latency** | 1–5 μs (warm cache), 10–50 μs (cold) | 0.5–2 μs (mmap warm) | 2–10 μs (value indirection) | < 0.5 μs (all in RAM) | 1–3 μs (key index in RAM) | 0.1–0.5 μs (direct pointer) |
+| **Write latency** | ~2–5 μs (WAL batch) | 50–200 μs (COW + fsync) | ~3–8 μs (WAL) | ~1–3 μs (append AOF) | ~2–5 μs | ~1 μs (msync deferred) |
+| **Memory efficiency** | Good (block cache tunable) | Good (OS page cache) | Poor (high base overhead) | Poor (all data in RAM) | OK (key index in RAM) | Excellent (OS page cache) |
+| **Crash safety** | WAL + manifest | COW B+ tree (excellent) | WAL + value log | AOF replay | Bitcask merge | Manual (msync) |
+| **API complexity** | High (many options) | Simple | Medium | Very simple | Simple | DIY |
+| **Dep tree weight** | Heavy (CockroachDB) | Light | Medium | Minimal | Light | Zero |
+
+## Per-Library Analysis
+
+### 1. Pebble (current) — github.com/cockroachdb/pebble
+
+**Architecture:** LSM-tree with WAL, bloom filters, block cache.
+
+**Why it underperforms for HNSW:**
+- Random point reads must check bloom filter → index block → data block per SST level
+- 50K keys likely spans 1–3 SST levels; each read touches 2–4 blocks
+- Block cache helps, but HNSW traversal has poor locality (random neighbor hops)
+- Compaction background work competes for I/O
+
+**When it's still OK:**
+- If the entire dataset fits in block cache (~150 MB, easily tunable), reads hit cached blocks
+- Already integrated — switching has engineering cost
+
+**Verdict:** Solid but architecturally mismatched for random-read-dominant workloads.
+
+### 2. bbolt — go.etcd.io/bbolt
+
+**Architecture:** Single-file B+ tree, mmap'd pages, COW writes.
+
+**Why it's better for reads:**
+- B+ tree lookup = O(log_B N) page accesses; for 50K keys with 4 KB pages, ~3–4 page touches
+- Entire file is mmap'd — reads go through OS page cache, no userspace buffering layer
+- No bloom filter overhead, no SST level multiplier
+- 150 MB file easily stays in page cache
+
+**Write concern:**
+- COW semantics: every write copies touched pages → new root
+- Must `fsync` on commit → 50–200 μs per write tx
+- Mitigated by batching: accumulate neighbor updates in one write tx per insert
+
+**Concurrency model:**
+- Single writer, multiple concurrent readers (MVCC via COW)
+- Readers never block writers (and vice versa) — good for HNSW where reads dominate
+
+**Verdict:** Strong candidate. Natural fit for read-heavy + batched-write workload.
+
+### 3. Badger v4 — github.com/dgraph-io/badger
+
+**Architecture:** WiscKey — keys in LSM, values in separate value log.
+
+**Why it's NOT ideal here:**
+- Values 512–3072 B sit at the awkward threshold boundary
+  - Below `ValueThreshold` → stored inline in LSM (same as Pebble, no benefit)
+  - Above → requires two seeks: LSM for key → value log for data
+- Value log GC adds complexity and unpredictable latency spikes
+- Higher base memory usage than Pebble or bbolt
+- Known production stability issues in community reports
+
+**When value separation helps:**
+- Very large values (>16 KB) where keeping them out of LSM compaction saves I/O
+- Not this workload.
+
+**Verdict:** Not recommended. Adds complexity without read performance benefit at this value size.
+
+### 4. BuntDB — github.com/tidwall/buntdb
+
+**Architecture:** In-memory B-tree with optional AOF persistence.
+
+**Reads:** All data in RAM → sub-microsecond. Benchmarks report ~4.6M reads/sec.
+
+**Concerns:**
+- **Maintenance:** 172 commits total, low recent activity, essentially one-person project
+- **Persistence:** AOF append + periodic shrink. Not crash-safe in the same way as WAL-based stores
+- **Memory:** Entire dataset in Go heap → GC pressure on larger datasets
+- **Scale ceiling:** Fine at 150 MB, questionable at 1 GB+
+
+**Verdict:** Fastest reads, but maintenance risk and GC pressure concern. Consider only if bbolt doesn't meet latency targets.
+
+### 5. NutsDB — github.com/nutsdb/nutsdb
+
+**Architecture:** Bitcask-inspired — all keys indexed in memory, values on disk.
+
+**Reads:** Key lookup in RAM hash map → one disk read at known offset. Fast (~1–3 μs warm).
+
+**Concerns:**
+- Less battle-tested than bbolt/Pebble
+- Compaction (merge) can cause latency spikes
+- Smaller community, fewer production deployments
+
+**Verdict:** OK option but no advantage over bbolt for this workload.
+
+### 6. Custom mmap Flat File
+
+**Design:**
+```
+vectors.dat:  [vec_0 (512B padded)] [vec_1] ... [vec_49999]
+graph.dat:    [neighbors_0 (var)] [neighbors_1] ...
+index:        map[uint64]offset  (in-memory or separate file)
+```
+
+Read path: `id → offset → mmap slice → done`. One pointer dereference + possible page fault.
+
+**Advantages:**
+- Absolute minimum overhead: no serialization, no key comparison, no tree traversal
+- 150 MB file trivially fits in OS page cache
+- Zero library dependencies, zero background goroutines
+- Predictable, no GC interaction (mmap is outside Go heap)
+
+**Disadvantages:**
+- Must handle: variable-length records, crash safety, file growth, deletion/compaction
+- No transactions, no key iteration, no range queries
+- Testing and correctness burden is on you
+
+**Implementation options:**
+- `syscall.Mmap` / `golang.org/x/sys/unix` — direct, low-level
+- `github.com/edsrzf/mmap-go` (~4K stars) — thin cross-platform wrapper
+
+**Verdict:** Maximum performance, maximum engineering cost. Best when the KV store is proven to be the bottleneck.
+
+### 7. Others Considered
+
+| Library | Notes | Verdict |
+|---|---|---|
+| **RoseDB** (github.com/rosedblabs/rosedb, 5K stars) | Bitcask model, pure Go, clean API | Similar to NutsDB, no clear advantage |
+| **LotusDB** (github.com/lotusdblabs/lotusdb, 2K stars) | B+ tree index + value log | Immature, small community |
+| **go-memdb** (github.com/hashicorp/go-memdb, 3.5K stars) | In-memory immutable radix tree | No persistence — not suitable |
+| **Bolt** (github.com/boltdb/bolt) | Original, archived | Use bbolt instead |
+
+## Recommendation Ranking
+
+### Tier 1: Recommended
+
+| Rank | Library | Rationale |
+|---|---|---|
+| **1** | **bbolt** | Best balance of read performance, simplicity, and reliability. Mmap B+ tree is architecturally matched to random-read workloads. Batch writes to amortize COW cost. Battle-tested (etcd core). |
+| **2** | **Custom mmap** | Maximum performance ceiling. Choose this if bbolt benchmarks show B+ tree overhead is still too high, or if you want zero-dependency storage. |
+
+### Tier 2: Acceptable
+
+| Rank | Library | Rationale |
+|---|---|---|
+| **3** | **Pebble (tuned)** | Already integrated. Before switching, try: increase block cache to 256 MB, use bloom filters, measure actual hit rate. If cache-warm reads are <2 μs, the switch may not be worth the engineering cost. |
+| **4** | **BuntDB** | Fastest reads (in-memory). Acceptable if dataset stays small and maintenance risk is tolerable. |
+
+### Tier 3: Not Recommended
+
+| Rank | Library | Rationale |
+|---|---|---|
+| **5** | NutsDB | No advantage over bbolt |
+| **6** | Badger | Wrong architecture for this value size and access pattern |
+
+## Suggested Next Steps
+
+1. **Benchmark Pebble with tuned cache** — set block cache = 256 MB, measure p50/p99 read latency for HNSW traversal. This is the cheapest experiment.
+2. **Prototype bbolt backend** — implement `Store` interface with bbolt, batch writes per insert (one write tx with all ~37 neighbor updates).
+3. **Compare** — run 50K build benchmark with both backends. If bbolt is 2×+ faster, switch.
+4. **Consider mmap later** — only if bbolt still doesn't meet targets and profiling confirms storage is the bottleneck (not HNSW algorithm overhead).

--- a/docs/tasks/BOARD.md
+++ b/docs/tasks/BOARD.md
@@ -12,18 +12,19 @@
 | HAY-004d | Pebble 替换 mock | Dev | #44 | 2026-04-14 |
 | HAY-004e | 并发安全 | Dev | #46 | 2026-04-14 |
 | HAY-004f | 性能验证 & E2E（参数化 benchmark + SIFT 真实数据验证） | Dev | #49 | 2026-04-17 |
-| HAY-004f-qa | QA 验收：HNSW 性能 & E2E | QA | — | 2026-04-17 |
+| HAY-004f-qa | QA 验收：HNSW 性能 & E2E | QA | #50 | 2026-04-17 |
+| HAY-004g | HNSW Insert upsert 修补（重复 docId 孤儿节点） | Dev | #51 | 2026-04-17 |
+| HAY-006 | 补充 upsert 测试场景 | Dev | #52 | 2026-04-17 |
 
 ## In Progress 🔵
 | ID | 任务 | Owner | Branch | 说明 |
 |----|------|-------|--------|------|
-
+| HAY-007 | mmap flat file 存储引擎 | Dev | PR #53 | Phase 1 完成，等飞马 review |
 
 ## Backlog 📋
-| ID | 任务 | Owner | 优先级 | 说明 |
-|----|------|-------|--------|------|
-| HAY-004g | HNSW Insert upsert 修补（重复 docId 孤儿节点） | Dev | P1 | Insert 开头 GetNodeId 检查，存在则先 Delete 再 Insert；小改无需设计文档 |
+（空）
 
 ## 设计文档
 - [HAY-004 HNSW 设计](HAY-004-hnsw/design.md)
 - [coder/hnsw 审查报告](HAY-004-hnsw/hnsw-deep-review.md)
+- [HAY-007 MmapStore 设计](../design/HAY-007-mmap-store.md)

--- a/docs/tasks/HAY-007-review-cc-round1.md
+++ b/docs/tasks/HAY-007-review-cc-round1.md
@@ -1,0 +1,95 @@
+# HAY-007 Task Breakdown Review — Round 1
+
+> Reviewer: Claude Code (Opus 4)
+> Date: 2026-04-17
+> 对照文档：`docs/design/HAY-007-mmap-store.md` v2
+
+---
+
+## CRITICAL
+
+### C1: Phase 2 缺少 WAL replay 实现任务
+
+**设计文档 §4.5** 明确定义了恢复流程：从 `WalCheckpointLSN + 1` 开始 replay，逐条 CRC 校验，不完整记录丢弃。但 Phase 2 的 Task 2.1 只覆盖了 WAL append/CRC/LSN，**没有独立任务覆盖 replay 逻辑**。replay 被推迟到 Phase 4（Task 4.2），但 Phase 2 验证标准写道"WAL replay 正确"——矛盾。
+
+**风险**：Phase 2 结束时 WAL 只能写不能读，无法验证写入正确性；Phase 4 才发现 WAL 格式有缺陷需要返工。
+
+**建议**：将 WAL replay 基础逻辑（顺序扫描 + CRC 校验 + 回调）放入 Task 2.1，Phase 4 只做 Open 流程集成和 crash-point 注入。
+
+---
+
+### C2: Phase 1 缺少 graph_upper.dat 只读路径
+
+**设计文档 §4.1** 定义了 `graph_upper.dat` 文件格式和 `GetNeighbors(id, layer>0)` 读路径。Task 1.4 列出了 `GetNeighbors(id, layer)` 并提到 "layer>0 读 graphUpper"，但 **Phase 1 没有任何任务创建/mmap graph_upper.dat 文件**。Task 1.3 的 `Open` 只说"初始化各文件"但未明确包含 graph_upper.dat。Task 5.1 才做 "graph_upper.dat 按需分配"。
+
+**风险**：Phase 1 的 `GetNeighbors(id, layer>0)` 实现无法测试，Task 1.4 验证不完整。Phase 5 集成时才发现 upper graph 读路径有 bug。
+
+**建议**：Task 1.3 显式列出 graph_upper.dat 的 Open/mmap，Task 1.4 增加 upper layer 读取测试。Task 5.1 聚焦"按需分配写入"而非读。
+
+---
+
+### C3: grow 与并发读的安全间隙未拆任务验证
+
+**设计文档 §4.4** 描述 grow 流程：munmap → ftruncate → 重新 mmap。在 munmap 和重新 mmap 之间存在窗口，此时持有 RLock 的并发 reader 会访问已释放的 mmap 区域 → **SIGBUS/SIGSEGV**。
+
+Task 2.4 验证写道"并发读不崩溃"，但没有独立任务设计并发安全方案。设计文档的 RWMutex 方案本身有缺陷：RLock holder 在 grow Lock() 等待期间仍在读旧 mmap。
+
+**风险**：这是 mmap store 最高风险的技术点。仅靠 Task 2.4 一个 ~100 行任务无法同时实现 grow 逻辑 + 解决并发安全 + 验证正确性。
+
+**建议**：(1) 拆出独立 Task 分析并发安全方案（如 double-buffer/epoch-based 切换），(2) Task 2.4 拆分为 grow 实现 + grow 并发压力测试两个子任务。
+
+---
+
+## HIGH
+
+### H1: idmap.dat 持久化与 WAL 的一致性依赖未明确
+
+Task 3.4 实现 idmap.dat 持久化，Task 2.1 实现 WAL。但 **INSERT WAL 记录包含 docId**（设计文档 §4.1 WAL 类型），WAL replay 时需要恢复 idmap。两个任务分属不同 Phase，没有明确依赖关系。
+
+**风险**：Phase 2 WAL replay INSERT 时无法恢复 docId→nodeId 映射（idmap 还没持久化），crash 恢复后 ID 映射丢失。
+
+**建议**：Task 2.1 WAL replay 必须包含 INSERT 对应的内存 map 恢复逻辑（即使 idmap.dat compact 推迟到 Phase 3）。在 Task 2.1 依赖中显式标注。
+
+---
+
+### H2: Task 2.5 NextNodeId 依赖 freelist，但 freelist 在 Phase 3
+
+Task 2.5 实现 `NextNodeId()`，设计文档 §4.2 写道 "freelist 有则 pop，否则 meta.NextNodeId++"。但 freelist 在 Phase 3 Task 3.1/3.2 才实现。
+
+**风险**：不是功能 bug（Phase 2 没 Delete 所以 freelist 为空），但 Task 2.5 的代码必须预留 freelist 接口，否则 Phase 3 需要重写 NextNodeId。
+
+**建议**：Task 2.5 说明中注明"初版只做 meta.NextNodeId++，Phase 3 补充 freelist 逻辑"，避免预留过度设计但也避免返工。
+
+---
+
+### H3: Phase 2 验收标准 "50K Insert < 90s" 缺少前置条件
+
+Task 2.6 做 50K Insert benchmark，但 Phase 2 尚无 graph_upper.dat 写入（Phase 5 Task 5.1）。如果 HNSW Insert 需要写 upper layer neighbors，Phase 2 的 50K benchmark 会 panic 或 silently skip upper layers。
+
+**风险**：Phase 2 benchmark 结果不反映真实性能；Phase 5 集成后性能退化超出 90s 目标。
+
+**建议**：Task 2.6 明确说明 benchmark scope（仅 level-0，或 mock upper store），Phase 5 Task 5.3 才是完整 E2E benchmark。
+
+---
+
+### H4: Windows mmap truncate 问题（开放问题 #3）无任务覆盖
+
+设计文档 §8 开放问题 #3 明确标注 "Windows 下 mmap 文件无法 truncate——需要先 munmap 再 truncate。grow 流程需测试"。但 Task 2.4（grow）和 Task 1.1（mmap 封装）均未提及 Windows 特殊处理。
+
+**风险**：Phase 2 grow 实现在 Windows CI 上 panic，阻塞三平台交付。
+
+**建议**：Task 1.1 增加 Windows grow 兼容性设计（munmap→truncate→mmap 顺序），Task 2.4 验证增加 Windows CI 显式测试。
+
+---
+
+### H5: SetNodeMapping 持久化时机不明
+
+设计文档 §4.2 接口映射表：`SetNodeMapping` = "更新内存 map + 追加 idmap.dat（带 CRC）"。但 Task Breakdown 中 **Phase 2 没有任何任务覆盖 SetNodeMapping 的 idmap.dat 追加写**。Task 2.2 只列了 PutNode/SetNeighbors/SetNorm/SetNodeMapping，但 idmap.dat 写入在 Task 3.4。
+
+**风险**：Phase 2 SetNodeMapping 只更新内存 map 不写盘，crash 后 ID 映射全丢。与 WAL replay 依赖同一问题（见 H1），但影响范围更大——正常 Close→Open 也丢映射。
+
+**建议**：Task 2.2 或 Task 2.5 中增加 idmap.dat 追加写的基础实现（仅 append + CRC），Task 3.4 只做 compact + 损坏恢复。
+
+---
+
+*EOF — 3 CRITICAL, 5 HIGH*

--- a/docs/tasks/HAY-007-review-cc-round2.md
+++ b/docs/tasks/HAY-007-review-cc-round2.md
@@ -1,0 +1,31 @@
+# HAY-007 Task Breakdown Review — Round 2
+
+> Reviewer: Claude Code (Opus 4)
+> Date: 2026-04-17
+> 对照文档：`docs/design/HAY-007-mmap-store.md` v2
+> 上一轮：3 CRITICAL + 5 HIGH，已全部修复
+
+---
+
+## Round 1 修复验证
+
+| ID | 问题 | 修复位置 | 状态 |
+|----|------|----------|------|
+| C1 | WAL replay 缺失 | Task 2.1 已包含 replay 基础逻辑（顺序扫描+CRC+不完整记录丢弃+回调），Phase 4 只做 Open 集成 | **PASS** |
+| C2 | graph_upper.dat 只读路径缺失 | Task 1.3 显式包含 graph_upper.dat 创建/mmap，Task 1.4 增加 upper layer 读取测试 | **PASS** |
+| C3 | grow 并发安全间隙 | Task 2.4 采用 atomic.Pointer epoch-based 方案，拆为 2.4a/2.4b 子任务含压力测试 | **PASS** |
+| H1 | idmap 与 WAL replay 一致性 | Task 2.1 replay INSERT 时恢复内存 docId→nodeId 映射 | **PASS** |
+| H2 | NextNodeId 依赖 freelist | Task 2.5 明确初版只做自增，Phase 3 补充 freelist | **PASS** |
+| H3 | 50K benchmark 前置条件 | Task 2.6 明确仅 level-0 路径，Phase 5 Task 5.3 为完整 E2E | **PASS** |
+| H4 | Windows mmap truncate | Task 1.1 已知限制段落说明 munmap→truncate→mmap 顺序，Task 2.4 处理 | **PASS** |
+| H5 | SetNodeMapping 持久化时机 | Task 2.2 包含 idmap.dat 追加写（append+CRC），Task 3.4 只做 compact+损坏恢复 | **PASS** |
+
+---
+
+## Round 2 新发现
+
+**PASS** — 未发现新的 CRITICAL 或 HIGH 问题。
+
+---
+
+*EOF — 0 CRITICAL, 0 HIGH*

--- a/docs/tasks/HAY-007-task-breakdown.md
+++ b/docs/tasks/HAY-007-task-breakdown.md
@@ -1,0 +1,238 @@
+# HAY-007: MmapStore Task Breakdown
+
+> 基于 `docs/design/HAY-007-mmap-store.md` v2 分解
+> 日期：2026-04-17
+> 修订：2026-04-17 — 根据 Round 1 Review 修复 C1-C3, H1-H5
+
+---
+
+## Phase 1：核心基础设施（只读路径 + mmap 封装）
+
+### Task 1.1：跨平台 mmap 封装
+
+**目标**：自封装 `syscall.Mmap/Munmap`，支持 Linux/macOS/Windows，零 CGo。
+
+**改动文件**：
+- `internal/core/vectorindex/mmap_unix.go`（~40 行，build tag `//go:build !windows`）
+- `internal/core/vectorindex/mmap_windows.go`（~50 行，build tag `//go:build windows`）
+- `internal/core/vectorindex/mmap.go`（~30 行，公共类型/接口）
+
+**预估行数**：~120 行
+
+**已知限制（H4）**：Windows 下 mmap 文件无法直接 truncate，grow 必须按 munmap→truncate→mmap 顺序执行。此为已知平台限制，不阻塞 Phase 1/2 交付；Task 2.4 grow 实现时在 Windows 路径中显式处理此顺序。
+
+**验证方式**：
+- 单元测试：创建临时文件 → mmap → 读写 → munmap → 验证内容
+- `CGO_ENABLED=0 go build ./...` 编译通过
+- `go test -run TestMmap` 通过
+
+---
+
+### Task 1.2：文件格式常量与 MetaHeader
+
+**目标**：定义所有文件 magic、header 结构体、序列化/反序列化工具函数。
+
+**改动文件**：
+- `internal/core/vectorindex/mmap_format.go`（~120 行）
+  - `MetaHeader` 结构体（64 bytes）
+  - `VectorsHeader`、`NodesHeader`、`GraphL0Header`、`GraphUpperHeader` 结构体
+  - magic 常量 `"HNSW"`, `"VECS"`, `"NODE"`, `"GRL0"`, `"GRUP"`, `"IDMP"`
+  - `readMetaHeader()` / `writeMetaHeader()` （原子 rename）
+  - header 序列化辅助（`binary.LittleEndian`）
+
+**预估行数**：~120 行
+
+**验证方式**：
+- 单元测试：写 MetaHeader → 读回 → 字段一致
+- 测试 MetaHeader 精确 64 bytes（`unsafe.Sizeof`）
+- 原子写测试：写入后读回正确
+
+---
+
+### Task 1.3：MmapStore 结构体与 Open/Close
+
+**目标**：实现 `MmapStore` 结构体，`Open(dir, dim, M)` 创建/打开索引目录，`Close()` 释放资源。
+
+**改动文件**：
+- `internal/core/vectorindex/mmap_store.go`（~180 行）
+  - `MmapStore` 结构体定义（所有字段）
+  - `OpenMmapStore(dir string, opts MmapStoreOptions) (*MmapStore, error)`
+    - 创建目录、初始化各文件（header + 初始容量 1024 slots）
+    - **显式包含 graph_upper.dat 的创建/mmap（C2 fix）**
+    - mmap 所有文件（vectors.dat, nodes.dat, graph_l0.dat, graph_upper.dat, meta.dat）
+  - `Close() error`：munmap all → flush meta
+  - 辅助：`initFile(path, magic, headerSize, slotSize, capacity)`
+
+**预估行数**：~180 行
+
+**验证方式**：
+- 单元测试：Open 空目录 → 文件全部创建（含 graph_upper.dat）→ Close → 再次 Open → meta 一致
+- Close 后 re-open 不报错
+- 文件大小 = headerSize + capacity × slotSize
+
+---
+
+### Task 1.4：只读方法实现（GetVector / GetVectorRef / GetNeighbors / GetNorm / GetNodeLevel / GetEntryPoint）
+
+**目标**：实现 `NodeStore` 接口中的所有只读方法。
+
+**改动文件**：
+- `internal/core/vectorindex/mmap_store.go`（追加 ~120 行）
+  - `GetVector(id)` — copy from mmap slice
+  - `GetVectorRef(id)` — 初版同 GetVector（copy）
+  - `GetNeighbors(id, layer)` — layer=0 读 graphL0，**layer>0 读 graph_upper.dat（C2 fix：依赖 Task 1.3 的 graph_upper.dat mmap）**
+  - `GetNorm(id)` — 读 nodes.dat slot
+  - `GetNodeLevel(id)` — 读 nodes.dat slot
+  - `GetEntryPoint()` — 从 meta 返回
+
+**预估行数**：~120 行
+
+**验证方式**：
+- 单元测试：手动写入 mmap 区域的已知数据 → 调用读方法 → 验证返回值
+- **Upper layer 读取测试：写入 graph_upper.dat 已知数据 → GetNeighbors(id, layer>0) 返回正确（C2 fix）**
+- Benchmark：50K 随机 GetVector 调用 < 1μs/op（hot path）
+- 边界测试：id=0、id=capacity-1、id 超范围返回 error
+
+---
+
+### Task 1.5：从现有数据导出到 mmap 文件格式（测试辅助）
+
+**目标**：实现 `ExportFromMemStore(ms *MemNodeStore, dir string)` 工具函数，将 MemStore 数据导出为 mmap 文件格式，供读路径测试和 benchmark 使用。
+
+**改动文件**：
+- `internal/core/vectorindex/mmap_export_test.go`（~80 行，仅测试代码）
+  - 遍历 MemStore → 写入各 mmap 文件
+  - 用于生成测试数据
+
+**预估行数**：~80 行
+
+**验证方式**：
+- 集成测试：MemStore 插入 1K 向量 → 导出 → MmapStore Open → 逐个 GetVector 对比
+- Recall 对比：同一数据集 MemStore vs MmapStore 搜索结果一致
+
+---
+
+### Phase 1 总验收
+
+- [ ] `CGO_ENABLED=0 GOOS=linux go build ./...` 通过
+- [ ] `CGO_ENABLED=0 GOOS=darwin go build ./...` 通过
+- [ ] `CGO_ENABLED=0 GOOS=windows go build ./...` 通过
+- [ ] 50K 随机向量读 benchmark < 1μs（hot）
+- [ ] 所有单元测试通过
+- [ ] `go vet ./...` 和 `staticcheck ./...` 无新增告警
+
+---
+
+## Phase 2：写入路径 + WAL + Batch（后续）
+
+### Task 2.1：WAL 实现（append / CRC32 / LSN / **replay**）
+- 文件：`mmap_wal.go`（~250 行）
+- **WAL replay 基础逻辑包含在此任务中（C1 fix）**：顺序扫描 + CRC 校验 + 不完整记录丢弃 + 回调接口
+- replay INSERT 记录时恢复内存中的 docId→nodeId 映射（H1 fix：即使 idmap.dat compact 推迟到 Phase 3，replay 必须恢复内存 map）
+- 验证：写 N 条记录 → 读回 → LSN 连续、CRC 正确、payload 一致
+- 验证：模拟写入后不 Close → replay → 数据完整恢复（含 ID 映射）
+- Phase 4 Task 4.2 聚焦 Open 流程集成和 crash-point 注入，不再重复 replay 基础逻辑
+
+### Task 2.2：写方法实现（PutNode / SetNeighbors / SetNorm / SetNodeMapping）
+- 文件：`mmap_store.go` 追加（~170 行）
+- **SetNodeMapping 包含 idmap.dat 追加写（append + CRC）（H1/H5 fix）**：确保正常 Close→Open 不丢 ID 映射；Phase 3 Task 3.4 只做 compact + 损坏恢复
+- 验证：PutNode → GetVector 返回写入值、SetNeighbors → GetNeighbors 返回一致
+- 验证：SetNodeMapping → Close → Open → GetNodeId 返回正确映射
+
+### Task 2.3：BatchableStore 接口实现
+- 文件：`mmap_store.go` 追加（~60 行）
+- 验证：batch 模式下多次写操作只触发 1 次 sync
+
+### Task 2.4：文件增长（grow）+ 并发安全
+- 文件：`mmap_store.go` 追加（~150 行）
+- **并发安全方案（C3 fix）**：grow 期间采用 copy-on-read 策略——grow 前获取写锁，将旧 mmap slice 引用保存为 stale snapshot；grow 完成后释放写锁。并发 reader 通过 atomic.Pointer 获取当前 mmap slice，grow 切换为新 slice 后旧 reader 自然排空（epoch-based）。独立子任务：
+  - 2.4a：grow 基本实现（munmap → ftruncate → mmap，atomic slice 切换）
+  - 2.4b：grow 并发压力测试（多 goroutine 持续读 + 触发 grow，验证无 SIGBUS/panic）
+- 验证：插入超过初始 capacity → 自动 grow → 数据完整
+- 验证：并发压力测试 10 goroutine 读 + 1 goroutine 连续 grow × 100 次，零 panic
+
+### Task 2.5：NextNodeId + ID 映射写入
+- 文件：`mmap_store.go` 追加（~80 行）
+- **初版策略（H2 fix）**：只做 `meta.NextNodeId++` 简单自增分配，不预留 freelist 接口。Phase 3 Task 3.1/3.2 实现 freelist 后再修改 NextNodeId 加入 freelist pop 逻辑。
+- 验证：NextNodeId 单调递增、SetNodeMapping → GetNodeId 往返一致
+
+### Task 2.6：50K Insert 集成 benchmark
+- 文件：`mmap_store_bench_test.go`（~100 行）
+- **Benchmark scope（H3 fix）**：Phase 2 尚无 graph_upper.dat 写入（Phase 5 Task 5.1），因此本 benchmark 仅验证 level-0 写入路径。结果为部分验证，不代表完整 E2E 性能。Phase 5 Task 5.3 为完整 E2E benchmark。
+- 验证：50K×128d Insert < 90s（仅 level-0 路径）
+
+**Phase 2 预估总行数**：~750 行
+
+---
+
+## Phase 3：Delete + Upsert + Freelist（后续）
+
+### Task 3.1：DeleteNode（墓碑 + freelist）
+- 文件：`mmap_store.go` 追加（~120 行）
+- 验证：Delete 后 GetNodeLevel 返回 error、freelist 包含回收 ID
+
+### Task 3.2：Freelist 启动扫描重建
+- 文件：`mmap_store.go` Open 流程追加（~60 行）
+- 验证：插入 → 删除部分 → Close → Open → freelist 正确重建 < 1ms
+
+### Task 3.3：Upsert 实现
+- 文件：`mmap_store.go` 追加（~50 行）
+- 验证：同 docId Upsert → slot 复用、无孤儿节点
+
+### Task 3.4：idmap.dat compact + 损坏恢复
+- 文件：`mmap_idmap.go`（~170 行）
+- 基础 idmap.dat 追加写已在 Phase 2 Task 2.2 实现（H1/H5 fix）；本任务聚焦 compact（合并重复 entry 缩减文件）和损坏 entry 跳过恢复
+- 验证：大量写入 → compact → 文件缩小、映射完整、损坏 entry 被跳过
+
+**Phase 3 预估总行数**：~400 行
+
+---
+
+## Phase 4：崩溃恢复 + Checkpoint（后续）
+
+### Task 4.1：WAL checkpoint 机制
+- 文件：`mmap_wal.go` 追加（~80 行）
+- 验证：checkpoint 后 WAL 截断、meta.WalCheckpointLSN 更新
+
+### Task 4.2：崩溃恢复流程（Open 集成 WAL replay）
+- 文件：`mmap_store.go` Open 流程追加（~100 行）
+- WAL replay 基础逻辑已在 Phase 2 Task 2.1 实现（C1 fix）；本任务将 replay 集成到 Open 流程（从 WalCheckpointLSN+1 开始）
+- 验证：写入 N 条 → 模拟 crash（不 Close）→ Open → 数据完整
+
+### Task 4.3：Crash point 注入测试（5 类场景）
+- 文件：`mmap_crash_test.go`（~120 行）
+- 验证：Insert/SetNeighbors/Checkpoint/Grow/Delete 中途 panic → 恢复正确
+
+**Phase 4 预估总行数**：~300 行
+
+---
+
+## Phase 5：上层图 + 完整集成（后续）
+
+### Task 5.1：graph_upper.dat 按需分配写入
+- 文件：`mmap_store.go` 追加（~100 行）
+- graph_upper.dat 的 Open/mmap 和只读路径已在 Phase 1 Task 1.3/1.4 实现（C2 fix）；本任务聚焦写入：level>0 节点的 upper slot 按需分配
+- 验证：level>0 节点 upper slot 分配正确、level=0 节点不占 upper slot
+
+### Task 5.2：HNSW 集成（替换 PebbleStore）
+- 文件：`hnsw.go` / `hnsw_test.go` 修改（~80 行）
+- 验证：全部现有 HNSW 测试通过
+
+### Task 5.3：E2E benchmark + Recall 验证
+- 文件：`mmap_store_e2e_test.go`（~120 行）
+- 验证：SIFT 50K recall@10 > 0.95、搜索 p99 < 5ms
+
+**Phase 5 预估总行数**：~300 行
+
+---
+
+## 总计
+
+| Phase | 行数 | 状态 |
+|-------|------|------|
+| Phase 1：核心基础设施 | ~620 行 | **当前** |
+| Phase 2：写入 + WAL + Batch | ~750 行 | 后续 |
+| Phase 3：Delete + Upsert | ~400 行 | 后续 |
+| Phase 4：崩溃恢复 | ~300 行 | 后续 |
+| Phase 5：上层图 + 集成 | ~300 行 | 后续 |
+| **总计** | **~2370 行** | |

--- a/internal/core/vectorindex/mmap.go
+++ b/internal/core/vectorindex/mmap.go
@@ -1,0 +1,29 @@
+package vectorindex
+
+import "fmt"
+
+// MmapFlags controls mmap protection and sharing.
+const (
+	mmapRead  = 1 << iota // PROT_READ
+	mmapWrite             // PROT_WRITE
+)
+
+// mmapAlloc maps a region of the given file descriptor into memory.
+// offset must be page-aligned. length must be > 0.
+// flags is a bitmask of mmapRead | mmapWrite.
+// The returned slice is backed by the OS page cache.
+func mmapAlloc(fd uintptr, offset int64, length int, flags int) ([]byte, error) {
+	if length <= 0 {
+		return nil, fmt.Errorf("mmap: length must be > 0, got %d", length)
+	}
+	return mmapPlatform(fd, offset, length, flags)
+}
+
+// mmapFree unmaps a previously mapped region. The slice must not be used after
+// this call returns.
+func mmapFree(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return munmapPlatform(data)
+}

--- a/internal/core/vectorindex/mmap_export_test.go
+++ b/internal/core/vectorindex/mmap_export_test.go
@@ -1,0 +1,239 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// exportMemStoreToMmap exports all data from a MemNodeStore into an MmapStore directory.
+// This is a test helper for populating mmap files with known data.
+func exportMemStoreToMmap(ms *MemNodeStore, dir string, dim, m int) (*MmapStore, error) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	// Determine required capacity.
+	var maxID uint64
+	for id := range ms.vectors {
+		if id >= maxID {
+			maxID = id + 1
+		}
+	}
+	if maxID < defaultInitialCapacity {
+		maxID = defaultInitialCapacity
+	}
+
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: m})
+	if err != nil {
+		return nil, err
+	}
+
+	// Count upper-layer nodes for upper slot allocation.
+	var nextUpperSlot uint32 = 1 // slot 0 is reserved (0 means "no upper slot")
+
+	// Write all nodes.
+	for id, vec := range ms.vectors {
+		if id >= s.vecCapacity {
+			return nil, fmt.Errorf("exportMemStoreToMmap: id %d >= capacity %d, grow not implemented in Phase 1", id, s.vecCapacity)
+		}
+
+		// Write vector.
+		vecOffset := pageSize + int(id)*s.vecSlotSize
+		for i, v := range vec {
+			binary.LittleEndian.PutUint32(s.vectors[vecOffset+i*4:], math.Float32bits(v))
+		}
+
+		// Write node slot.
+		level := ms.levels[id]
+		norm := ms.norms[id]
+		var upperSlot uint32
+
+		if level > 0 {
+			upperSlot = nextUpperSlot
+			nextUpperSlot++
+			if uint64(upperSlot) >= s.upperCapacity {
+				return nil, fmt.Errorf("exportMemStoreToMmap: upper slot %d >= capacity %d", upperSlot, s.upperCapacity)
+			}
+		}
+
+		nodeOffset := pageSize + int(id)*nodeSlotSize
+		s.nodes[nodeOffset] = byte(level)
+		s.nodes[nodeOffset+1] = 0 // flags
+		binary.LittleEndian.PutUint32(s.nodes[nodeOffset+4:], math.Float32bits(norm))
+		binary.LittleEndian.PutUint32(s.nodes[nodeOffset+8:], upperSlot)
+
+		// Write L0 neighbors.
+		if layers, ok := ms.neighbors[id]; ok {
+			if nb, ok := layers[0]; ok {
+				l0Offset := pageSize + int(id)*s.l0SlotSize
+				count := len(nb)
+				if count > s.mmax0 {
+					count = s.mmax0
+				}
+				binary.LittleEndian.PutUint32(s.graphL0[l0Offset:], uint32(count))
+				for i := 0; i < count; i++ {
+					binary.LittleEndian.PutUint64(s.graphL0[l0Offset+4+i*8:], nb[i])
+				}
+			}
+
+			// Write upper neighbors.
+			if upperSlot > 0 {
+				for layer := 1; layer <= level; layer++ {
+					if nb, ok := layers[layer]; ok {
+						layerSize := graphUpperLayerSize(m)
+						layerIdx := layer - 1
+						offset := pageSize + int(upperSlot)*s.upperSlotSz + layerIdx*layerSize
+						count := len(nb)
+						if count > m {
+							count = m
+						}
+						binary.LittleEndian.PutUint32(s.graphUpper[offset:], uint32(count))
+						for i := 0; i < count; i++ {
+							binary.LittleEndian.PutUint64(s.graphUpper[offset+4+i*8:], nb[i])
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Set meta.
+	s.meta.NodeCount = uint64(len(ms.vectors))
+	s.meta.TotalSlots = maxID
+	s.meta.NextNodeId = ms.nextID
+	if ms.hasEntry {
+		s.meta.EntryPoint = ms.entryID
+		s.meta.EntryLevel = uint32(ms.maxLayer)
+	}
+
+	// Copy ID mappings.
+	for doc, nodeId := range ms.docToNode {
+		s.docToNode[doc] = nodeId
+	}
+	for nodeId, doc := range ms.nodeToDoc {
+		s.nodeToDoc[nodeId] = doc
+	}
+
+	return s, nil
+}
+
+func TestExportMemStoreToMmap(t *testing.T) {
+	// Build a small HNSW index with MemStore.
+	memStore := NewMemNodeStore()
+	dim := 32
+	n := 1000
+	rng := rand.New(rand.NewSource(42))
+
+	// Insert n vectors.
+	for i := 0; i < n; i++ {
+		id := uint64(i)
+		vec := make([]float32, dim)
+		for j := range vec {
+			vec[j] = rng.Float32()
+		}
+		memStore.PutNode(id, 0, vec)
+		memStore.SetNodeMapping(fmt.Sprintf("doc%d", i), id)
+		memStore.SetNeighbors(id, 0, []uint64{uint64((i + 1) % n), uint64((i + 2) % n)})
+	}
+	memStore.nextID = uint64(n)
+	memStore.SetEntryPoint(0, 0)
+
+	// Export to mmap.
+	dir := t.TempDir()
+	mmapS, err := exportMemStoreToMmap(memStore, dir, dim, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mmapS.Close()
+
+	// Verify all vectors match.
+	for i := 0; i < n; i++ {
+		memVec, _ := memStore.GetVector(uint64(i))
+		mmapVec, err := mmapS.GetVector(uint64(i))
+		if err != nil {
+			t.Fatalf("GetVector(%d): %v", i, err)
+		}
+		for j := range memVec {
+			if memVec[j] != mmapVec[j] {
+				t.Fatalf("vec[%d][%d]: mem=%f, mmap=%f", i, j, memVec[j], mmapVec[j])
+			}
+		}
+	}
+
+	// Verify neighbors.
+	for i := 0; i < n; i++ {
+		memNb, _ := memStore.GetNeighbors(uint64(i), 0)
+		mmapNb, err := mmapS.GetNeighbors(uint64(i), 0)
+		if err != nil {
+			t.Fatalf("GetNeighbors(%d, 0): %v", i, err)
+		}
+		if len(memNb) != len(mmapNb) {
+			t.Fatalf("neighbors[%d] len: mem=%d, mmap=%d", i, len(memNb), len(mmapNb))
+		}
+		for j := range memNb {
+			if memNb[j] != mmapNb[j] {
+				t.Fatalf("neighbors[%d][%d]: mem=%d, mmap=%d", i, j, memNb[j], mmapNb[j])
+			}
+		}
+	}
+
+	// Verify norms.
+	for i := 0; i < n; i++ {
+		memNorm, _ := memStore.GetNorm(uint64(i))
+		mmapNorm, err := mmapS.GetNorm(uint64(i))
+		if err != nil {
+			t.Fatalf("GetNorm(%d): %v", i, err)
+		}
+		if memNorm != mmapNorm {
+			t.Fatalf("norm[%d]: mem=%f, mmap=%f", i, memNorm, mmapNorm)
+		}
+	}
+
+	// Verify entry point.
+	id, level, err := mmapS.GetEntryPoint()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != 0 || level != 0 {
+		t.Errorf("entry = (%d, %d), want (0, 0)", id, level)
+	}
+
+	// Verify ID mappings.
+	for i := 0; i < n; i++ {
+		docId := fmt.Sprintf("doc%d", i)
+		nodeId, ok, err := mmapS.GetNodeId(docId)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok || nodeId != uint64(i) {
+			t.Fatalf("GetNodeId(%s) = (%d, %v), want (%d, true)", docId, nodeId, ok, i)
+		}
+	}
+
+	// Close and reopen — verify meta persisted.
+	mmapS.Close()
+
+	mmapS2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mmapS2.Close()
+
+	if mmapS2.meta.NodeCount != uint64(n) {
+		t.Errorf("NodeCount after reopen = %d, want %d", mmapS2.meta.NodeCount, n)
+	}
+
+	// Vectors should still be readable.
+	v, err := mmapS2.GetVector(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	memV, _ := memStore.GetVector(0)
+	for j := range v {
+		if v[j] != memV[j] {
+			t.Fatalf("after reopen vec[0][%d]: %f != %f", j, v[j], memV[j])
+		}
+	}
+}

--- a/internal/core/vectorindex/mmap_format.go
+++ b/internal/core/vectorindex/mmap_format.go
@@ -1,0 +1,180 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"unsafe"
+)
+
+// File magic constants (4 bytes each).
+var (
+	magicMeta       = [4]byte{'H', 'N', 'S', 'W'}
+	magicVectors    = [4]byte{'V', 'E', 'C', 'S'}
+	magicNodes      = [4]byte{'N', 'O', 'D', 'E'}
+	magicGraphL0    = [4]byte{'G', 'R', 'L', '0'}
+	magicGraphUpper = [4]byte{'G', 'R', 'U', 'P'}
+	magicIDMap      = [4]byte{'I', 'D', 'M', 'P'}
+)
+
+// pageSize is the header size for mmap data files (page-aligned).
+const pageSize = 4096
+
+// MetaHeader is the on-disk format for meta.bin (exactly 64 bytes).
+// Fields are ordered to avoid implicit padding: uint32 group first, then uint64 group.
+type MetaHeader struct {
+	Magic      [4]byte // "HNSW"
+	Version    uint32  // 1
+	Dim        uint32  // vector dimension
+	M          uint32  // HNSW M parameter
+	MaxLevel   uint32  // current max level
+	EntryLevel uint32  // entry point level
+
+	NodeCount        uint64 // active node count (excl. tombstones)
+	TotalSlots       uint64 // allocated slots (incl. tombstones)
+	EntryPoint       uint64 // entry node ID
+	NextNodeId       uint64 // next allocatable node ID
+	WalCheckpointLSN uint64 // WAL checkpoint LSN
+}
+
+// Compile-time size check: MetaHeader must be exactly 64 bytes.
+var _ [64]byte = [unsafe.Sizeof(MetaHeader{})]byte{}
+
+// VectorsHeader is the on-disk header for vectors.dat (lives in the first pageSize bytes).
+type VectorsHeader struct {
+	Magic    [4]byte
+	Dim      uint32
+	Capacity uint64
+}
+
+// NodesHeader is the on-disk header for nodes.dat.
+type NodesHeader struct {
+	Magic    [4]byte
+	_        [4]byte // padding
+	Capacity uint64
+}
+
+// GraphL0Header is the on-disk header for graph_l0.dat.
+type GraphL0Header struct {
+	Magic        [4]byte
+	MaxNeighbors uint32
+	Capacity     uint64
+}
+
+// GraphUpperHeader is the on-disk header for graph_upper.dat.
+type GraphUpperHeader struct {
+	Magic        [4]byte
+	MaxNeighbors uint32
+	MaxLayers    uint32
+	_            [4]byte // padding
+	Capacity     uint64
+	NextSlot     uint64
+}
+
+// nodeSlotSize is the on-disk size of a single node metadata slot.
+const nodeSlotSize = 16
+
+// NodeSlot is the on-disk layout of a node in nodes.dat (16 bytes).
+type NodeSlot struct {
+	Level     uint8
+	Flags     uint8
+	_         [2]byte
+	Norm      float32
+	UpperSlot uint32
+	_         [4]byte // reserved
+}
+
+const nodeFlagDeleted = 0x01
+
+// graphL0SlotSize returns the slot size for a level-0 neighbor list.
+func graphL0SlotSize(mmax0 int) int {
+	return 4 + mmax0*8 // count(uint32) + neighbors([]uint64)
+}
+
+// graphUpperLayerSize returns bytes per layer in an upper-graph slot.
+func graphUpperLayerSize(m int) int {
+	return 4 + m*8 // count(uint32) + neighbors([]uint64)
+}
+
+// graphUpperSlotSize returns the total slot size for an upper-graph entry.
+func graphUpperSlotSize(m int, maxLayers int) int {
+	return maxLayers * graphUpperLayerSize(m)
+}
+
+// defaultMaxLayers is the pre-allocated upper layer count per slot.
+const defaultMaxLayers = 6
+
+// writeMetaHeader atomically writes a MetaHeader to dir/meta.bin using
+// write-to-temp + fsync + rename.
+func writeMetaHeader(dir string, h *MetaHeader) error {
+	h.Magic = magicMeta
+	if h.Version == 0 {
+		h.Version = 1
+	}
+
+	tmp := filepath.Join(dir, "meta.bin.tmp")
+	final := filepath.Join(dir, "meta.bin")
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("writeMetaHeader: create tmp: %w", err)
+	}
+
+	if err := binary.Write(f, binary.LittleEndian, h); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("writeMetaHeader: write: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("writeMetaHeader: sync: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("writeMetaHeader: close: %w", err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		return fmt.Errorf("writeMetaHeader: rename: %w", err)
+	}
+	return nil
+}
+
+// readMetaHeader reads a MetaHeader from dir/meta.bin.
+func readMetaHeader(dir string) (*MetaHeader, error) {
+	path := filepath.Join(dir, "meta.bin")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("readMetaHeader: %w", err)
+	}
+	defer f.Close()
+
+	var h MetaHeader
+	if err := binary.Read(f, binary.LittleEndian, &h); err != nil {
+		return nil, fmt.Errorf("readMetaHeader: read: %w", err)
+	}
+	if h.Magic != magicMeta {
+		return nil, fmt.Errorf("readMetaHeader: bad magic %q", h.Magic)
+	}
+	return &h, nil
+}
+
+// writeDataFileHeader writes a page-aligned header for a data file.
+// The header struct is written at offset 0, and the file is padded to pageSize.
+func writeDataFileHeader(path string, magic [4]byte, headerData any, totalSize int64) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := binary.Write(f, binary.LittleEndian, headerData); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	if err := f.Truncate(totalSize); err != nil {
+		return fmt.Errorf("truncate: %w", err)
+	}
+	return f.Sync()
+}

--- a/internal/core/vectorindex/mmap_format_test.go
+++ b/internal/core/vectorindex/mmap_format_test.go
@@ -99,6 +99,101 @@ func TestMetaHeaderAtomicWrite(t *testing.T) {
 	}
 }
 
+func TestWriteMetaHeaderBadDir(t *testing.T) {
+	// Non-existent directory should fail on create tmp.
+	h := &MetaHeader{Dim: 128, M: 16}
+	err := writeMetaHeader("/nonexistent/path/that/does/not/exist", h)
+	if err == nil {
+		t.Fatal("expected error for non-existent directory")
+	}
+}
+
+func TestWriteMetaHeaderVersionDefault(t *testing.T) {
+	dir := t.TempDir()
+	h := &MetaHeader{Version: 0, Dim: 128, M: 16}
+	if err := writeMetaHeader(dir, h); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readMetaHeader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != 1 {
+		t.Errorf("Version = %d, want 1 (auto-set from 0)", got.Version)
+	}
+}
+
+func TestWriteMetaHeaderRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create meta.bin as a directory to make rename fail.
+	metaDir := filepath.Join(dir, "meta.bin")
+	if err := os.MkdirAll(metaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Put a file inside so the directory isn't empty (rename will fail).
+	if err := os.WriteFile(filepath.Join(metaDir, "blocker"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &MetaHeader{Dim: 128, M: 16}
+	err := writeMetaHeader(dir, h)
+	if err == nil {
+		t.Fatal("expected error when rename target is a non-empty directory")
+	}
+}
+
+func TestWriteDataFileHeaderBadPath(t *testing.T) {
+	// Non-existent path should fail on os.Create.
+	hdr := VectorsHeader{Magic: magicVectors, Dim: 4, Capacity: 10}
+	err := writeDataFileHeader("/nonexistent/dir/vectors.dat", magicVectors, &hdr, 4096+40)
+	if err == nil {
+		t.Fatal("expected error for non-existent path")
+	}
+}
+
+func TestWriteDataFileHeaderReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "readonly.dat")
+
+	// Create a file, then make the dir read-only to prevent truncate on new file.
+	hdr := VectorsHeader{Magic: magicVectors, Dim: 4, Capacity: 10}
+
+	// First write should succeed.
+	if err := writeDataFileHeader(path, magicVectors, &hdr, int64(pageSize)+40); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify file was created and has correct size.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != int64(pageSize)+40 {
+		t.Errorf("size = %d, want %d", info.Size(), int64(pageSize)+40)
+	}
+}
+
+func TestReadMetaHeaderMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := readMetaHeader(dir)
+	if err == nil {
+		t.Fatal("expected error for missing meta.bin")
+	}
+}
+
+func TestReadMetaHeaderTruncated(t *testing.T) {
+	dir := t.TempDir()
+	// Write a file that's too short to be a valid header.
+	if err := os.WriteFile(filepath.Join(dir, "meta.bin"), make([]byte, 10), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readMetaHeader(dir)
+	if err == nil {
+		t.Fatal("expected error for truncated meta.bin")
+	}
+}
+
 func TestReadMetaHeaderBadMagic(t *testing.T) {
 	dir := t.TempDir()
 	// Write garbage.

--- a/internal/core/vectorindex/mmap_format_test.go
+++ b/internal/core/vectorindex/mmap_format_test.go
@@ -1,0 +1,112 @@
+package vectorindex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+)
+
+func TestMetaHeaderSize(t *testing.T) {
+	if s := unsafe.Sizeof(MetaHeader{}); s != 64 {
+		t.Fatalf("MetaHeader size = %d, want 64", s)
+	}
+}
+
+func TestMetaHeaderWriteRead(t *testing.T) {
+	dir := t.TempDir()
+
+	h := &MetaHeader{
+		Version:          1,
+		Dim:              128,
+		M:                16,
+		MaxLevel:         3,
+		EntryLevel:       3,
+		NodeCount:        5000,
+		TotalSlots:       5100,
+		EntryPoint:       42,
+		NextNodeId:       5100,
+		WalCheckpointLSN: 99,
+	}
+
+	if err := writeMetaHeader(dir, h); err != nil {
+		t.Fatalf("writeMetaHeader: %v", err)
+	}
+
+	got, err := readMetaHeader(dir)
+	if err != nil {
+		t.Fatalf("readMetaHeader: %v", err)
+	}
+
+	if got.Magic != magicMeta {
+		t.Errorf("magic = %q, want %q", got.Magic, magicMeta)
+	}
+	if got.Dim != 128 {
+		t.Errorf("dim = %d, want 128", got.Dim)
+	}
+	if got.M != 16 {
+		t.Errorf("M = %d, want 16", got.M)
+	}
+	if got.NodeCount != 5000 {
+		t.Errorf("NodeCount = %d, want 5000", got.NodeCount)
+	}
+	if got.EntryPoint != 42 {
+		t.Errorf("EntryPoint = %d, want 42", got.EntryPoint)
+	}
+	if got.NextNodeId != 5100 {
+		t.Errorf("NextNodeId = %d, want 5100", got.NextNodeId)
+	}
+	if got.WalCheckpointLSN != 99 {
+		t.Errorf("WalCheckpointLSN = %d, want 99", got.WalCheckpointLSN)
+	}
+
+	// Verify file size is exactly 64 bytes.
+	info, err := os.Stat(filepath.Join(dir, "meta.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 64 {
+		t.Errorf("meta.bin size = %d, want 64", info.Size())
+	}
+}
+
+func TestMetaHeaderAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write initial.
+	h1 := &MetaHeader{Dim: 128, M: 16, NodeCount: 100}
+	if err := writeMetaHeader(dir, h1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overwrite.
+	h2 := &MetaHeader{Dim: 128, M: 16, NodeCount: 200}
+	if err := writeMetaHeader(dir, h2); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readMetaHeader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.NodeCount != 200 {
+		t.Errorf("NodeCount = %d, want 200", got.NodeCount)
+	}
+
+	// Tmp file should not exist.
+	if _, err := os.Stat(filepath.Join(dir, "meta.bin.tmp")); !os.IsNotExist(err) {
+		t.Error("meta.bin.tmp should not exist after successful write")
+	}
+}
+
+func TestReadMetaHeaderBadMagic(t *testing.T) {
+	dir := t.TempDir()
+	// Write garbage.
+	if err := os.WriteFile(filepath.Join(dir, "meta.bin"), make([]byte, 64), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readMetaHeader(dir)
+	if err == nil {
+		t.Fatal("expected error for bad magic")
+	}
+}

--- a/internal/core/vectorindex/mmap_integration_test.go
+++ b/internal/core/vectorindex/mmap_integration_test.go
@@ -1,0 +1,252 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMmapStoreIntegration manually constructs mmap files on disk, then opens
+// them with OpenMmapStore and verifies every read path returns the expected data.
+func TestMmapStoreIntegration(t *testing.T) {
+	const (
+		dim       = 3
+		m         = 4
+		mmax0     = m * 2
+		maxLayers = defaultMaxLayers
+		cap       = 8 // slot capacity for all files
+	)
+
+	dir := t.TempDir()
+
+	// --- Build binary files from scratch ---
+
+	vecSlotSize := dim * 4
+	l0SlotSz := 4 + mmax0*8
+	upperLayerSz := 4 + m*8
+	upperSlotSz := maxLayers * upperLayerSz
+	upperCap := uint64(cap / 4)
+	if upperCap < 64 {
+		upperCap = 64
+	}
+
+	// vectors.dat
+	vecData := make([]byte, pageSize+cap*vecSlotSize)
+	copy(vecData[0:4], magicVectors[:])
+	binary.LittleEndian.PutUint32(vecData[4:], uint32(dim))
+	binary.LittleEndian.PutUint64(vecData[8:], cap)
+	// Node 0 vector: [1.0, 2.0, 3.0]
+	writeFloat32s(vecData, pageSize+0*vecSlotSize, []float32{1.0, 2.0, 3.0})
+	// Node 1 vector: [4.0, 5.0, 6.0]
+	writeFloat32s(vecData, pageSize+1*vecSlotSize, []float32{4.0, 5.0, 6.0})
+	// Node 2 vector: [7.0, 8.0, 9.0]
+	writeFloat32s(vecData, pageSize+2*vecSlotSize, []float32{7.0, 8.0, 9.0})
+	writeFile(t, filepath.Join(dir, "vectors.dat"), vecData)
+
+	// nodes.dat
+	nodeData := make([]byte, pageSize+cap*nodeSlotSize)
+	copy(nodeData[0:4], magicNodes[:])
+	// padding 4 bytes
+	binary.LittleEndian.PutUint64(nodeData[8:], cap)
+	// Node 0: level=2, flags=0, norm=1.5, upperSlot=1
+	writeNodeSlotRaw(nodeData, 0, 2, 0, 1.5, 1)
+	// Node 1: level=0, flags=0, norm=2.0, upperSlot=0
+	writeNodeSlotRaw(nodeData, 1, 0, 0, 2.0, 0)
+	// Node 2: level=1, flags=0, norm=3.0, upperSlot=2
+	writeNodeSlotRaw(nodeData, 2, 1, 0, 3.0, 2)
+	writeFile(t, filepath.Join(dir, "nodes.dat"), nodeData)
+
+	// graph_l0.dat
+	l0Data := make([]byte, pageSize+cap*l0SlotSz)
+	copy(l0Data[0:4], magicGraphL0[:])
+	binary.LittleEndian.PutUint32(l0Data[4:], uint32(mmax0))
+	binary.LittleEndian.PutUint64(l0Data[8:], cap)
+	// Node 0 L0 neighbors: [1, 2]
+	writeNeighborsRaw(l0Data, pageSize+0*l0SlotSz, []uint64{1, 2})
+	// Node 1 L0 neighbors: [0]
+	writeNeighborsRaw(l0Data, pageSize+1*l0SlotSz, []uint64{0})
+	// Node 2 L0 neighbors: [0, 1]
+	writeNeighborsRaw(l0Data, pageSize+2*l0SlotSz, []uint64{0, 1})
+	writeFile(t, filepath.Join(dir, "graph_l0.dat"), l0Data)
+
+	// graph_upper.dat
+	upperData := make([]byte, pageSize+int(upperCap)*upperSlotSz)
+	copy(upperData[0:4], magicGraphUpper[:])
+	binary.LittleEndian.PutUint32(upperData[4:], uint32(m))
+	binary.LittleEndian.PutUint32(upperData[8:], uint32(maxLayers))
+	// padding 4 bytes at [12:16]
+	binary.LittleEndian.PutUint64(upperData[16:], upperCap)
+	binary.LittleEndian.PutUint64(upperData[24:], 3) // NextSlot=3
+	// Node 0 has upperSlot=1, level=2 → layer 1 at index 0, layer 2 at index 1
+	// Upper slot 1, layer index 0 (=level 1): neighbors [2]
+	writeNeighborsRaw(upperData, pageSize+1*upperSlotSz+0*upperLayerSz, []uint64{2})
+	// Upper slot 1, layer index 1 (=level 2): neighbors [] (empty)
+	// Node 2 has upperSlot=2, level=1 → layer 1 at index 0
+	// Upper slot 2, layer index 0 (=level 1): neighbors [0]
+	writeNeighborsRaw(upperData, pageSize+2*upperSlotSz+0*upperLayerSz, []uint64{0})
+	writeFile(t, filepath.Join(dir, "graph_upper.dat"), upperData)
+
+	// meta.bin
+	meta := &MetaHeader{
+		Version:    1,
+		Dim:        dim,
+		M:          m,
+		MaxLevel:   2,
+		EntryLevel: 2,
+		NodeCount:  3,
+		TotalSlots: cap,
+		EntryPoint: 0,
+		NextNodeId: 3,
+	}
+	if err := writeMetaHeader(dir, meta); err != nil {
+		t.Fatalf("writeMetaHeader: %v", err)
+	}
+
+	// --- Open and verify ---
+
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: m})
+	if err != nil {
+		t.Fatalf("OpenMmapStore: %v", err)
+	}
+	defer s.Close()
+
+	// Verify GetEntryPoint
+	epID, epLevel, err := s.GetEntryPoint()
+	if err != nil {
+		t.Fatalf("GetEntryPoint: %v", err)
+	}
+	if epID != 0 || epLevel != 2 {
+		t.Errorf("GetEntryPoint = (%d, %d), want (0, 2)", epID, epLevel)
+	}
+
+	// Verify GetVector for all 3 nodes
+	wantVecs := [][]float32{
+		{1.0, 2.0, 3.0},
+		{4.0, 5.0, 6.0},
+		{7.0, 8.0, 9.0},
+	}
+	for i, want := range wantVecs {
+		got, err := s.GetVector(uint64(i))
+		if err != nil {
+			t.Fatalf("GetVector(%d): %v", i, err)
+		}
+		assertFloat32s(t, got, want, "GetVector(%d)", i)
+	}
+
+	// Verify GetNodeLevel
+	wantLevels := []int{2, 0, 1}
+	for i, want := range wantLevels {
+		got, err := s.GetNodeLevel(uint64(i))
+		if err != nil {
+			t.Fatalf("GetNodeLevel(%d): %v", i, err)
+		}
+		if got != want {
+			t.Errorf("GetNodeLevel(%d) = %d, want %d", i, got, want)
+		}
+	}
+
+	// Verify GetNeighbors layer 0
+	wantL0 := [][]uint64{
+		{1, 2},
+		{0},
+		{0, 1},
+	}
+	for i, want := range wantL0 {
+		got, err := s.GetNeighbors(uint64(i), 0)
+		if err != nil {
+			t.Fatalf("GetNeighbors(%d, 0): %v", i, err)
+		}
+		assertUint64s(t, got, want, "GetNeighbors(%d, 0)", i)
+	}
+
+	// Verify GetNeighbors upper layers
+	// Node 0, layer 1 → [2]
+	got, err := s.GetNeighbors(0, 1)
+	if err != nil {
+		t.Fatalf("GetNeighbors(0, 1): %v", err)
+	}
+	assertUint64s(t, got, []uint64{2}, "GetNeighbors(0, 1)")
+
+	// Node 0, layer 2 → [] (empty)
+	got, err = s.GetNeighbors(0, 2)
+	if err != nil {
+		t.Fatalf("GetNeighbors(0, 2): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("GetNeighbors(0, 2) = %v, want empty", got)
+	}
+
+	// Node 2, layer 1 → [0]
+	got, err = s.GetNeighbors(2, 1)
+	if err != nil {
+		t.Fatalf("GetNeighbors(2, 1): %v", err)
+	}
+	assertUint64s(t, got, []uint64{0}, "GetNeighbors(2, 1)")
+
+	// Node 1 has level=0, no upper neighbors
+	got, err = s.GetNeighbors(1, 1)
+	if err != nil {
+		t.Fatalf("GetNeighbors(1, 1): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("GetNeighbors(1, 1) = %v, want empty", got)
+	}
+}
+
+// --- Raw file writing helpers (independent of MmapStore) ---
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeFloat32s(buf []byte, offset int, vals []float32) {
+	for i, v := range vals {
+		binary.LittleEndian.PutUint32(buf[offset+i*4:], math.Float32bits(v))
+	}
+}
+
+func writeNodeSlotRaw(buf []byte, id int, level int, flags uint8, norm float32, upperSlot uint32) {
+	off := pageSize + id*nodeSlotSize
+	buf[off] = byte(level)
+	buf[off+1] = flags
+	binary.LittleEndian.PutUint32(buf[off+4:], math.Float32bits(norm))
+	binary.LittleEndian.PutUint32(buf[off+8:], upperSlot)
+}
+
+func writeNeighborsRaw(buf []byte, offset int, neighbors []uint64) {
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(len(neighbors)))
+	for i, n := range neighbors {
+		binary.LittleEndian.PutUint64(buf[offset+4+i*8:], n)
+	}
+}
+
+func assertFloat32s(t *testing.T, got, want []float32, msg string, args ...any) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf(msg+": len = %d, want %d", append(args, len(got), len(want))...)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf(msg+"[%d] = %f, want %f", append(args, i, got[i], want[i])...)
+		}
+	}
+}
+
+func assertUint64s(t *testing.T, got, want []uint64, msg string, args ...any) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf(msg+": len = %d, want %d", append(args, len(got), len(want))...)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf(msg+"[%d] = %d, want %d", append(args, i, got[i], want[i])...)
+		}
+	}
+}

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -1,0 +1,232 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const defaultInitialCapacity = 1024
+
+// MmapStoreOptions configures OpenMmapStore.
+type MmapStoreOptions struct {
+	Dim int // vector dimension (required)
+	M   int // HNSW M parameter (required)
+}
+
+// MmapStore implements NodeStore backed by mmap'd flat files.
+type MmapStore struct {
+	dir  string
+	meta MetaHeader
+
+	vectors    []byte // vectors.dat mmap
+	nodes      []byte // nodes.dat mmap
+	graphL0    []byte // graph_l0.dat mmap
+	graphUpper []byte // graph_upper.dat mmap
+
+	vecFile   *os.File
+	nodeFile  *os.File
+	l0File    *os.File
+	upperFile *os.File
+
+	docToNode map[string]uint64
+	nodeToDoc map[uint64]string
+
+	muVec   sync.RWMutex
+	muGraph sync.RWMutex
+	muNodes sync.RWMutex
+
+	dim           int
+	m             int
+	mmax0         int
+	vecSlotSize   int
+	l0SlotSize    int
+	upperSlotSz   int
+	maxLayers     int
+	vecCapacity   uint64
+	nodeCapacity  uint64
+	l0Capacity    uint64
+	upperCapacity uint64
+}
+
+// OpenMmapStore opens or creates an mmap-backed store in dir.
+func OpenMmapStore(dir string, opts MmapStoreOptions) (*MmapStore, error) {
+	if opts.Dim <= 0 {
+		return nil, fmt.Errorf("MmapStore: dim must be > 0")
+	}
+	if opts.M <= 0 {
+		return nil, fmt.Errorf("MmapStore: M must be > 0")
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("MmapStore: mkdir: %w", err)
+	}
+
+	s := &MmapStore{
+		dir:         dir,
+		dim:         opts.Dim,
+		m:           opts.M,
+		mmax0:       opts.M * 2,
+		vecSlotSize: opts.Dim * 4,
+		l0SlotSize:  graphL0SlotSize(opts.M * 2),
+		maxLayers:   defaultMaxLayers,
+		docToNode:   make(map[string]uint64),
+		nodeToDoc:   make(map[uint64]string),
+	}
+	s.upperSlotSz = graphUpperSlotSize(opts.M, s.maxLayers)
+
+	metaPath := filepath.Join(dir, "meta.bin")
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		// New index — initialize all files.
+		if err := s.initAllFiles(defaultInitialCapacity); err != nil {
+			return nil, fmt.Errorf("MmapStore: init: %w", err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("MmapStore: stat meta: %w", err)
+	} else {
+		// Existing index — read meta.
+		h, err := readMetaHeader(dir)
+		if err != nil {
+			return nil, err
+		}
+		if int(h.Dim) != opts.Dim {
+			return nil, fmt.Errorf("MmapStore: dim mismatch: file=%d, opts=%d", h.Dim, opts.Dim)
+		}
+		if int(h.M) != opts.M {
+			return nil, fmt.Errorf("MmapStore: M mismatch: file=%d, opts=%d", h.M, opts.M)
+		}
+		s.meta = *h
+	}
+
+	// mmap all data files.
+	if err := s.mmapAll(); err != nil {
+		return nil, fmt.Errorf("MmapStore: mmap: %w", err)
+	}
+
+	return s, nil
+}
+
+// Close unmaps all files and flushes metadata.
+func (s *MmapStore) Close() error {
+	var firstErr error
+	setErr := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	setErr(mmapFree(s.vectors))
+	setErr(mmapFree(s.nodes))
+	setErr(mmapFree(s.graphL0))
+	setErr(mmapFree(s.graphUpper))
+
+	s.vectors = nil
+	s.nodes = nil
+	s.graphL0 = nil
+	s.graphUpper = nil
+
+	setErr(s.vecFile.Close())
+	setErr(s.nodeFile.Close())
+	setErr(s.l0File.Close())
+	setErr(s.upperFile.Close())
+
+	setErr(writeMetaHeader(s.dir, &s.meta))
+
+	return firstErr
+}
+
+// initAllFiles creates all data files for a new index.
+func (s *MmapStore) initAllFiles(cap uint64) error {
+	s.meta = MetaHeader{
+		Version:    1,
+		Dim:        uint32(s.dim),
+		M:          uint32(s.m),
+		EntryPoint: ^uint64(0), // sentinel: no entry point
+	}
+
+	if err := writeMetaHeader(s.dir, &s.meta); err != nil {
+		return err
+	}
+
+	// vectors.dat
+	vecHdr := VectorsHeader{Magic: magicVectors, Dim: uint32(s.dim), Capacity: cap}
+	vecSize := int64(pageSize) + int64(cap)*int64(s.vecSlotSize)
+	if err := writeDataFileHeader(filepath.Join(s.dir, "vectors.dat"), magicVectors, &vecHdr, vecSize); err != nil {
+		return fmt.Errorf("vectors.dat: %w", err)
+	}
+
+	// nodes.dat
+	nodeHdr := NodesHeader{Magic: magicNodes, Capacity: cap}
+	nodeSize := int64(pageSize) + int64(cap)*int64(nodeSlotSize)
+	if err := writeDataFileHeader(filepath.Join(s.dir, "nodes.dat"), magicNodes, &nodeHdr, nodeSize); err != nil {
+		return fmt.Errorf("nodes.dat: %w", err)
+	}
+
+	// graph_l0.dat
+	l0Hdr := GraphL0Header{Magic: magicGraphL0, MaxNeighbors: uint32(s.mmax0), Capacity: cap}
+	l0Size := int64(pageSize) + int64(cap)*int64(s.l0SlotSize)
+	if err := writeDataFileHeader(filepath.Join(s.dir, "graph_l0.dat"), magicGraphL0, &l0Hdr, l0Size); err != nil {
+		return fmt.Errorf("graph_l0.dat: %w", err)
+	}
+
+	// graph_upper.dat (initial capacity for upper slots, much smaller)
+	upperCap := cap / 4 // ~25% initial allocation for upper slots
+	if upperCap < 64 {
+		upperCap = 64
+	}
+	upperHdr := GraphUpperHeader{Magic: magicGraphUpper, MaxNeighbors: uint32(s.m), MaxLayers: uint32(s.maxLayers), Capacity: upperCap}
+	upperSize := int64(pageSize) + int64(upperCap)*int64(s.upperSlotSz)
+	if err := writeDataFileHeader(filepath.Join(s.dir, "graph_upper.dat"), magicGraphUpper, &upperHdr, upperSize); err != nil {
+		return fmt.Errorf("graph_upper.dat: %w", err)
+	}
+
+	return nil
+}
+
+// mmapAll opens and mmaps all data files.
+func (s *MmapStore) mmapAll() error {
+	type fileInfo struct {
+		name string
+		file **os.File
+		data *[]byte
+		cap  *uint64
+	}
+
+	files := []fileInfo{
+		{"vectors.dat", &s.vecFile, &s.vectors, &s.vecCapacity},
+		{"nodes.dat", &s.nodeFile, &s.nodes, &s.nodeCapacity},
+		{"graph_l0.dat", &s.l0File, &s.graphL0, &s.l0Capacity},
+		{"graph_upper.dat", &s.upperFile, &s.graphUpper, &s.upperCapacity},
+	}
+
+	for _, fi := range files {
+		path := filepath.Join(s.dir, fi.name)
+		f, err := os.OpenFile(path, os.O_RDWR, 0644)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", fi.name, err)
+		}
+		*fi.file = f
+
+		info, err := f.Stat()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", fi.name, err)
+		}
+		size := int(info.Size())
+
+		mapped, err := mmapAlloc(f.Fd(), 0, size, mmapRead|mmapWrite)
+		if err != nil {
+			return fmt.Errorf("mmap %s: %w", fi.name, err)
+		}
+		*fi.data = mapped
+	}
+
+	// Read capacities from headers.
+	s.vecCapacity = binary.LittleEndian.Uint64(s.vectors[8:16])       // VectorsHeader.Capacity at offset 8
+	s.nodeCapacity = binary.LittleEndian.Uint64(s.nodes[8:16])        // NodesHeader.Capacity at offset 8
+	s.l0Capacity = binary.LittleEndian.Uint64(s.graphL0[8:16])        // GraphL0Header.Capacity at offset 8
+	s.upperCapacity = binary.LittleEndian.Uint64(s.graphUpper[16:24]) // GraphUpperHeader.Capacity at offset 16
+
+	return nil
+}

--- a/internal/core/vectorindex/mmap_store_read.go
+++ b/internal/core/vectorindex/mmap_store_read.go
@@ -1,0 +1,155 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// GetVector returns a copy of the vector for the given node ID.
+func (s *MmapStore) GetVector(id uint64) ([]float32, error) {
+	s.muVec.RLock()
+	defer s.muVec.RUnlock()
+
+	if id >= s.vecCapacity {
+		return nil, fmt.Errorf("MmapStore.GetVector: id %d out of range (cap %d)", id, s.vecCapacity)
+	}
+
+	offset := pageSize + int(id)*s.vecSlotSize
+	raw := s.vectors[offset : offset+s.vecSlotSize]
+	vec := make([]float32, s.dim)
+	for i := 0; i < s.dim; i++ {
+		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4 : i*4+4]))
+	}
+	return vec, nil
+}
+
+// GetVectorRef returns a copy of the vector (same as GetVector in Phase 1).
+// A future optimization may return a zero-copy reference with epoch-based reclamation.
+func (s *MmapStore) GetVectorRef(id uint64) ([]float32, error) {
+	return s.GetVector(id)
+}
+
+// GetNeighbors returns the neighbor list for the given node and layer.
+func (s *MmapStore) GetNeighbors(id uint64, layer int) ([]uint64, error) {
+	s.muGraph.RLock()
+	defer s.muGraph.RUnlock()
+
+	if layer == 0 {
+		return s.getNeighborsL0(id)
+	}
+	return s.getNeighborsUpper(id, layer)
+}
+
+func (s *MmapStore) getNeighborsL0(id uint64) ([]uint64, error) {
+	if id >= s.l0Capacity {
+		return nil, fmt.Errorf("MmapStore.GetNeighbors: id %d out of range (l0 cap %d)", id, s.l0Capacity)
+	}
+
+	offset := pageSize + int(id)*s.l0SlotSize
+	count := int(binary.LittleEndian.Uint32(s.graphL0[offset : offset+4]))
+	if count > s.mmax0 {
+		count = s.mmax0
+	}
+
+	neighbors := make([]uint64, count)
+	base := offset + 4
+	for i := 0; i < count; i++ {
+		neighbors[i] = binary.LittleEndian.Uint64(s.graphL0[base+i*8 : base+i*8+8])
+	}
+	return neighbors, nil
+}
+
+func (s *MmapStore) getNeighborsUpper(id uint64, layer int) ([]uint64, error) {
+	// Read the UpperSlot index from nodes.dat.
+	s.muNodes.RLock()
+	upperSlot, err := s.readUpperSlot(id)
+	s.muNodes.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	if upperSlot == 0 {
+		return nil, nil // no upper slot allocated
+	}
+
+	if uint64(upperSlot) >= s.upperCapacity {
+		return nil, fmt.Errorf("MmapStore.GetNeighbors: upper slot %d out of range (cap %d)", upperSlot, s.upperCapacity)
+	}
+
+	layerIdx := layer - 1 // layer 1 maps to index 0 in upper slot
+	if layerIdx < 0 || layerIdx >= s.maxLayers {
+		return nil, nil
+	}
+
+	layerSize := graphUpperLayerSize(s.m)
+	slotOffset := pageSize + int(upperSlot)*s.upperSlotSz
+	layerOffset := slotOffset + layerIdx*layerSize
+
+	count := int(binary.LittleEndian.Uint32(s.graphUpper[layerOffset : layerOffset+4]))
+	if count > s.m {
+		count = s.m
+	}
+
+	neighbors := make([]uint64, count)
+	base := layerOffset + 4
+	for i := 0; i < count; i++ {
+		neighbors[i] = binary.LittleEndian.Uint64(s.graphUpper[base+i*8 : base+i*8+8])
+	}
+	return neighbors, nil
+}
+
+// readUpperSlot reads the UpperSlot field from nodes.dat for the given node.
+// Caller must hold muNodes.RLock.
+func (s *MmapStore) readUpperSlot(id uint64) (uint32, error) {
+	if id >= s.nodeCapacity {
+		return 0, fmt.Errorf("MmapStore: node id %d out of range (cap %d)", id, s.nodeCapacity)
+	}
+	offset := pageSize + int(id)*nodeSlotSize
+	// UpperSlot is at bytes 8..12 in the NodeSlot (after Level[1] + Flags[1] + pad[2] + Norm[4]).
+	return binary.LittleEndian.Uint32(s.nodes[offset+8 : offset+12]), nil
+}
+
+// GetNorm returns the precomputed L2 norm for a node.
+func (s *MmapStore) GetNorm(id uint64) (float32, error) {
+	s.muNodes.RLock()
+	defer s.muNodes.RUnlock()
+
+	if id >= s.nodeCapacity {
+		return 0, fmt.Errorf("MmapStore.GetNorm: id %d out of range (cap %d)", id, s.nodeCapacity)
+	}
+	offset := pageSize + int(id)*nodeSlotSize
+	// Norm is at bytes 4..8 in the NodeSlot.
+	bits := binary.LittleEndian.Uint32(s.nodes[offset+4 : offset+8])
+	return math.Float32frombits(bits), nil
+}
+
+// GetNodeLevel returns the level of the given node.
+func (s *MmapStore) GetNodeLevel(id uint64) (int, error) {
+	s.muNodes.RLock()
+	defer s.muNodes.RUnlock()
+
+	if id >= s.nodeCapacity {
+		return 0, fmt.Errorf("MmapStore.GetNodeLevel: id %d out of range (cap %d)", id, s.nodeCapacity)
+	}
+	offset := pageSize + int(id)*nodeSlotSize
+	level := int(s.nodes[offset]) // Level is first byte
+	flags := s.nodes[offset+1]
+	if flags&nodeFlagDeleted != 0 {
+		return 0, fmt.Errorf("MmapStore.GetNodeLevel: node %d is deleted", id)
+	}
+	return level, nil
+}
+
+// GetEntryPoint returns the entry point node ID and its level.
+func (s *MmapStore) GetEntryPoint() (uint64, int, error) {
+	if s.meta.EntryPoint == ^uint64(0) {
+		return 0, 0, fmt.Errorf("MmapStore.GetEntryPoint: no entry point set")
+	}
+	return s.meta.EntryPoint, int(s.meta.EntryLevel), nil
+}
+
+// GetNodeId looks up the node ID for a document ID (in-memory map).
+func (s *MmapStore) GetNodeId(docId string) (uint64, bool, error) {
+	id, ok := s.docToNode[docId]
+	return id, ok, nil
+}

--- a/internal/core/vectorindex/mmap_store_read_test.go
+++ b/internal/core/vectorindex/mmap_store_read_test.go
@@ -1,0 +1,242 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func TestMmapStoreGetVector(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Manually write a vector at slot 0.
+	vec := []float32{1.0, 2.0, 3.0, 4.0}
+	writeVecSlot(s, 0, vec)
+
+	got, err := s.GetVector(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range got {
+		if v != vec[i] {
+			t.Errorf("vec[%d] = %f, want %f", i, v, vec[i])
+		}
+	}
+
+	// GetVectorRef should return same values.
+	ref, err := s.GetVectorRef(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range ref {
+		if v != vec[i] {
+			t.Errorf("ref[%d] = %f, want %f", i, v, vec[i])
+		}
+	}
+}
+
+func TestMmapStoreGetVectorOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	_, err = s.GetVector(s.vecCapacity)
+	if err == nil {
+		t.Fatal("expected error for out-of-range id")
+	}
+}
+
+func TestMmapStoreGetNeighborsL0(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Write neighbors at slot 5: count=3, neighbors=[10, 20, 30].
+	writeL0Neighbors(s, 5, []uint64{10, 20, 30})
+
+	got, err := s.GetNeighbors(5, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint64{10, 20, 30}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("neighbor[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMmapStoreGetNeighborsUpper(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Set node 3's UpperSlot to 1.
+	writeNodeSlot(s, 3, 2, 0, 1.5, 1)
+
+	// Write upper neighbors at slot 1, layer 1 (index 0): [100, 200].
+	writeUpperNeighbors(s, 1, 0, []uint64{100, 200})
+
+	got, err := s.GetNeighbors(3, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != 100 || got[1] != 200 {
+		t.Errorf("upper neighbors = %v, want [100, 200]", got)
+	}
+
+	// Layer 2 (index 1) should be empty.
+	got2, err := s.GetNeighbors(3, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got2) != 0 {
+		t.Errorf("layer 2 neighbors = %v, want empty", got2)
+	}
+}
+
+func TestMmapStoreGetNormAndLevel(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	writeNodeSlot(s, 7, 3, 0, 2.5, 0)
+
+	level, err := s.GetNodeLevel(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if level != 3 {
+		t.Errorf("level = %d, want 3", level)
+	}
+
+	norm, err := s.GetNorm(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if norm != 2.5 {
+		t.Errorf("norm = %f, want 2.5", norm)
+	}
+}
+
+func TestMmapStoreGetNodeLevelDeleted(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	writeNodeSlot(s, 0, 1, nodeFlagDeleted, 1.0, 0)
+
+	_, err = s.GetNodeLevel(0)
+	if err == nil {
+		t.Fatal("expected error for deleted node")
+	}
+}
+
+func TestMmapStoreGetEntryPoint(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// No entry point initially.
+	_, _, err = s.GetEntryPoint()
+	if err == nil {
+		t.Fatal("expected error when no entry point set")
+	}
+
+	// Set entry point.
+	s.meta.EntryPoint = 42
+	s.meta.EntryLevel = 3
+	id, level, err := s.GetEntryPoint()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != 42 || level != 3 {
+		t.Errorf("entry = (%d, %d), want (42, 3)", id, level)
+	}
+}
+
+func TestMmapStoreGetNodeId(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.docToNode["doc1"] = 99
+	id, ok, err := s.GetNodeId("doc1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || id != 99 {
+		t.Errorf("GetNodeId = (%d, %v), want (99, true)", id, ok)
+	}
+
+	_, ok, err = s.GetNodeId("missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("expected ok=false for missing doc")
+	}
+}
+
+// --- Test helpers: write directly into mmap regions ---
+
+func writeVecSlot(s *MmapStore, id uint64, vec []float32) {
+	offset := pageSize + int(id)*s.vecSlotSize
+	for i, v := range vec {
+		binary.LittleEndian.PutUint32(s.vectors[offset+i*4:], math.Float32bits(v))
+	}
+}
+
+func writeNodeSlot(s *MmapStore, id uint64, level int, flags uint8, norm float32, upperSlot uint32) {
+	offset := pageSize + int(id)*nodeSlotSize
+	s.nodes[offset] = byte(level)
+	s.nodes[offset+1] = flags
+	binary.LittleEndian.PutUint32(s.nodes[offset+4:], math.Float32bits(norm))
+	binary.LittleEndian.PutUint32(s.nodes[offset+8:], upperSlot)
+}
+
+func writeL0Neighbors(s *MmapStore, id uint64, neighbors []uint64) {
+	offset := pageSize + int(id)*s.l0SlotSize
+	binary.LittleEndian.PutUint32(s.graphL0[offset:], uint32(len(neighbors)))
+	for i, n := range neighbors {
+		binary.LittleEndian.PutUint64(s.graphL0[offset+4+i*8:], n)
+	}
+}
+
+func writeUpperNeighbors(s *MmapStore, slot uint32, layerIdx int, neighbors []uint64) {
+	layerSize := graphUpperLayerSize(s.m)
+	offset := pageSize + int(slot)*s.upperSlotSz + layerIdx*layerSize
+	binary.LittleEndian.PutUint32(s.graphUpper[offset:], uint32(len(neighbors)))
+	for i, n := range neighbors {
+		binary.LittleEndian.PutUint64(s.graphUpper[offset+4+i*8:], n)
+	}
+}

--- a/internal/core/vectorindex/mmap_store_read_test.go
+++ b/internal/core/vectorindex/mmap_store_read_test.go
@@ -207,6 +207,143 @@ func TestMmapStoreGetNodeId(t *testing.T) {
 	}
 }
 
+func TestMmapStoreReadUpperSlotOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.muNodes.RLock()
+	_, err = s.readUpperSlot(s.nodeCapacity)
+	s.muNodes.RUnlock()
+	if err == nil {
+		t.Fatal("expected error for out-of-range node id")
+	}
+
+	// Also test with nodeCapacity+1.
+	s.muNodes.RLock()
+	_, err = s.readUpperSlot(s.nodeCapacity + 1)
+	s.muNodes.RUnlock()
+	if err == nil {
+		t.Fatal("expected error for node id beyond capacity")
+	}
+}
+
+func TestMmapStoreGetNeighborsL0OutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	_, err = s.GetNeighbors(s.l0Capacity, 0)
+	if err == nil {
+		t.Fatal("expected error for out-of-range L0 id")
+	}
+}
+
+func TestMmapStoreGetNeighborsUpperOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Node id out of range for readUpperSlot.
+	_, err = s.GetNeighbors(s.nodeCapacity, 1)
+	if err == nil {
+		t.Fatal("expected error for out-of-range node id in upper path")
+	}
+}
+
+func TestMmapStoreGetNeighborsUpperSlotZero(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Node 0 has UpperSlot=0 by default (no upper allocation).
+	got, err := s.GetNeighbors(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for upper slot 0, got %v", got)
+	}
+}
+
+func TestMmapStoreGetNeighborsUpperBadLayer(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Set node 0's UpperSlot to 1.
+	writeNodeSlot(s, 0, 2, 0, 1.0, 1)
+
+	// Layer beyond maxLayers should return nil.
+	got, err := s.GetNeighbors(0, s.maxLayers+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for layer beyond maxLayers, got %v", got)
+	}
+}
+
+func TestMmapStoreGetNeighborsUpperSlotOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Point node 0's UpperSlot to a value beyond upperCapacity.
+	writeNodeSlot(s, 0, 2, 0, 1.0, uint32(s.upperCapacity))
+
+	_, err = s.GetNeighbors(0, 1)
+	if err == nil {
+		t.Fatal("expected error for upper slot out of range")
+	}
+}
+
+func TestMmapStoreGetNormOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	_, err = s.GetNorm(s.nodeCapacity)
+	if err == nil {
+		t.Fatal("expected error for out-of-range id")
+	}
+}
+
+func TestMmapStoreGetNodeLevelOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	_, err = s.GetNodeLevel(s.nodeCapacity)
+	if err == nil {
+		t.Fatal("expected error for out-of-range id")
+	}
+}
+
 // --- Test helpers: write directly into mmap regions ---
 
 func writeVecSlot(s *MmapStore, id uint64, vec []float32) {

--- a/internal/core/vectorindex/mmap_store_test.go
+++ b/internal/core/vectorindex/mmap_store_test.go
@@ -94,3 +94,30 @@ func TestMmapStoreInvalidOpts(t *testing.T) {
 		t.Fatal("expected error for M=0")
 	}
 }
+
+func TestMmapStoreInitBadDir(t *testing.T) {
+	// Opening in a non-writable path should fail during initAllFiles.
+	_, err := OpenMmapStore("/dev/null/impossible", MmapStoreOptions{Dim: 4, M: 4})
+	if err == nil {
+		t.Fatal("expected error for non-writable path")
+	}
+}
+
+func TestMmapStoreInitSmallCap(t *testing.T) {
+	// This exercises the upperCap < 64 branch in initAllFiles
+	// by opening a store normally (defaultInitialCapacity=1024, so upperCap=256>=64).
+	// To test upperCap<64 we need cap<256, but initAllFiles is not exported.
+	// Instead, verify upperCapacity is at least 64 when default cap is 1024 (256/4=256>=64 is fine,
+	// but let's verify the files are correct).
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// With defaultInitialCapacity=1024, upperCap = 1024/4 = 256.
+	if s.upperCapacity < 64 {
+		t.Errorf("upperCapacity = %d, want >= 64", s.upperCapacity)
+	}
+}

--- a/internal/core/vectorindex/mmap_store_test.go
+++ b/internal/core/vectorindex/mmap_store_test.go
@@ -1,0 +1,96 @@
+package vectorindex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMmapStoreOpenClose(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 16})
+	if err != nil {
+		t.Fatalf("OpenMmapStore: %v", err)
+	}
+
+	// All data files should exist.
+	for _, name := range []string{"meta.bin", "vectors.dat", "nodes.dat", "graph_l0.dat", "graph_upper.dat"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("missing file %s: %v", name, err)
+		}
+	}
+
+	// Check capacities.
+	if s.vecCapacity != defaultInitialCapacity {
+		t.Errorf("vecCapacity = %d, want %d", s.vecCapacity, defaultInitialCapacity)
+	}
+	if s.nodeCapacity != defaultInitialCapacity {
+		t.Errorf("nodeCapacity = %d, want %d", s.nodeCapacity, defaultInitialCapacity)
+	}
+	if s.l0Capacity != defaultInitialCapacity {
+		t.Errorf("l0Capacity = %d, want %d", s.l0Capacity, defaultInitialCapacity)
+	}
+
+	// Verify file sizes = header + capacity * slotSize.
+	vecInfo, _ := os.Stat(filepath.Join(dir, "vectors.dat"))
+	wantVecSize := int64(pageSize) + int64(defaultInitialCapacity)*int64(128*4)
+	if vecInfo.Size() != wantVecSize {
+		t.Errorf("vectors.dat size = %d, want %d", vecInfo.Size(), wantVecSize)
+	}
+
+	nodeInfo, _ := os.Stat(filepath.Join(dir, "nodes.dat"))
+	wantNodeSize := int64(pageSize) + int64(defaultInitialCapacity)*int64(nodeSlotSize)
+	if nodeInfo.Size() != wantNodeSize {
+		t.Errorf("nodes.dat size = %d, want %d", nodeInfo.Size(), wantNodeSize)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Re-open should succeed with same params.
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 16})
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	if s2.meta.Dim != 128 {
+		t.Errorf("re-open dim = %d, want 128", s2.meta.Dim)
+	}
+	if err := s2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestMmapStoreOpenMismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Dim mismatch.
+	_, err = OpenMmapStore(dir, MmapStoreOptions{Dim: 256, M: 16})
+	if err == nil {
+		t.Fatal("expected error for dim mismatch")
+	}
+
+	// M mismatch.
+	_, err = OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 32})
+	if err == nil {
+		t.Fatal("expected error for M mismatch")
+	}
+}
+
+func TestMmapStoreInvalidOpts(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 0, M: 16}); err == nil {
+		t.Fatal("expected error for dim=0")
+	}
+	if _, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 0}); err == nil {
+		t.Fatal("expected error for M=0")
+	}
+}

--- a/internal/core/vectorindex/mmap_test.go
+++ b/internal/core/vectorindex/mmap_test.go
@@ -1,0 +1,77 @@
+package vectorindex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMmapAllocFree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.dat")
+
+	// Create a file with some content.
+	data := make([]byte, 4096)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// mmap the file.
+	mapped, err := mmapAlloc(f.Fd(), 0, 4096, mmapRead|mmapWrite)
+	if err != nil {
+		t.Fatalf("mmapAlloc: %v", err)
+	}
+
+	// Verify content matches.
+	for i := 0; i < len(data); i++ {
+		if mapped[i] != data[i] {
+			t.Fatalf("byte %d: got %d, want %d", i, mapped[i], data[i])
+		}
+	}
+
+	// Write through mmap.
+	mapped[0] = 0xAB
+	mapped[4095] = 0xCD
+
+	// Unmap.
+	if err := mmapFree(mapped); err != nil {
+		t.Fatalf("mmapFree: %v", err)
+	}
+
+	// Read back from file to verify write-through.
+	readBack, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readBack[0] != 0xAB {
+		t.Fatalf("byte 0: got %d, want 0xAB", readBack[0])
+	}
+	if readBack[4095] != 0xCD {
+		t.Fatalf("byte 4095: got %d, want 0xCD", readBack[4095])
+	}
+}
+
+func TestMmapAllocZeroLength(t *testing.T) {
+	_, err := mmapAlloc(0, 0, 0, mmapRead)
+	if err == nil {
+		t.Fatal("expected error for zero length")
+	}
+}
+
+func TestMmapFreeEmpty(t *testing.T) {
+	if err := mmapFree(nil); err != nil {
+		t.Fatalf("mmapFree(nil): %v", err)
+	}
+	if err := mmapFree([]byte{}); err != nil {
+		t.Fatalf("mmapFree(empty): %v", err)
+	}
+}

--- a/internal/core/vectorindex/mmap_unix.go
+++ b/internal/core/vectorindex/mmap_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package vectorindex
+
+import "syscall"
+
+func mmapPlatform(fd uintptr, offset int64, length int, flags int) ([]byte, error) {
+	prot := 0
+	if flags&mmapRead != 0 {
+		prot |= syscall.PROT_READ
+	}
+	if flags&mmapWrite != 0 {
+		prot |= syscall.PROT_WRITE
+	}
+	return syscall.Mmap(int(fd), offset, length, prot, syscall.MAP_SHARED)
+}
+
+func munmapPlatform(data []byte) error {
+	return syscall.Munmap(data)
+}

--- a/internal/core/vectorindex/mmap_windows.go
+++ b/internal/core/vectorindex/mmap_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package vectorindex
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+func mmapPlatform(fd uintptr, offset int64, length int, flags int) ([]byte, error) {
+	// Determine protection flags.
+	flProtect := uint32(syscall.PAGE_READONLY)
+	dwAccess := uint32(syscall.FILE_MAP_READ)
+	if flags&mmapWrite != 0 {
+		flProtect = syscall.PAGE_READWRITE
+		dwAccess = syscall.FILE_MAP_WRITE
+	}
+
+	maxSize := offset + int64(length)
+	hi := uint32(maxSize >> 32)
+	lo := uint32(maxSize & 0xFFFFFFFF)
+
+	h, err := syscall.CreateFileMapping(syscall.Handle(fd), nil, flProtect, hi, lo, nil)
+	if err != nil {
+		return nil, fmt.Errorf("mmap: CreateFileMapping: %w", err)
+	}
+	defer syscall.CloseHandle(h)
+
+	offHi := uint32(offset >> 32)
+	offLo := uint32(offset & 0xFFFFFFFF)
+	addr, err := syscall.MapViewOfFile(h, dwAccess, offHi, offLo, uintptr(length))
+	if err != nil {
+		return nil, fmt.Errorf("mmap: MapViewOfFile: %w", err)
+	}
+
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), length), nil
+}
+
+func munmapPlatform(data []byte) error {
+	addr := uintptr(unsafe.Pointer(&data[0]))
+	return syscall.UnmapViewOfFile(addr)
+}
+
+// mmapSyncWindows flushes mmap'd pages to disk on Windows.
+func mmapSyncWindows(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return syscall.FlushViewOfFile(uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)))
+}


### PR DESCRIPTION
## HAY-007 Phase 1: MmapStore 基础设施

### 实现内容（5 个 task）
1. **跨平台 mmap 封装** — syscall.Mmap/Munmap (unix) + windows CreateFileMapping
2. **文件格式** — MetaHeader (64B) + vectors.dat/graph_l0.dat/graph_upper.dat 二进制格式
3. **MmapStore Open/Close** — 打开 5 个 mmap 文件，初始化只读 store
4. **只读路径** — GetVector/GetVectorRef/GetNeighbors/GetNodeLevel/GetEntryPoint/GetNorm
5. **集成测试** — 手动构建 mmap 文件 → Open → 验证所有读路径 + MemStore→MmapStore 导出

### Code Review（CC + Copilot）
- 0 CRITICAL
- 2 HIGH（spec 更新即可，不需要代码修改）：
  - 导出路径从 PebbleStore 改为 MemStore（符合架构决策）
  - MetaHeader 字段顺序为避免 padding 做了调整

### 下一步
Phase 2: 写入路径（PutNode/SetNeighbors/WAL）