### PR TITLE
test(vectorindex): remove coverage exclude list — cover all mmap error paths (88% → 94%)

### DIFF
--- a/.github/workflows/scripts/test_and_coverage.sh
+++ b/.github/workflows/scripts/test_and_coverage.sh
@@ -4,5 +4,4 @@
 
 set -e
 
-EXCLUDE_FUNCS="PutNode,DeleteNode,SetNodeMapping,DeleteNodeMapping,writeMetaHeader,writeDataFileHeader,initAllFiles,mmapAll,Replay,setNeighborsUpper,remapFile,Close,OpenWAL,growFile,ensureUpperCapacity,OpenMmapStore,syncAll,closeMmaps,compactIdmap,replayWAL,init,Sync,InsertBatch" \
-  go run github.com/codetreker/go-cov/cmd/go-cov@v0.1.0
+go run github.com/codetreker/go-cov/cmd/go-cov@v0.1.0

--- a/internal/core/vectorindex/mmap.go
+++ b/internal/core/vectorindex/mmap.go
@@ -12,7 +12,9 @@ const (
 // offset must be page-aligned. length must be > 0.
 // flags is a bitmask of mmapRead | mmapWrite.
 // The returned slice is backed by the OS page cache.
-func mmapAlloc(fd uintptr, offset int64, length int, flags int) ([]byte, error) {
+//
+// It is a package var (not a plain func) so tests can inject mapping failures.
+var mmapAlloc = func(fd uintptr, offset int64, length int, flags int) ([]byte, error) {
 	if length <= 0 {
 		return nil, fmt.Errorf("mmap: length must be > 0, got %d", length)
 	}
@@ -20,15 +22,16 @@ func mmapAlloc(fd uintptr, offset int64, length int, flags int) ([]byte, error) 
 }
 
 // mmapFree unmaps a previously mapped region. The slice must not be used after
-// this call returns.
-func mmapFree(data []byte) error {
+// this call returns. It is a package var so tests can inject unmap failures.
+var mmapFree = func(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
 	return munmapPlatform(data)
 }
 
-// mmapSync flushes dirty pages in the mapped region to disk.
-func mmapSync(data []byte) error {
+// mmapSync flushes dirty pages in the mapped region to disk. It is a package var
+// so tests can inject msync failures.
+var mmapSync = func(data []byte) error {
 	return mmapSyncPlatform(data)
 }

--- a/internal/core/vectorindex/mmap_coverage_test.go
+++ b/internal/core/vectorindex/mmap_coverage_test.go
@@ -1,0 +1,91 @@
+package vectorindex
+
+import (
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+)
+
+// TestMmapStoreCloseMmaps exercises the closeMmaps cleanup helper directly.
+// In production it is only reached from OpenMmapStore error paths, so normal
+// tests never cover it; calling it on a healthy store covers the unmap/close
+// logic without needing fault injection.
+func TestMmapStoreCloseMmaps(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.closeMmaps()
+	// closeMmaps does not touch the WAL or idmap handles; release them so the
+	// test leaks no descriptors.
+	if s.wal != nil {
+		_ = s.wal.Close()
+	}
+	if s.idmapFile != nil {
+		_ = s.idmapFile.Close()
+	}
+}
+
+// TestOpenWALMissingParentDir covers OpenWAL's open-error branch by pointing it
+// at a directory whose parents do not exist.
+func TestOpenWALMissingParentDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no", "such", "dir")
+	if _, err := OpenWAL(missing); err == nil {
+		t.Fatal("expected error opening WAL in a nonexistent directory")
+	}
+}
+
+// TestWALReplayPayloadTooLarge covers Replay's corruption guard: a record whose
+// declared payload length exceeds maxWalPayloadSize must be rejected rather than
+// triggering a huge allocation.
+func TestWALReplayPayloadTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	if _, err := w.Append(WalInsert, []byte("x"), false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overwrite the record's Length field (bytes 8..12) with an over-large value.
+	huge := make([]byte, 4)
+	binary.LittleEndian.PutUint32(huge, uint32(maxWalPayloadSize+1))
+	if _, err := w.file.WriteAt(huge, 8); err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.Replay(0, func(uint64, WalRecordType, []byte) error { return nil })
+	if err == nil {
+		t.Fatal("expected corruption error for oversized payload length")
+	}
+}
+
+// TestSetNeighborsUpperInvalidArgs covers setNeighborsUpper's argument-validation
+// branches: a node with no upper slot, and a node id beyond capacity.
+func TestSetNeighborsUpperInvalidArgs(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	vec := []float32{1, 0, 0, 0}
+	if err := s.PutNode(0, 0, vec); err != nil { // level-0 node => no upper slot
+		t.Fatal(err)
+	}
+
+	// Upper-layer write on a node that has no upper slot allocated.
+	if err := s.SetNeighbors(0, 1, []uint64{1}); err == nil {
+		t.Fatal("expected error: node has no upper slot")
+	}
+
+	// readUpperSlot rejects an id beyond node capacity.
+	if err := s.SetNeighbors(1<<40, 1, []uint64{1}); err == nil {
+		t.Fatal("expected error: node id out of range")
+	}
+}

--- a/internal/core/vectorindex/mmap_fault2_test.go
+++ b/internal/core/vectorindex/mmap_fault2_test.go
@@ -1,0 +1,223 @@
+package vectorindex
+
+import (
+	"os"
+	"testing"
+)
+
+// --- OpenMmapStore + initAllFiles + mmapAll: failures during open ---
+
+func TestOpenMmapStoreInitMetaError(t *testing.T) {
+	wrapNextCreate(t, "meta.bin.tmp", faultFile{failWrite: true})
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected init error (meta write)")
+	}
+}
+
+func TestOpenMmapStoreInitDataFileError(t *testing.T) {
+	wrapNextCreate(t, "vectors.dat", faultFile{failWrite: true})
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected init error (vectors.dat write)")
+	}
+}
+
+func TestOpenMmapStoreInitNodesError(t *testing.T) {
+	wrapNextCreate(t, "nodes.dat", faultFile{failWrite: true})
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected init error (nodes.dat write)")
+	}
+}
+
+func TestOpenMmapStoreInitL0Error(t *testing.T) {
+	wrapNextCreate(t, "graph_l0.dat", faultFile{failWrite: true})
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected init error (graph_l0.dat write)")
+	}
+}
+
+func TestOpenMmapStoreInitUpperError(t *testing.T) {
+	wrapNextCreate(t, "graph_upper.dat", faultFile{failWrite: true})
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected init error (graph_upper.dat write)")
+	}
+}
+
+func TestOpenMmapStoreMmapError(t *testing.T) {
+	orig := mmapAlloc
+	defer func() { mmapAlloc = orig }()
+	mmapAlloc = func(fd uintptr, off int64, length, flags int) ([]byte, error) {
+		return nil, errInjected
+	}
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected mmap error")
+	}
+}
+
+func TestMmapAllStatError(t *testing.T) {
+	orig := fsOpenFile
+	defer func() { fsOpenFile = orig }()
+	fsOpenFile = func(name string, flag int, perm os.FileMode) (osFile, error) {
+		f, err := orig(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		if contains(name, ".dat") && !contains(name, "idmap") {
+			return &faultFile{osFile: f, failStat: true}, nil
+		}
+		return f, nil
+	}
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected stat error in mmapAll")
+	}
+}
+
+func TestMmapAllOpenError(t *testing.T) {
+	orig := fsOpenFile
+	defer func() { fsOpenFile = orig }()
+	fsOpenFile = func(name string, flag int, perm os.FileMode) (osFile, error) {
+		if contains(name, "nodes.dat") {
+			return nil, errInjected
+		}
+		return orig(name, flag, perm)
+	}
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected open error in mmapAll")
+	}
+}
+
+func TestOpenMmapStoreWALError(t *testing.T) {
+	orig := fsOpenFile
+	defer func() { fsOpenFile = orig }()
+	fsOpenFile = func(name string, flag int, perm os.FileMode) (osFile, error) {
+		if contains(name, "wal.bin") {
+			return nil, errInjected
+		}
+		return orig(name, flag, perm)
+	}
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected WAL open error")
+	}
+}
+
+func TestOpenMmapStoreIdmapError(t *testing.T) {
+	orig := fsOpenFile
+	defer func() { fsOpenFile = orig }()
+	fsOpenFile = func(name string, flag int, perm os.FileMode) (osFile, error) {
+		if contains(name, "idmap.dat") {
+			return nil, errInjected
+		}
+		return orig(name, flag, perm)
+	}
+	if _, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected idmap open error")
+	}
+}
+
+// --- remapFile grow error paths ---
+
+func TestRemapFileMunmapError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	orig := mmapFree
+	defer func() { mmapFree = orig }()
+	mmapFree = func([]byte) error { return errInjected }
+	// munmap fails first, before the region is touched, so the store stays usable.
+	if err := s.remapFile(s.vecFile, &s.vectors, &s.vecCapacity, s.vecCapacity+1, s.vecSlotSize, 8); err == nil {
+		t.Fatal("expected munmap error")
+	}
+}
+
+func TestRemapFileTruncateError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	// Operate on a throwaway file+mapping so the store's real vectors region is
+	// left intact (remapFile unmaps the region before truncating, so failing on
+	// the real one would leave a dangling mapping).
+	f, err := fsCreate(t.TempDir() + "/throw.dat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := f.Truncate(int64(pageSize) + 16); err != nil {
+		t.Fatal(err)
+	}
+	data, err := mmapAlloc(f.Fd(), 0, pageSize+16, mmapRead|mmapWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := uint64(1)
+	ff := &faultFile{osFile: f, failTruncate: true}
+	if err := s.remapFile(ff, &data, &c, 2, 16, 8); err == nil {
+		t.Fatal("expected truncate error")
+	}
+}
+
+func TestRemapFileMmapError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	f, err := fsCreate(t.TempDir() + "/throw.dat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := f.Truncate(int64(pageSize) + 16); err != nil {
+		t.Fatal(err)
+	}
+	data, err := mmapAlloc(f.Fd(), 0, pageSize+16, mmapRead|mmapWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := uint64(1)
+	orig := mmapAlloc
+	mmapAlloc = func(uintptr, int64, int, int) ([]byte, error) { return nil, errInjected }
+	err = s.remapFile(f, &data, &c, 2, 16, 8)
+	mmapAlloc = orig
+	if err == nil {
+		t.Fatal("expected mmap error")
+	}
+}
+
+// --- compactIdmap error paths ---
+
+func TestCompactIdmapCreateError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	if err := s.SetNodeMapping("doc0", 0); err != nil {
+		t.Fatal(err)
+	}
+	orig := fsCreate
+	defer func() { fsCreate = orig }()
+	fsCreate = func(name string) (osFile, error) {
+		if contains(name, "idmap.dat.tmp") {
+			return nil, errInjected
+		}
+		return orig(name)
+	}
+	if err := s.compactIdmap(); err == nil {
+		t.Fatal("expected create error")
+	}
+}
+
+func TestCompactIdmapWriteError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	if err := s.SetNodeMapping("doc0", 0); err != nil {
+		t.Fatal(err)
+	}
+	wrapNextCreate(t, "idmap.dat.tmp", faultFile{failWrite: true})
+	if err := s.compactIdmap(); err == nil {
+		t.Fatal("expected write error")
+	}
+}
+
+func TestCompactIdmapSyncError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	if err := s.SetNodeMapping("doc0", 0); err != nil {
+		t.Fatal(err)
+	}
+	wrapNextCreate(t, "idmap.dat.tmp", faultFile{failSync: true})
+	if err := s.compactIdmap(); err == nil {
+		t.Fatal("expected sync error")
+	}
+}

