### PR TITLE
perf(vectorindex): speed up HNSW hot paths — make coverage 42s → 32s

### DIFF
--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -881,14 +881,9 @@ func BenchmarkMmapStoreGetVector(b *testing.B) {
 	}
 
 	dir := b.TempDir()
-	err := ExportMemStoreToMmap(store, 1000, 128, dir)
+	ms, err := exportMemStoreToMmap(store, dir, 128, 16)
 	if err != nil {
 		b.Fatalf("export: %v", err)
-	}
-
-	ms, err := OpenMmapStore(dir, 128)
-	if err != nil {
-		b.Fatalf("open: %v", err)
 	}
 	defer ms.Close()
 

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -543,7 +543,10 @@ func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 		return nil, err
 	}
 
-	visited := map[uint64]bool{entryId: true}
+	visited := visitedPool.Get().(*visitedSet)
+	visited.begin()
+	defer visitedPool.Put(visited)
+	visited.mark(entryId)
 
 	// candidates: min-heap (closest first)
 	cands := &minDistHeap{}
@@ -568,10 +571,10 @@ func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 		}
 
 		for _, nbId := range neighbors {
-			if visited[nbId] {
+			if visited.seen(nbId) {
 				continue
 			}
-			visited[nbId] = true
+			visited.mark(nbId)
 
 			nbDist, err := h.nodeDistCalc(nbId, query, queryNorm)
 			if err != nil {
@@ -611,84 +614,88 @@ func (h *HNSWIndex) selectNeighborsHeuristic(query []float32, candidates []distI
 	// Sort candidates by distance to query.
 	sortDistItems(candidates)
 
-	// Build vector cache from store if not provided.
-	if vecCache == nil {
-		vecCache = make(map[uint64][]float32, len(candidates))
-		for _, c := range candidates {
-			v, err := h.store.GetVectorRef(c.id)
-			if err == nil {
-				vecCache[c.id] = v
-			}
+	// Resolve each candidate's vector (and norm) once into position-indexed
+	// slices. The diversity loop below is O(candidates*selected); reading from
+	// these slices instead of id-keyed maps removes the map hashing that
+	// dominated the insert CPU profile. vecs[i]/norms[i] correspond to the
+	// just-sorted candidates[i]. A nil vecs[i] means the vector was
+	// unavailable; norms[i] < 0 means the norm was unavailable (mirroring the
+	// previous "missing from cache" checks).
+	n := len(candidates)
+	vecs := make([][]float32, n)
+	for i, c := range candidates {
+		if vecCache != nil {
+			vecs[i] = vecCache[c.id]
+		} else if v, err := h.store.GetVectorRef(c.id); err == nil {
+			vecs[i] = v
 		}
 	}
-
-	// Pre-load norms for cosine distance optimization.
-	var normCache map[uint64]float32
+	var norms []float32
 	if h.isCosine {
-		normCache = make(map[uint64]float32, len(candidates))
-		for _, c := range candidates {
-			if n, err := h.store.GetNorm(c.id); err == nil {
-				normCache[c.id] = n
+		norms = make([]float32, n)
+		for i, c := range candidates {
+			if nrm, err := h.store.GetNorm(c.id); err == nil {
+				norms[i] = nrm
+			} else {
+				norms[i] = -1 // sentinel: norm unavailable
 			}
 		}
 	}
 
-	selected := make([]distItem, 0, m)
-	for _, c := range candidates {
+	selected := make([]int, 0, m) // indices into candidates/vecs/norms
+	for i := range candidates {
 		if len(selected) >= m {
 			break
 		}
-		// Check if c is closer to query than to any already-selected neighbor.
-		good := true
-		cVec, ok := vecCache[c.id]
-		if !ok {
+		cVec := vecs[i]
+		if cVec == nil {
 			continue
 		}
-		for _, s := range selected {
-			sVec, ok := vecCache[s.id]
-			if !ok {
+		// Check if c is closer to query than to any already-selected neighbor.
+		good := true
+		for _, sIdx := range selected {
+			sVec := vecs[sIdx]
+			if sVec == nil {
 				continue
 			}
 			var dist float32
-			if h.isCosine {
-				cNorm, cOk := normCache[c.id]
-				sNorm, sOk := normCache[s.id]
-				if cOk && sOk {
-					dist = CosineDistanceWithNorms(cVec, sVec, cNorm, sNorm)
-				} else {
-					dist = h.distance(cVec, sVec)
-				}
+			if h.isCosine && norms[i] >= 0 && norms[sIdx] >= 0 {
+				dist = CosineDistanceWithNorms(cVec, sVec, norms[i], norms[sIdx])
 			} else {
 				dist = h.distance(cVec, sVec)
 			}
-			if dist < c.dist {
+			if dist < candidates[i].dist {
 				good = false
 				break
 			}
 		}
 		if good {
-			selected = append(selected, c)
+			selected = append(selected, i)
 		}
 	}
 
 	// If we didn't get enough from heuristic, fill from remaining by distance.
 	if len(selected) < m {
-		selectedSet := make(map[uint64]bool, len(selected))
-		for _, s := range selected {
-			selectedSet[s.id] = true
+		inSel := make([]bool, n)
+		for _, idx := range selected {
+			inSel[idx] = true
 		}
-		for _, c := range candidates {
+		for i := range candidates {
 			if len(selected) >= m {
 				break
 			}
-			if !selectedSet[c.id] {
-				selected = append(selected, c)
-				selectedSet[c.id] = true
+			if !inSel[i] {
+				selected = append(selected, i)
+				inSel[i] = true
 			}
 		}
 	}
 
-	return selected
+	out := make([]distItem, len(selected))
+	for j, idx := range selected {
+		out[j] = candidates[idx]
+	}
+	return out
 }
 
 // nodeDistance computes distance between a stored node and a query vector.
@@ -739,6 +746,54 @@ func removeId(ids []uint64, target uint64) []uint64 {
 type distItem struct {
 	id   uint64
 	dist float32
+}
+
+// visitedSet is a reusable, allocation-free set of node IDs based on version
+// stamping: an ID counts as visited iff versions[id] == epoch. Resetting the
+// set is O(1) (bump the epoch) instead of clearing a map, and node IDs are
+// dense 0-based so a flat slice indexes them directly. This replaces the
+// per-call map[uint64]bool that dominated searchLayer's CPU profile.
+//
+// Buffers are pooled (visitedPool) rather than stored on HNSWIndex because
+// searchLayer runs concurrently under RLock; each call borrows its own set.
+type visitedSet struct {
+	versions []uint32
+	epoch    uint32
+}
+
+var visitedPool = sync.Pool{New: func() any { return &visitedSet{} }}
+
+// begin prepares the set for a fresh search by advancing the epoch, which
+// logically clears all prior marks. On epoch overflow it zeroes the backing
+// array so stale stamps cannot alias the wrapped-around epoch.
+func (v *visitedSet) begin() {
+	if v.epoch == math.MaxUint32 {
+		for i := range v.versions {
+			v.versions[i] = 0
+		}
+		v.epoch = 0
+	}
+	v.epoch++
+}
+
+// seen reports whether id was marked during the current epoch.
+func (v *visitedSet) seen(id uint64) bool {
+	return id < uint64(len(v.versions)) && v.versions[id] == v.epoch
+}
+
+// mark records id as visited in the current epoch, growing the backing array
+// (with doubling to amortize) when id is out of range.
+func (v *visitedSet) mark(id uint64) {
+	if id >= uint64(len(v.versions)) {
+		newLen := id + 1
+		if double := uint64(len(v.versions)) * 2; double > newLen {
+			newLen = double
+		}
+		grown := make([]uint32, newLen)
+		copy(grown, v.versions)
+		v.versions = grown
+	}
+	v.versions[id] = v.epoch
 }
 
 // minDistHeap is a min-heap (closest first).

--- a/internal/core/vectorindex/hnsw_test.go
+++ b/internal/core/vectorindex/hnsw_test.go
@@ -351,6 +351,40 @@ func TestHNSWRecallSmall(t *testing.T) {
 	assert.Equal(t, 1.0, avgRecall, "Expected perfect recall for 100 vectors")
 }
 
+// TestVisitedSet exercises the version-stamped visited set used by searchLayer,
+// including the array-grow path and the epoch-overflow wraparound that zeroes
+// the backing array (which normal search workloads never reach).
+func TestVisitedSet(t *testing.T) {
+	v := &visitedSet{}
+
+	// First epoch: an id is unseen until marked.
+	v.begin()
+	assert.False(t, v.seen(3), "id should be unseen before marking")
+	v.mark(3)
+	assert.True(t, v.seen(3), "id should be seen after marking")
+	assert.False(t, v.seen(1000), "unmarked out-of-range id should be unseen")
+
+	// A new epoch logically clears all prior marks in O(1).
+	v.begin()
+	assert.False(t, v.seen(3), "mark from previous epoch should be cleared")
+
+	// mark grows the backing array to fit a large out-of-range id.
+	v.mark(5000)
+	assert.True(t, v.seen(5000), "id should be seen after grow+mark")
+
+	// Epoch overflow: force the wraparound branch in begin(), which must zero
+	// the backing array so a stale stamp equal to the pre-wrap epoch cannot
+	// alias the reset epoch.
+	v.mark(7)
+	v.epoch = math.MaxUint32
+	v.versions[7] = math.MaxUint32 // stale stamp matching the pre-wrap epoch
+	v.begin()                      // wraps: zero array, epoch -> 0 -> 1
+	assert.Equal(t, uint32(1), v.epoch, "epoch should reset to 1 after overflow")
+	assert.False(t, v.seen(7), "stale stamp must not survive the wraparound")
+	v.mark(7)
+	assert.True(t, v.seen(7), "id should be seen after re-marking post-wraparound")
+}
+
 func TestHNSWRecallLarger(t *testing.T) {
 	// 1000 vectors, 128 dimensions.
 	rng := rand.New(rand.NewSource(54321))

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -233,6 +233,21 @@ func TestMmapHNSW_Upsert(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // mmapHNSWSearchResults runs search and returns results for comparison.
+// insertAllBatch builds an index from vecs via a single InsertBatch using doc
+// IDs "doc-%d". For MmapStore this collapses ~N per-insert WAL syncs into one,
+// which is far faster than a serial Insert loop while producing an identical
+// graph (same insertion order → same random levels → same topology).
+func insertAllBatch(t *testing.T, idx *HNSWIndex, vecs [][]float32) {
+	t.Helper()
+	items := make([]InsertItem, len(vecs))
+	for i, v := range vecs {
+		items[i] = InsertItem{DocId: fmt.Sprintf("doc-%d", i), Vector: v}
+	}
+	if err := idx.InsertBatch(items); err != nil {
+		t.Fatalf("InsertBatch (%d items): %v", len(vecs), err)
+	}
+}
+
 func mmapHNSWSearchResults(t *testing.T, idx *HNSWIndex, queries [][]float32, k int) [][]SearchResult {
 	t.Helper()
 	results := make([][]SearchResult, len(queries))
@@ -548,11 +563,7 @@ func TestMmapHNSW_UpperGraph_MultiLayer(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(99))
 	vecs := randomVectors(rng, n, dim)
-	for i, v := range vecs {
-		if err := idx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
-			t.Fatalf("Insert doc-%d: %v", i, err)
-		}
-	}
+	insertAllBatch(t, idx, vecs)
 
 	// Verify entry point exists and has level > 0 (with 2000 nodes this is very likely).
 	epID, maxLevel, err := store.GetEntryPoint()
@@ -660,11 +671,7 @@ func TestMmapHNSW_UpperGraph_PersistenceReopen(t *testing.T) {
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
-		for i, v := range vecs {
-			if err := idx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
-				t.Fatalf("Insert doc-%d: %v", i, err)
-			}
-		}
+		insertAllBatch(t, idx, vecs)
 
 		preResults = mmapHNSWSearchResults(t, idx, queries, k)
 		preEP, preMaxLevel, err = store.GetEntryPoint()
@@ -750,11 +757,7 @@ func TestMmapHNSW_UpperGraph_GrowCrashRecovery(t *testing.T) {
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
-		for i, v := range vecs {
-			if err := idx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
-				t.Fatalf("Insert doc-%d: %v", i, err)
-			}
-		}
+		insertAllBatch(t, idx, vecs)
 
 		preResults = mmapHNSWSearchResults(t, idx, queries, k)
 
@@ -903,11 +906,7 @@ func TestMmapHNSW_RecallAt10(t *testing.T) {
 	mmapIdx := NewHNSWIndex(mmapStore, CosineDistance, WithCosineDistance(),
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
-	for i, v := range baseVecs {
-		if err := mmapIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
-			t.Fatalf("MmapStore insert %d: %v", i, err)
-		}
-	}
+	insertAllBatch(t, mmapIdx, baseVecs)
 
 	var mmapRecallSum float64
 	mmapMapping := buildNodeToBaseIdxMap(mmapStore, n, "doc-%d")


### PR DESCRIPTION
## What

`internal/core/vectorindex` is the slowest step in `make coverage` (34.8s of 38.2s). This PR cuts it down by attacking the actual bottleneck, found via CPU profiling.

## How it went

**First hypothesis (kept, but not the win):** the serial `idx.Insert` build loops in the heavy recall/upper-graph tests pay a WAL fsync per insert, so switch them to `InsertBatch` (one outer batch). Result: **~0 speedup** — profiling showed no IO in the hot path at all; these tests are CPU-bound on graph construction (`efConstruction=200`). `InsertBatch` is kept because it's the idiomatic bulk-build API and the graph it produces is identical (all recall + mmap-vs-mem exact-match assertions still pass).

**The actual win:** the profile pointed at ~30–40% of time in Go map hashing from per-call maps in two hot functions:

| Hot path | Before | After |
|---|---|---|
| `searchLayer` visited set | `map[uint64]bool` allocated per call | pooled **version-stamped `[]uint32`** (visited iff `versions[id]==epoch`, O(1) reset). `sync.Pool` because Search runs it concurrently under RLock; node IDs are dense 0-based. Race-clean. |
| `selectNeighborsHeuristic` | `vecCache` / `normCache` / `selectedSet` maps per call | vectors/norms resolved once into **position-indexed slices**; O(candidates×selected) loop does zero map access. `-1` norm sentinel mirrors the old "missing from cache" fallback. |

## Results

Benchmarks (default `efConstruction=200`, dim=128, cosine, fixed iteration count):

| | Before | After | Δ |
|---|---|---|---|
| `BenchmarkHNSWInsert` | 1,522k ns/op | 953k ns/op | **−37% (1.6×)** |
| `BenchmarkHNSWSearch` | 218k ns/op | 145k ns/op | **−33% (1.5×)** |

End-to-end:
- vectorindex test suite (no coverage): **26.1s → 17.6s (−33%)**
- `make coverage` total: **42.1s → 31.9s (−24%)**
- Coverage unchanged (TOTAL 91.5%, vectorindex 87.4% → 87.5%); gate still passes.

Because both functions are on the production hot path, **real indexing/search get faster too**, not just the tests.

## Verification
- `go test ./internal/core/vectorindex/` — all pass (incl. recall>0.95 and mmap==mem exact ID/distance assertions)
- `go test -race -run Concurrent` — clean
- `make coverage` — exit 0, coverage unchanged
- `gofmt` clean

## Incidental
`BenchmarkMmapStoreGetVector` referenced a renamed function + old `OpenMmapStore` signature; since the file is gated behind `//go:build benchmark` it had bit-rotted and blocked the whole tagged build. Repaired so benchmarks run again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)