### PR TITLE
perf(vectorindex): zero-copy GetVectorRef + de-boxed heaps (make coverage 32s → 25s)

### DIFF
--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -1,7 +1,6 @@
 package vectorindex
 
 import (
-	"container/heap"
 	"fmt"
 	"math"
 	"math/rand"
@@ -550,14 +549,14 @@ func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 
 	// candidates: min-heap (closest first)
 	cands := &minDistHeap{}
-	heap.Push(cands, distItem{id: entryId, dist: entryDist})
+	cands.push(distItem{id: entryId, dist: entryDist})
 
 	// result: max-heap bounded by ef (farthest first at top)
 	results := &maxDistHeap{}
-	heap.Push(results, distItem{id: entryId, dist: entryDist})
+	results.push(distItem{id: entryId, dist: entryDist})
 
 	for cands.Len() > 0 {
-		c := heap.Pop(cands).(distItem)
+		c := cands.pop()
 
 		// If closest candidate is farther than the farthest result, stop.
 		farthest := (*results)[0] // top of max-heap = farthest
@@ -583,10 +582,10 @@ func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 
 			farthest = (*results)[0]
 			if results.Len() < ef || nbDist < farthest.dist {
-				heap.Push(cands, distItem{id: nbId, dist: nbDist})
-				heap.Push(results, distItem{id: nbId, dist: nbDist})
+				cands.push(distItem{id: nbId, dist: nbDist})
+				results.push(distItem{id: nbId, dist: nbDist})
 				if results.Len() > ef {
-					heap.Pop(results) // remove the farthest
+					results.pop() // remove the farthest
 				}
 			}
 		}
@@ -796,34 +795,111 @@ func (v *visitedSet) mark(id uint64) {
 	v.versions[id] = v.epoch
 }
 
-// minDistHeap is a min-heap (closest first).
+// minDistHeap is a min-heap (closest first). It provides typed push/pop helpers
+// instead of going through container/heap, whose Push(interface{}) / Pop()
+// interface{} signatures box every distItem onto the heap — that boxing
+// dominated searchLayer's allocation profile. The up/down sift logic mirrors
+// container/heap exactly, so ordering (including tie-breaking) is identical.
 type minDistHeap []distItem
 
-func (h minDistHeap) Len() int            { return len(h) }
-func (h minDistHeap) Less(i, j int) bool  { return h[i].dist < h[j].dist }
-func (h minDistHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h *minDistHeap) Push(x interface{}) { *h = append(*h, x.(distItem)) }
-func (h *minDistHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	item := old[n-1]
-	*h = old[:n-1]
-	return item
+func (h minDistHeap) Len() int           { return len(h) }
+func (h minDistHeap) less(i, j int) bool { return h[i].dist < h[j].dist }
+
+func (h *minDistHeap) push(it distItem) {
+	*h = append(*h, it)
+	h.up(len(*h) - 1)
 }
 
-// maxDistHeap is a max-heap (farthest first).
+func (h *minDistHeap) pop() distItem {
+	old := *h
+	n := len(old) - 1
+	old[0], old[n] = old[n], old[0]
+	h.down(0, n)
+	it := old[n]
+	*h = old[:n]
+	return it
+}
+
+func (h minDistHeap) up(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !h.less(j, i) {
+			break
+		}
+		h[i], h[j] = h[j], h[i]
+		j = i
+	}
+}
+
+func (h minDistHeap) down(i0, n int) {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 {
+			break
+		}
+		j := j1
+		if j2 := j1 + 1; j2 < n && h.less(j2, j1) {
+			j = j2 // prefer the smaller child
+		}
+		if !h.less(j, i) {
+			break
+		}
+		h[i], h[j] = h[j], h[i]
+		i = j
+	}
+}
+
+// maxDistHeap is a max-heap (farthest first). See minDistHeap for why it avoids
+// container/heap.
 type maxDistHeap []distItem
 
-func (h maxDistHeap) Len() int            { return len(h) }
-func (h maxDistHeap) Less(i, j int) bool  { return h[i].dist > h[j].dist }
-func (h maxDistHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h *maxDistHeap) Push(x interface{}) { *h = append(*h, x.(distItem)) }
-func (h *maxDistHeap) Pop() interface{} {
+func (h maxDistHeap) Len() int           { return len(h) }
+func (h maxDistHeap) less(i, j int) bool { return h[i].dist > h[j].dist }
+
+func (h *maxDistHeap) push(it distItem) {
+	*h = append(*h, it)
+	h.up(len(*h) - 1)
+}
+
+func (h *maxDistHeap) pop() distItem {
 	old := *h
-	n := len(old)
-	item := old[n-1]
-	*h = old[:n-1]
-	return item
+	n := len(old) - 1
+	old[0], old[n] = old[n], old[0]
+	h.down(0, n)
+	it := old[n]
+	*h = old[:n]
+	return it
+}
+
+func (h maxDistHeap) up(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !h.less(j, i) {
+			break
+		}
+		h[i], h[j] = h[j], h[i]
+		j = i
+	}
+}
+
+func (h maxDistHeap) down(i0, n int) {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 {
+			break
+		}
+		j := j1
+		if j2 := j1 + 1; j2 < n && h.less(j2, j1) {
+			j = j2 // prefer the larger child
+		}
+		if !h.less(j, i) {
+			break
+		}
+		h[i], h[j] = h[j], h[i]
+		i = j
+	}
 }
 
 // sortDistItems sorts distItems by distance ascending.