--- a/internal/core/vectorindex/mmap_fault3_test.go
+++ b/internal/core/vectorindex/mmap_fault3_test.go
@@ -1,0 +1,205 @@
+package vectorindex
+
+import (
+	"testing"
+)
+
+// failWALNextWrite makes the store's WAL fail its next buffered flush, so the
+// next non-batch Append (and the write method calling it) returns an error.
+func failWALNextWrite(s *MmapStore) {
+	s.wal.file = &faultFile{osFile: s.wal.file, failWrite: true}
+	s.wal.buf.Reset(s.wal.file)
+}
+
+// --- grow dispatch / re-check / newCap==0 ---
+
+func TestGrowFileUnknownType(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	if err := s.growFile(fileType(99), 1); err == nil {
+		t.Fatal("expected unknown file type error")
+	}
+}
+
+func TestGrowReCheckNoOp(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	// requiredCap below current capacity: each grow re-checks and returns nil.
+	if err := s.growVectors(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.growNodes(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.growL0(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.growUpper(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGrowFromZeroCapacity(t *testing.T) {
+	// Drive the newCap==0 → default seeding branch in each grow path by forcing
+	// the tracked capacity to 0 before growing.
+	s := openTestStore(t)
+	defer s.Close()
+	s.vecCapacity, s.nodeCapacity, s.l0Capacity, s.upperCapacity = 0, 0, 0, 0
+	if err := s.growVectors(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.growNodes(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.growL0(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.growUpper(1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// --- write methods: WAL append failure branch ---
+
+func TestPutNodeWALError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	failWALNextWrite(s)
+	if err := s.PutNode(0, 0, []float32{1, 0, 0, 0}); err == nil {
+		t.Fatal("expected WAL error from PutNode")
+	}
+}
+
+func TestSetNormWALError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	failWALNextWrite(s)
+	if err := s.SetNorm(0, 1.0); err == nil {
+		t.Fatal("expected WAL error from SetNorm")
+	}
+}
+
+func TestSetNeighborsWALError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	failWALNextWrite(s)
+	if err := s.SetNeighbors(0, 0, []uint64{1}); err == nil {
+		t.Fatal("expected WAL error from SetNeighbors")
+	}
+}
+
+func TestSetEntryPointWALError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	failWALNextWrite(s)
+	if err := s.SetEntryPoint(0, 0); err == nil {
+		t.Fatal("expected WAL error from SetEntryPoint")
+	}
+}
+
+func TestDeleteNodeWALError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	failWALNextWrite(s)
+	if err := s.DeleteNode(0); err == nil {
+		t.Fatal("expected WAL error from DeleteNode")
+	}
+}
+
+// --- WAL method error branches ---
+
+func TestWALAppendFlushError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.file = &faultFile{osFile: w.file, failWrite: true}
+	w.buf.Reset(w.file)
+	if _, err := w.Append(WalInsert, []byte("x"), false); err == nil {
+		t.Fatal("expected flush error from Append")
+	}
+}
+
+func TestWALAppendSyncError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.file = &faultFile{osFile: w.file, failSync: true}
+	if _, err := w.Append(WalInsert, []byte("x"), false); err == nil {
+		t.Fatal("expected sync error from Append")
+	}
+}
+
+func TestWALSyncFlushError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.file = &faultFile{osFile: w.file, failWrite: true}
+	w.buf.Reset(w.file)
+	if _, err := w.buf.WriteString("pending"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Sync(); err == nil {
+		t.Fatal("expected flush error from Sync")
+	}
+}
+
+func TestWALResetFlushError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.file = &faultFile{osFile: w.file, failWrite: true}
+	w.buf.Reset(w.file)
+	if _, err := w.buf.WriteString("pending"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Reset(); err == nil {
+		t.Fatal("expected flush error from Reset")
+	}
+}
+
+func TestWALResetTruncateError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.file = &faultFile{osFile: w.file, failTruncate: true}
+	if err := w.Reset(); err == nil {
+		t.Fatal("expected truncate error from Reset")
+	}
+}
+
+func TestWALReplaySeekError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.file = &faultFile{osFile: w.file, failSeek: true}
+	if err := w.Replay(0, nil); err == nil {
+		t.Fatal("expected seek error from Replay")
+	}
+}
+
+func TestWALReplayTruncateError(t *testing.T) {
+	w, err := OpenWAL(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if _, err := w.Append(WalInsert, []byte("x"), false); err != nil {
+		t.Fatal(err)
+	}
+	w.file = &faultFile{osFile: w.file, failTruncate: true}
+	if err := w.Replay(0, func(uint64, WalRecordType, []byte) error { return nil }); err == nil {
+		t.Fatal("expected truncate error from Replay")
+	}
+}

--- a/internal/core/vectorindex/mmap_fault4_test.go
+++ b/internal/core/vectorindex/mmap_fault4_test.go
@@ -1,0 +1,138 @@
+package vectorindex
+
+import (
+	"testing"
+)
+
+// --- normal out-of-range id branches (read + L0 write) ---
+
+func TestReadOutOfRangeIds(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	const huge = uint64(1) << 40
+	if _, err := s.GetVectorRef(huge); err == nil {
+		t.Fatal("expected GetVectorRef out-of-range error")
+	}
+	if _, err := s.GetVector(huge); err == nil {
+		t.Fatal("expected GetVector out-of-range error")
+	}
+	if _, err := s.GetNeighbors(huge, 0); err == nil {
+		t.Fatal("expected getNeighborsL0 out-of-range error")
+	}
+	if _, err := s.GetNeighbors(huge, 1); err == nil {
+		t.Fatal("expected getNeighborsUpper out-of-range error")
+	}
+	if _, err := s.GetNorm(huge); err == nil {
+		t.Fatal("expected GetNorm out-of-range error")
+	}
+	if _, err := s.GetNodeLevel(huge); err == nil {
+		t.Fatal("expected GetNodeLevel out-of-range error")
+	}
+}
+
+func TestSetNeighborsL0OutOfRange(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	// WAL append succeeds, then setNeighborsL0 rejects the out-of-range id.
+	if err := s.SetNeighbors(uint64(1)<<40, 0, []uint64{1}); err == nil {
+		t.Fatal("expected setNeighborsL0 out-of-range error")
+	}
+}
+
+// --- checkpointLocked fault branches (via Checkpoint) ---
+
+func TestCheckpointMsyncError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	orig := mmapSync
+	defer func() { mmapSync = orig }()
+	mmapSync = func([]byte) error { return errInjected }
+	if err := s.Checkpoint(); err == nil {
+		t.Fatal("expected msync error from Checkpoint")
+	}
+}
+
+func TestCheckpointMetaError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	wrapNextCreate(t, "meta.bin.tmp", faultFile{failWrite: true})
+	if err := s.Checkpoint(); err == nil {
+		t.Fatal("expected meta error from Checkpoint")
+	}
+}
+
+func TestCheckpointWALResetError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	s.wal.file = &faultFile{osFile: s.wal.file, failTruncate: true}
+	if err := s.Checkpoint(); err == nil {
+		t.Fatal("expected WAL reset error from Checkpoint")
+	}
+}
+
+func TestCheckpointCompactError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	orig := fsCreate
+	defer func() { fsCreate = orig }()
+	fsCreate = func(name string) (osFile, error) {
+		if contains(name, "idmap.dat.tmp") {
+			return nil, errInjected
+		}
+		return orig(name)
+	}
+	if err := s.Checkpoint(); err == nil {
+		t.Fatal("expected idmap compact error from Checkpoint")
+	}
+}
+
+// --- store Sync: checkpoint error branch ---
+
+func TestStoreSyncCheckpointError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	orig := mmapSync
+	defer func() { mmapSync = orig }()
+	mmapSync = func([]byte) error { return errInjected }
+	if err := s.Sync(); err == nil {
+		t.Fatal("expected checkpoint error from Sync")
+	}
+}
+
+// --- CommitBatch branches ---
+
+func TestCommitBatchNestedNoCommit(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	s.BeginBatch()
+	s.BeginBatch()
+	// depth still > 0: returns without flushing/syncing.
+	if err := s.CommitBatch(true); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CommitBatch(true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommitBatchSyncError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	s.BeginBatch()
+	s.wal.file = &faultFile{osFile: s.wal.file, failSync: true}
+	if err := s.CommitBatch(true); err == nil {
+		t.Fatal("expected WAL sync error from CommitBatch")
+	}
+}
+
+func TestCommitBatchMsyncError(t *testing.T) {
+	s := openTestStore(t)
+	defer s.Close()
+	s.BeginBatch()
+	orig := mmapSync
+	defer func() { mmapSync = orig }()
+	mmapSync = func([]byte) error { return errInjected }
+	if err := s.CommitBatch(true); err == nil {
+		t.Fatal("expected msync error from CommitBatch")
+	}
+}

--- a/internal/core/vectorindex/mmap_fault_test.go
+++ b/internal/core/vectorindex/mmap_fault_test.go
@@ -1,0 +1,236 @@
+package vectorindex
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// errInjected is the canonical fault returned by injected failures.
+var errInjected = errors.New("injected fault")
+
+// faultFile wraps an osFile and fails the selected operations with errInjected.
+// Unset operations delegate to the embedded file.
+type faultFile struct {
+	osFile
+	failWrite    bool
+	failSync     bool
+	failClose    bool
+	failTruncate bool
+	failSeek     bool
+	failStat     bool
+}
+
+func (f *faultFile) Write(p []byte) (int, error) {
+	if f.failWrite {
+		return 0, errInjected
+	}
+	return f.osFile.Write(p)
+}
+
+func (f *faultFile) Sync() error {
+	if f.failSync {
+		return errInjected
+	}
+	return f.osFile.Sync()
+}
+
+func (f *faultFile) Close() error {
+	// Always release the underlying handle even when injecting a failure, so
+	// tests never leak an fd / file lock (which on Windows blocks the TempDir
+	// cleanup from deleting the file).
+	err := f.osFile.Close()
+	if f.failClose {
+		return errInjected
+	}
+	return err
+}
+
+func (f *faultFile) Truncate(size int64) error {
+	if f.failTruncate {
+		return errInjected
+	}
+	return f.osFile.Truncate(size)
+}
+
+func (f *faultFile) Seek(off int64, whence int) (int64, error) {
+	if f.failSeek {
+		return 0, errInjected
+	}
+	return f.osFile.Seek(off, whence)
+}
+
+func (f *faultFile) Stat() (os.FileInfo, error) {
+	if f.failStat {
+		return nil, errInjected
+	}
+	return f.osFile.Stat()
+}
+
+// wrapNextCreate makes the next fsCreate whose path contains match return a
+// faultFile configured by tmpl (its osFile is filled in). Restored via Cleanup.
+func wrapNextCreate(t *testing.T, match string, tmpl faultFile) {
+	t.Helper()
+	orig := fsCreate
+	t.Cleanup(func() { fsCreate = orig })
+	fsCreate = func(name string) (osFile, error) {
+		f, err := orig(name)
+		if err != nil {
+			return nil, err
+		}
+		if match == "" || contains(name, match) {
+			ff := tmpl
+			ff.osFile = f
+			return &ff, nil
+		}
+		return f, nil
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// openTestStore opens a small MmapStore in a temp dir and guarantees it is
+// closed at test end (so no test leaks mmaps/fds, which on Windows would block
+// the t.TempDir cleanup from deleting the files).
+func openTestStore(t *testing.T) *MmapStore {
+	t.Helper()
+	s, err := OpenMmapStore(t.TempDir(), MmapStoreOptions{Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// --- init / endianness guard ---
+
+func TestCheckEndianProbeLittleEndian(t *testing.T) {
+	checkEndianProbe(0x01020304) // low byte 0x04 on little-endian: must not panic
+}
+
+func TestCheckEndianProbeNonLittleEndianPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for non-0x04 low byte")
+		}
+	}()
+	checkEndianProbe(0x00000000) // low byte 0x00 != 0x04: panics
+}
+
+// --- writeMetaHeader IO error paths ---
+
+func TestWriteMetaHeaderWriteError(t *testing.T) {
+	wrapNextCreate(t, "meta.bin.tmp", faultFile{failWrite: true})
+	if err := writeMetaHeader(t.TempDir(), &MetaHeader{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected write error")
+	}
+}
+
+func TestWriteMetaHeaderSyncError(t *testing.T) {
+	wrapNextCreate(t, "meta.bin.tmp", faultFile{failSync: true})
+	if err := writeMetaHeader(t.TempDir(), &MetaHeader{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected sync error")
+	}
+}
+
+func TestWriteMetaHeaderCloseError(t *testing.T) {
+	wrapNextCreate(t, "meta.bin.tmp", faultFile{failClose: true})
+	if err := writeMetaHeader(t.TempDir(), &MetaHeader{Dim: 4, M: 4}); err == nil {
+		t.Fatal("expected close error")
+	}
+}
+
+// --- writeDataFileHeader IO error paths ---
+
+func TestWriteDataFileHeaderWriteError(t *testing.T) {
+	wrapNextCreate(t, "", faultFile{failWrite: true})
+	path := t.TempDir() + "/x.dat"
+	if err := writeDataFileHeader(path, magicVectors, &VectorsHeader{Magic: magicVectors, Dim: 4, Capacity: 1}, int64(pageSize)); err == nil {
+		t.Fatal("expected write error")
+	}
+}
+
+func TestWriteDataFileHeaderTruncateError(t *testing.T) {
+	wrapNextCreate(t, "", faultFile{failTruncate: true})
+	path := t.TempDir() + "/x.dat"
+	if err := writeDataFileHeader(path, magicVectors, &VectorsHeader{Magic: magicVectors, Dim: 4, Capacity: 1}, int64(pageSize)); err == nil {
+		t.Fatal("expected truncate error")
+	}
+}
+
+// --- syncAll msync error paths ---
+
+func TestSyncAllMsyncErrors(t *testing.T) {
+	for n := 1; n <= 4; n++ {
+		s := openTestStore(t)
+		orig := mmapSync
+		count := 0
+		mmapSync = func(data []byte) error {
+			count++
+			if count == n {
+				return errInjected
+			}
+			return orig(data)
+		}
+		err := s.syncAll()
+		mmapSync = orig
+		if err == nil {
+			t.Fatalf("expected msync error on call %d", n)
+		}
+		_ = s.Close()
+	}
+}
+
+// --- WAL Close flush error ---
+
+func TestWALCloseFlushError(t *testing.T) {
+	dir := t.TempDir()
+	w, err := OpenWAL(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Point the buffered writer at a file that fails writes, then buffer some
+	// bytes so the Flush inside Close must write them (and fail).
+	w.file = &faultFile{osFile: w.file, failWrite: true}
+	w.buf.Reset(w.file)
+	if _, err := w.buf.WriteString("pending"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err == nil {
+		t.Fatal("expected flush error from Close")
+	}
+}
+
+// --- OpenWAL scanLSN error (Truncate fails) ---
+
+func TestOpenWALScanError(t *testing.T) {
+	orig := fsOpenFile
+	defer func() { fsOpenFile = orig }()
+	fsOpenFile = func(name string, flag int, perm os.FileMode) (osFile, error) {
+		f, err := orig(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		return &faultFile{osFile: f, failTruncate: true}, nil
+	}
+	if _, err := OpenWAL(t.TempDir()); err == nil {
+		t.Fatal("expected scanLSN truncate error")
+	}
+}
+
+// --- store Sync WAL flush/sync errors ---
+
+func TestStoreSyncWALErrors(t *testing.T) {
+	s := openTestStore(t)
+	s.wal.file = &faultFile{osFile: s.wal.file, failSync: true}
+	if err := s.Sync(); err == nil {
+		t.Fatal("expected WAL sync error from store Sync")
+	}
+}

--- a/internal/core/vectorindex/mmap_format.go
+++ b/internal/core/vectorindex/mmap_format.go
@@ -3,14 +3,20 @@ package vectorindex
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
 	"path/filepath"
 	"unsafe"
 )
 
 func init() {
-	var x uint32 = 0x01020304
-	if *(*byte)(unsafe.Pointer(&x)) != 0x04 {
+	checkEndianProbe(0x01020304)
+}
+
+// checkEndianProbe panics unless probe's lowest-address byte is 0x04. init calls
+// it with the constant 0x01020304, so it panics exactly on big-endian platforms
+// (which the unsafe mmap reinterpretation in this package does not support).
+// Parameterizing the probe keeps the panic branch reachable from tests.
+func checkEndianProbe(probe uint32) {
+	if *(*byte)(unsafe.Pointer(&probe)) != 0x04 {
 		panic("mmap store requires little-endian platform")
 	}
 }
@@ -123,26 +129,26 @@ func writeMetaHeader(dir string, h *MetaHeader) error {
 	tmp := filepath.Join(dir, "meta.bin.tmp")
 	final := filepath.Join(dir, "meta.bin")
 
-	f, err := os.Create(tmp)
+	f, err := fsCreate(tmp)
 	if err != nil {
 		return fmt.Errorf("writeMetaHeader: create tmp: %w", err)
 	}
 
 	if err := binary.Write(f, binary.LittleEndian, h); err != nil {
 		f.Close()
-		os.Remove(tmp)
+		fsRemove(tmp)
 		return fmt.Errorf("writeMetaHeader: write: %w", err)
 	}
 	if err := f.Sync(); err != nil {
 		f.Close()
-		os.Remove(tmp)
+		fsRemove(tmp)
 		return fmt.Errorf("writeMetaHeader: sync: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmp)
+		fsRemove(tmp)
 		return fmt.Errorf("writeMetaHeader: close: %w", err)
 	}
-	if err := os.Rename(tmp, final); err != nil {
+	if err := fsRename(tmp, final); err != nil {
 		return fmt.Errorf("writeMetaHeader: rename: %w", err)
 	}
 	return nil
@@ -151,7 +157,7 @@ func writeMetaHeader(dir string, h *MetaHeader) error {
 // readMetaHeader reads a MetaHeader from dir/meta.bin.
 func readMetaHeader(dir string) (*MetaHeader, error) {
 	path := filepath.Join(dir, "meta.bin")
-	f, err := os.Open(path)
+	f, err := fsOpen(path)
 	if err != nil {
 		return nil, fmt.Errorf("readMetaHeader: %w", err)
 	}
@@ -170,7 +176,7 @@ func readMetaHeader(dir string) (*MetaHeader, error) {
 // writeDataFileHeader writes a page-aligned header for a data file.
 // The header struct is written at offset 0, and the file is padded to pageSize.
 func writeDataFileHeader(path string, magic [4]byte, headerData any, totalSize int64) error {
-	f, err := os.Create(path)
+	f, err := fsCreate(path)
 	if err != nil {
 		return err
 	}

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -47,10 +47,10 @@ type MmapStore struct {
 	graphL0    []byte // graph_l0.dat mmap
 	graphUpper []byte // graph_upper.dat mmap
 
-	vecFile   *os.File
-	nodeFile  *os.File
-	l0File    *os.File
-	upperFile *os.File
+	vecFile   osFile
+	nodeFile  osFile
+	l0File    osFile
+	upperFile osFile
 
 	// WAL and batch support
 	wal                *WAL
@@ -62,7 +62,7 @@ type MmapStore struct {
 	// ID mapping (doc ↔ node)
 	docToNode map[string]uint64
 	nodeToDoc map[uint64]string
-	idmapFile *os.File // idmap.dat append handle
+	idmapFile osFile // idmap.dat append handle
 
 	syncMode SyncMode
 
@@ -280,7 +280,7 @@ func (s *MmapStore) initAllFiles(cap uint64) error {
 func (s *MmapStore) mmapAll() error {
 	type fileInfo struct {
 		name string
-		file **os.File
+		file *osFile
 		data *[]byte
 		cap  *uint64
 	}
@@ -293,9 +293,9 @@ func (s *MmapStore) mmapAll() error {
 	}
 
 	// Track opened files and mappings for cleanup on error.
-	var openedFiles []*os.File
+	var openedFiles []osFile
 	var mappedRegions [][]byte
-	cleanup := func() { // nocov: error cleanup path — requires partial mmap failure to trigger
+	cleanup := func() {
 		for _, m := range mappedRegions {
 			mmapFree(m)
 		}
@@ -306,7 +306,7 @@ func (s *MmapStore) mmapAll() error {
 
 	for _, fi := range files {
 		path := filepath.Join(s.dir, fi.name)
-		f, err := os.OpenFile(path, os.O_RDWR, 0644)
+		f, err := fsOpenFile(path, os.O_RDWR, 0644)
 		if err != nil {
 			cleanup()
 			return fmt.Errorf("open %s: %w", fi.name, err)
@@ -340,7 +340,7 @@ func (s *MmapStore) mmapAll() error {
 }
 
 // closeMmaps unmaps and closes all data files (cleanup helper).
-func (s *MmapStore) closeMmaps() { // nocov: cleanup helper — called from Close/error paths
+func (s *MmapStore) closeMmaps() {
 	mmapFree(s.vectors)
 	mmapFree(s.nodes)
 	mmapFree(s.graphL0)
@@ -362,7 +362,7 @@ func (s *MmapStore) closeMmaps() { // nocov: cleanup helper — called from Clos
 // loadIdmap reads idmap.dat and populates docToNode/nodeToDoc maps.
 func (s *MmapStore) loadIdmap() error {
 	path := filepath.Join(s.dir, "idmap.dat")
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := fsOpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/internal/core/vectorindex/mmap_store_grow.go
+++ b/internal/core/vectorindex/mmap_store_grow.go
@@ -3,7 +3,6 @@ package vectorindex
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
 )
 
 // fileType identifies which mmap'd file to grow.
@@ -150,7 +149,7 @@ func (s *MmapStore) growUpper(requiredCap uint64) error {
 }
 
 // remapFile is the common grow logic: munmap → ftruncate → update header capacity → re-mmap.
-func (s *MmapStore) remapFile(f *os.File, data *[]byte, cap *uint64, newCap uint64, slotSize int, capHeaderOffset int) error {
+func (s *MmapStore) remapFile(f osFile, data *[]byte, cap *uint64, newCap uint64, slotSize int, capHeaderOffset int) error {
 	if err := mmapFree(*data); err != nil {
 		return fmt.Errorf("grow: munmap: %w", err)
 	}

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -434,7 +434,7 @@ func (s *MmapStore) checkpointLocked() error {
 func (s *MmapStore) compactIdmap() error {
 	path := filepath.Join(s.dir, "idmap.dat")
 	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
+	f, err := fsCreate(tmp)
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (s *MmapStore) compactIdmap() error {
 		if _, err := f.Write(entry); err != nil {
 			s.muDoc.RUnlock()
 			f.Close()
-			os.Remove(tmp)
+			fsRemove(tmp)
 			return err
 		}
 	}
@@ -484,13 +484,13 @@ func (s *MmapStore) compactIdmap() error {
 		return fmt.Errorf("MmapStore.compactIdmap: close old idmap: %w", err)
 	}
 
-	if err := os.Rename(tmp, path); err != nil {
+	if err := fsRename(tmp, path); err != nil {
 		s.muDoc.Unlock()
 		return err
 	}
 
 	// Reopen idmap for append.
-	nf, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND, 0644)
+	nf, err := fsOpenFile(path, os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {
 		s.muDoc.Unlock()
 		return err

--- a/internal/core/vectorindex/mmap_wal.go
+++ b/internal/core/vectorindex/mmap_wal.go
@@ -34,7 +34,7 @@ const maxWalPayloadSize = 64 << 20
 
 // WAL is an append-only write-ahead log with CRC32 integrity checks.
 type WAL struct {
-	file *os.File
+	file osFile
 	lsn  uint64
 	mu   sync.Mutex
 	buf  *bufio.Writer
@@ -44,7 +44,7 @@ type WAL struct {
 // It scans the file to determine the current LSN.
 func OpenWAL(dir string) (*WAL, error) {
 	path := filepath.Join(dir, "wal.bin")
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := fsOpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("WAL: open: %w", err)
 	}

--- a/internal/core/vectorindex/osfile.go
+++ b/internal/core/vectorindex/osfile.go
@@ -1,0 +1,49 @@
+package vectorindex
+
+import "os"
+
+// osFile is the subset of *os.File the mmap store and WAL use, abstracted behind
+// an interface so tests can inject IO failures (a healthy descriptor's
+// Write/Sync/Close/Truncate failing) that are otherwise impossible to trigger.
+// *os.File satisfies osFile.
+type osFile interface {
+	Read(p []byte) (int, error)
+	Write(p []byte) (int, error)
+	ReadAt(p []byte, off int64) (int, error)
+	WriteAt(p []byte, off int64) (int, error)
+	Seek(offset int64, whence int) (int64, error)
+	Truncate(size int64) error
+	Sync() error
+	Stat() (os.FileInfo, error)
+	Fd() uintptr
+	Close() error
+}
+
+// Injectable filesystem constructors. Production uses the real os package; tests
+// override these to return files that fail on chosen operations. Each returns a
+// true nil interface on error to avoid the typed-nil pitfall.
+var (
+	fsCreate = func(name string) (osFile, error) {
+		f, err := os.Create(name)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+	fsOpen = func(name string) (osFile, error) {
+		f, err := os.Open(name)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+	fsOpenFile = func(name string, flag int, perm os.FileMode) (osFile, error) {
+		f, err := os.OpenFile(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+	fsRename = os.Rename
+	fsRemove = os.Remove
+)


### PR DESCRIPTION
## What

The CI coverage gate (`test_and_coverage.sh`) excluded **23 functions** via `EXCLUDE_FUNCS` because their uncovered lines were IO/syscall error paths that couldn't be triggered. This PR **removes the entire exclude list** and covers those paths with real tests, by introducing a small IO/mmap injection seam.

## How

**1. Injection seam (production code, no behavioural change)** — `refactor` commit:
- An `osFile` interface + `fsCreate`/`fsOpen`/`fsOpenFile`/`fsRename`/`fsRemove` constructors; the store/WAL file fields become `osFile`. Production wiring is the real `os` package.
- `mmapAlloc`/`mmapFree`/`mmapSync` become package vars.
- `init`'s big-endian guard → `checkEndianProbe(probe uint32)` so its panic branch is reachable from a test (it was otherwise permanently uncoverable on little-endian).

**2. Tests** — `test` commit:
- Normal invalid-input / corrupted-data tests (missing dirs, oversized WAL payloads, out-of-range ids, no-upper-slot, etc.).
- A `faultFile` wrapper + seam overrides inject `Write`/`Sync`/`Close`/`Truncate`/`Seek`/`Stat` and `mmap` failures, covering the error paths in `writeMetaHeader`, `writeDataFileHeader`, `initAllFiles`, `mmapAll`, `remapFile`/grow, `OpenMmapStore`, `compactIdmap`, `checkpointLocked`, `CommitBatch`, `Sync`, the WAL methods, and the write-path WAL-append branches.

## Results

| | Before | After |
|---|---|---|
| `EXCLUDE_FUNCS` entries | **23** | **0** |
| `internal/core/vectorindex` coverage | 88.1% | **94.3%** |
| CRITICAL (<80%) functions, no excludes | 15 | **0** |
| Test count | 219 | 275 |

The gate now passes on raw coverage with no exemptions — every function in the package is ≥80%, and the core `mmap_*` files are 90–100%.

## Verification
- `go-cov` (zero excludes) — 0 CRITICAL, exit 0
- `go test ./internal/core/vectorindex/` — all pass
- `go test -race` — clean (validates the `*os.File` → `osFile` field-type change and the global-var seam under concurrency)
- `gofmt` clean

## Note
A handful of very deep branches (e.g. `OpenMmapStore`'s replay-during-open, unaligned-offset guards) remain uncovered but keep each function ≥80%; they weren't worth contorting tests for. Coverage went from 88% to 94% — the core store/WAL error handling is now exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)