--- a/internal/core/vectorindex/mmap_store_read.go
+++ b/internal/core/vectorindex/mmap_store_read.go
@@ -7,29 +7,38 @@ import (
 	"unsafe"
 )
 
-// GetVector returns a copy of the vector for the given node ID.
+// GetVector returns a copy of the vector for the given node ID. The returned
+// slice is owned by the caller and is safe to retain and mutate.
 func (s *MmapStore) GetVector(id uint64) ([]float32, error) {
+	ref, err := s.GetVectorRef(id)
+	if err != nil {
+		return nil, err
+	}
+	vec := make([]float32, len(ref))
+	copy(vec, ref)
+	return vec, nil
+}
+
+// GetVectorRef returns a zero-copy view of the vector backed directly by the
+// mmap region. Per the NodeStore contract the caller MUST NOT mutate the slice
+// or retain it across a store mutation (which may remap the region). This
+// avoids a per-call allocation on the hot distance-computation path; the HNSW
+// index serializes inserts (which grow/remap) against searches via its own
+// RWMutex, so refs stay valid for the duration of their use.
+func (s *MmapStore) GetVectorRef(id uint64) ([]float32, error) {
 	s.muVec.RLock()
 	defer s.muVec.RUnlock()
 
 	if id >= s.vecCapacity {
-		return nil, fmt.Errorf("MmapStore.GetVector: id %d out of range (cap %d)", id, s.vecCapacity)
+		return nil, fmt.Errorf("MmapStore.GetVectorRef: id %d out of range (cap %d)", id, s.vecCapacity)
 	}
 
 	offset := int64(pageSize) + int64(id)*int64(s.vecSlotSize)
 	if offset%4 != 0 {
-		return nil, fmt.Errorf("MmapStore.GetVector: unaligned offset %d for id %d", offset, id)
+		return nil, fmt.Errorf("MmapStore.GetVectorRef: unaligned offset %d for id %d", offset, id)
 	}
 	ptr := (*float32)(unsafe.Pointer(&s.vectors[offset]))
-	src := unsafe.Slice(ptr, s.dim)
-	vec := make([]float32, s.dim)
-	copy(vec, src)
-	return vec, nil
-}
-
-// GetVectorRef returns a copied vector for the given node ID.
-func (s *MmapStore) GetVectorRef(id uint64) ([]float32, error) {
-	return s.GetVector(id)
+	return unsafe.Slice(ptr, s.dim), nil
 }
 
 // GetNeighbors returns the neighbor list for the given node and layer.


### PR DESCRIPTION
## What

Follow-up to #65. Profiling the post-#65 hot path showed the remaining cost is mostly **allocation/GC**, with two clear sources. This PR removes both.

| Allocation source | Share of allocs | Fix |
|---|---|---|
| `MmapStore.GetVector` (via `GetVectorRef`) | ~37% | Return the zero-copy `unsafe.Slice` view it already builds |
| `container/heap` `Push`/`Pop` boxing `distItem`→`interface{}` | ~13% | Typed `push`/`pop` on the dist heaps (no `interface{}`) |

### 1. Zero-copy `GetVectorRef`
The `NodeStore` contract documents `GetVectorRef` as "returns the vector **without copying**", and `MemNodeStore` already honors it — but `MmapStore.GetVectorRef` delegated to the copying `GetVector`, allocating a fresh `[]float32` on every distance computation. Swapped the roles: `GetVectorRef` returns the mmap-backed view; `GetVector` copies from it. Safe because the HNSW index serializes inserts (which may remap) against searches via its `RWMutex` — the same aliasing contract `MemNodeStore` already relies on.

### 2. De-boxed heaps
`container/heap`'s `interface{}` API boxed every `distItem` pushed/popped in `searchLayer`. Replaced with typed `push`/`pop` whose up/down sift logic mirrors `container/heap` exactly (identical ordering + tie-breaking).

## Results

Benchmarks (default `efConstruction=200`, dim=128, cosine, fixed iteration count):

| | Before | After | Δ |
|---|---|---|---|
| `BenchmarkHNSWSearch` ns/op | 145k | 120k | **−17%** |
| `BenchmarkHNSWSearch` allocs/op | 679 | **90** | **−87%** |
| `BenchmarkHNSWInsert` ns/op | 933k | 864k | −7% |
| `BenchmarkHNSWInsert` allocs/op | 2247 | **756** | **−66%** |

(`BenchmarkHNSW*` use MemStore so they show only the heap win; the `GetVectorRef` win shows in the Mmap path — confirmed via alloc profile: `GetVector`, formerly the #1 allocator at 37%, is gone.)

End-to-end:
- vectorindex test suite (no coverage): **16.8s → 12.2s**
- `make coverage`: **31.9s → 24.7s**
- Coverage **up**: vectorindex 87.5% → **88.1%**, TOTAL 91.5% → **91.7%**

Cumulative across #65 + this PR: `make coverage` **42.1s → 24.7s**, and these are production hot paths so real indexing/search benefit too.

## Verification
- `go test ./internal/core/vectorindex/` — all pass (recall>0.95, mmap==mem exact ID/distance assertions — confirms the heap rewrite preserves ordering)
- `go test -race -run Concurrent` — clean (validates zero-copy refs under concurrent insert/search)
- Coverage gate: every CRITICAL function is in the CI exclude list; new heap methods and `GetVector`/`GetVectorRef` all ≥85%
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)