### PR TITLE
refactor(vectorindex): select distance metric via options only

### DIFF
--- a/cmd/insert-analysis/main.go
+++ b/cmd/insert-analysis/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	inner := vi.NewMemNodeStore()
 	cs := &countingStore{NodeStore: inner}
-	idx := vi.NewHNSWIndex(cs, vi.EuclideanDistance)
+	idx := vi.NewHNSWIndex(cs, vi.WithEuclideanDistance())
 
 	samplePoints := map[int]bool{
 		1000: true, 2000: true, 3000: true, 5000: true,

--- a/internal/core/vectorindex/batch_options_test.go
+++ b/internal/core/vectorindex/batch_options_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,56 +17,100 @@ import (
 
 func TestWithM(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithM(8))
+	idx := NewHNSWIndex(store, WithM(8))
 	assert.Equal(t, 8, idx.M)
 	assert.Equal(t, 16, idx.Mmax0, "Mmax0 should be 2*M")
 }
 
 func TestWithMBoundary(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithM(1))
+	idx := NewHNSWIndex(store, WithM(1))
 	assert.Equal(t, 1, idx.M)
 	assert.Equal(t, 2, idx.Mmax0)
 }
 
 func TestWithEfConstruction(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithEfConstruction(500))
+	idx := NewHNSWIndex(store, WithEfConstruction(500))
 	assert.Equal(t, 500, idx.efConstruction)
 }
 
 func TestWithEfConstructionDefault(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 	assert.Equal(t, DefaultEfConstruction, idx.efConstruction)
 }
 
 func TestWithEfSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithEfSearch(128))
+	idx := NewHNSWIndex(store, WithEfSearch(128))
 	assert.Equal(t, 128, idx.efSearch)
 }
 
 func TestWithEfSearchDefault(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 	assert.Equal(t, DefaultEfSearch, idx.efSearch)
 }
 
 func TestMultipleOptions(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithM(32), WithEfConstruction(400), WithEfSearch(256))
+	idx := NewHNSWIndex(store, WithM(32), WithEfConstruction(400), WithEfSearch(256))
 	assert.Equal(t, 32, idx.M)
 	assert.Equal(t, 64, idx.Mmax0)
 	assert.Equal(t, 400, idx.efConstruction)
 	assert.Equal(t, 256, idx.efSearch)
 }
 
+// The metric options must set the distance function and the norm-cache flag
+// together, so the two can never disagree. The default (no metric option) is
+// cosine, and when several metric options are given the last one wins.
+func TestDistanceMetricOptions(t *testing.T) {
+	store := NewMemNodeStore()
+
+	cases := []struct {
+		name     string
+		opts     []Option
+		wantFn   DistanceFunc
+		isCosine bool
+	}{
+		{"default", nil, CosineDistance, true},
+		{"cosine", []Option{WithCosineDistance()}, CosineDistance, true},
+		{"euclidean", []Option{WithEuclideanDistance()}, EuclideanDistance, false},
+		{"dotproduct", []Option{WithDotProductDistance()}, DotProductDistance, false},
+		// Last metric option wins; the flag stays consistent with it.
+		{"last-wins", []Option{WithCosineDistance(), WithEuclideanDistance()}, EuclideanDistance, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := NewHNSWIndex(store, tc.opts...)
+			assert.Equal(t, tc.isCosine, idx.isCosine)
+			assert.Equal(t,
+				reflect.ValueOf(tc.wantFn).Pointer(),
+				reflect.ValueOf(idx.distance).Pointer(),
+				"distance func mismatch")
+		})
+	}
+}
+
+// WithDistanceFunc installs a custom metric and disables the norm-cache fast
+// path (which is only valid for cosine).
+func TestWithDistanceFunc(t *testing.T) {
+	store := NewMemNodeStore()
+	custom := func(a, b []float32) float32 { return 0 }
+	idx := NewHNSWIndex(store, WithDistanceFunc(custom))
+
+	assert.False(t, idx.isCosine, "custom metric must not use the cosine fast path")
+	assert.Equal(t,
+		reflect.ValueOf(custom).Pointer(),
+		reflect.ValueOf(idx.distance).Pointer())
+}
+
 // --- InsertBatch tests ---
 
 func TestInsertBatchMemStore(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	items := []InsertItem{
 		{DocId: "doc-0", Vector: []float32{1, 0, 0}},
@@ -88,7 +133,7 @@ func TestInsertBatchMemStore(t *testing.T) {
 
 func TestInsertBatchEmpty(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	err := idx.InsertBatch(nil)
 	requireNoError(t, err)
@@ -100,7 +145,7 @@ func TestInsertBatchEmpty(t *testing.T) {
 
 func TestInsertBatchSingle(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	err := idx.InsertBatch([]InsertItem{
 		{DocId: "only", Vector: []float32{1, 2, 3}},
@@ -314,7 +359,7 @@ func TestLoadVectorsTruncatedData(t *testing.T) {
 
 func TestInsertBatchWithCustomOptions(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance,
+	idx := NewHNSWIndex(store,
 		WithCosineDistance(),
 		WithM(4),
 		WithEfConstruction(50),
@@ -387,7 +432,7 @@ func TestEncodeDecodeUint64Roundtrip(t *testing.T) {
 
 func TestHNSWWithMemStoreInsertAndSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1, 0}))

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -57,7 +57,7 @@ func TestBenchmarkSearchLatency(t *testing.T) {
 	t.Logf("Loaded %d vectors, %d queries, %d ground truth sets", len(vectors), len(queries), len(groundTruth))
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance,
+	idx := NewHNSWIndex(store,
 		WithCosineDistance(),
 		WithEfConstruction(200),
 		WithEfSearch(128),
@@ -152,7 +152,7 @@ func TestBenchmarkSearchLatency10K(t *testing.T) {
 	}
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance,
+	idx := NewHNSWIndex(store,
 		WithCosineDistance(),
 		WithEfConstruction(200),
 		WithEfSearch(128),
@@ -238,7 +238,7 @@ func BenchmarkHNSWInsert(b *testing.B) {
 	vecs := randomVectors(rng, b.N, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -261,7 +261,7 @@ func BenchmarkHNSWSearch(b *testing.B) {
 	vecs := randomVectors(rng, n, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
 
 	for i, v := range vecs {
 		if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
@@ -296,7 +296,7 @@ func TestRecallAt10_1000Vectors(t *testing.T) {
 	vecs := randomVectors(rng, n, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance,
+	idx := NewHNSWIndex(store,
 		WithCosineDistance(),
 		WithEfConstruction(200),
 		WithEfSearch(128),
@@ -342,7 +342,7 @@ func TestEdgeCases(t *testing.T) {
 		vecs := randomVectors(rng, n, dim)
 
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+		idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 		for i, v := range vecs {
 			if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
@@ -358,7 +358,7 @@ func TestEdgeCases(t *testing.T) {
 
 	t.Run("empty_graph_search", func(t *testing.T) {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+		idx := NewHNSWIndex(store, WithCosineDistance())
 
 		query := make([]float32, 128)
 		for i := range query {
@@ -383,7 +383,7 @@ func TestEdgeCases(t *testing.T) {
 		vecs := randomVectors(rng, n, dim)
 
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+		idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 		for i, v := range vecs {
 			if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
@@ -462,7 +462,7 @@ func TestBenchmarkParametric(t *testing.T) {
 		}
 
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance)
+		idx := NewHNSWIndex(store)
 
 		t.Run(fmt.Sprintf("N=%d/insert", n), func(t *testing.T) {
 			start := time.Now()
@@ -565,7 +565,7 @@ func TestBenchmarkEfConstructionCompare(t *testing.T) {
 
 	for _, efc := range efConstructionValues {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithEfConstruction(efc))
+		idx := NewHNSWIndex(store, WithEfConstruction(efc))
 
 		t.Run(fmt.Sprintf("efC=%d/insert", efc), func(t *testing.T) {
 			start := time.Now()
@@ -665,7 +665,7 @@ func TestBenchmarkMCompare(t *testing.T) {
 
 	for _, m := range mValues {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithM(m))
+		idx := NewHNSWIndex(store, WithM(m))
 
 		t.Run(fmt.Sprintf("M=%d/insert", m), func(t *testing.T) {
 			start := time.Now()
@@ -809,7 +809,7 @@ func TestBenchmarkSIFT(t *testing.T) {
 	efSearchValues := []int{128, 200, 400}
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, EuclideanDistance)
+	idx := NewHNSWIndex(store, WithEuclideanDistance())
 
 	t.Run("insert", func(t *testing.T) {
 		start := time.Now()

--- a/internal/core/vectorindex/error_path_test.go
+++ b/internal/core/vectorindex/error_path_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRandomLevelDistribution(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithM(16), WithRand(rand.New(rand.NewSource(12345))))
+	idx := NewHNSWIndex(store, WithM(16), WithRand(rand.New(rand.NewSource(12345))))
 
 	const iterations = 10_000
 	counts := make(map[int]int)
@@ -46,7 +46,7 @@ func (zeroSource) Seed(int64)   {}
 // Test the r == 0 guard in randomLevel by injecting a source that returns 0.
 func TestRandomLevelZeroGuard(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithM(16), WithRand(rand.New(zeroSource{})))
+	idx := NewHNSWIndex(store, WithM(16), WithRand(rand.New(zeroSource{})))
 
 	level := idx.randomLevel()
 	assert.GreaterOrEqual(t, level, 0, "level from r=0 must be non-negative")
@@ -59,7 +59,7 @@ func TestRandomLevelZeroGuard(t *testing.T) {
 
 func TestNodeDistanceGetVectorRefError(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	// Node 999 does not exist — GetVectorRef returns an error.
 	_, err := idx.nodeDistance(999, []float32{1.0, 2.0})
@@ -68,7 +68,7 @@ func TestNodeDistanceGetVectorRefError(t *testing.T) {
 
 func TestNodeDistanceSuccess(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	requireNoError(t, store.PutNode(1, 0, []float32{1.0, 0.0}))
 
@@ -84,7 +84,7 @@ func TestNodeDistanceSuccess(t *testing.T) {
 func TestRandomLevelDifferentM(t *testing.T) {
 	for _, m := range []int{4, 8, 32, 64} {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithM(m),
+		idx := NewHNSWIndex(store, WithM(m),
 			WithRand(rand.New(rand.NewSource(42))))
 
 		for i := 0; i < 500; i++ {

--- a/internal/core/vectorindex/error_store_test.go
+++ b/internal/core/vectorindex/error_store_test.go
@@ -165,7 +165,7 @@ var _ NodeStore = (*errorStore)(nil)
 
 func TestInsertNextNodeIdError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	es.NextNodeIdErr = fmt.Errorf("injected: NextNodeId")
 	err := idx.Insert("doc1", []float32{1, 0})
@@ -175,7 +175,7 @@ func TestInsertNextNodeIdError(t *testing.T) {
 
 func TestInsertPutNodeError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	es.PutNodeErr = fmt.Errorf("injected: PutNode")
 	err := idx.Insert("doc1", []float32{1, 0})
@@ -185,7 +185,7 @@ func TestInsertPutNodeError(t *testing.T) {
 
 func TestInsertSetNodeMappingError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	es.SetNodeMappingErr = fmt.Errorf("injected: SetNodeMapping")
 	err := idx.Insert("doc1", []float32{1, 0})
@@ -195,7 +195,7 @@ func TestInsertSetNodeMappingError(t *testing.T) {
 
 func TestInsertSetNeighborsError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	es.SetNeighborsErr = fmt.Errorf("injected: SetNeighbors")
 	err := idx.Insert("doc1", []float32{1, 0})
@@ -208,7 +208,7 @@ func TestInsertSetNeighborsError(t *testing.T) {
 // point to the new node and returns.
 func TestInsertStaleEntryPointRecovers(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	// Insert a first node so the index has an entry point.
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
@@ -225,7 +225,7 @@ func TestInsertStaleEntryPointRecovers(t *testing.T) {
 // Same branch, but SetEntryPoint itself fails during the recovery.
 func TestInsertStaleEntryPointSetEntryPointError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 
@@ -239,7 +239,7 @@ func TestInsertStaleEntryPointSetEntryPointError(t *testing.T) {
 // First-node insert path where SetEntryPoint fails.
 func TestInsertFirstNodeSetEntryPointError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	es.SetEntryPointErr = fmt.Errorf("injected: SetEntryPoint")
 	err := idx.Insert("doc1", []float32{1, 0})
@@ -253,7 +253,7 @@ func TestInsertFirstNodeSetEntryPointError(t *testing.T) {
 
 func TestSearchGetEntryPointError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	// Empty index — GetEntryPoint returns error. Search returns nil, nil.
 	results, err := idx.Search([]float32{1, 0}, 5)
@@ -263,7 +263,7 @@ func TestSearchGetEntryPointError(t *testing.T) {
 
 func TestSearchStaleEntryPoint(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 
@@ -280,7 +280,7 @@ func TestSearchStaleEntryPoint(t *testing.T) {
 
 func TestDeleteGetNodeIdError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	es.GetNodeIdErr = fmt.Errorf("injected: GetNodeId")
 	err := idx.Delete("doc1")
@@ -290,7 +290,7 @@ func TestDeleteGetNodeIdError(t *testing.T) {
 
 func TestDeleteGetNodeLevelError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 
@@ -302,7 +302,7 @@ func TestDeleteGetNodeLevelError(t *testing.T) {
 
 func TestDeleteGetNeighborsError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 
@@ -314,7 +314,7 @@ func TestDeleteGetNeighborsError(t *testing.T) {
 
 func TestDeleteDeleteNodeError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 
@@ -326,7 +326,7 @@ func TestDeleteDeleteNodeError(t *testing.T) {
 
 func TestDeleteDeleteNodeMappingError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 
@@ -338,7 +338,7 @@ func TestDeleteDeleteNodeMappingError(t *testing.T) {
 
 func TestDeleteSetNeighborsError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	// Insert enough nodes so that Delete has neighbors to reconnect.
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0, 0}))
@@ -357,7 +357,7 @@ func TestDeleteSetNeighborsError(t *testing.T) {
 
 func TestNodeDistanceWithNormFallback(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(es, WithCosineDistance())
 
 	requireNoError(t, es.inner.PutNode(1, 0, []float32{1, 0}))
 	requireNoError(t, es.inner.SetNorm(1, vek32.Norm([]float32{1, 0})))
@@ -376,7 +376,7 @@ func TestNodeDistanceWithNormFallback(t *testing.T) {
 
 func TestInsertWithCosineDistanceMultiNode(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(es, WithCosineDistance())
 
 	// Insert several nodes to exercise phase-1 greedy traversal and
 	// phase-2 neighbor selection with cosine + norm caching.
@@ -397,7 +397,7 @@ func TestInsertWithCosineDistanceMultiNode(t *testing.T) {
 
 func TestInsertBatchPropagatesError(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	items := []InsertItem{
 		{DocId: "a", Vector: []float32{1, 0}},
@@ -413,7 +413,7 @@ func TestInsertBatchPropagatesError(t *testing.T) {
 // Delete a doc that was never inserted — should be a no-op.
 func TestDeleteNonExistentDoc(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	err := idx.Delete("never-inserted")
 	requireNoError(t, err)
@@ -423,7 +423,7 @@ func TestDeleteNonExistentDoc(t *testing.T) {
 // via GetEntryPoint error after the index was previously populated.
 func TestInsertAfterDeleteAll(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(es, WithCosineDistance())
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 	requireNoError(t, idx.Insert("doc2", []float32{0, 1}))

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -59,20 +59,58 @@ func WithRand(r *rand.Rand) Option {
 	return func(h *HNSWIndex) { h.rng = r }
 }
 
-// WithCosineDistance marks the index as using cosine distance, enabling
-// precomputed norm optimizations. Pass this option when using CosineDistance
-// as the distance function.
+// The distance metric is selected with one of the With*Distance options below.
+// Each sets both h.distance and h.isCosine together, so the metric and the
+// norm-cache fast path can never disagree — there is no separate distance
+// argument to fall out of sync. nodeDistCalc selects the norm-cache fast path
+// purely off isCosine; if isCosine were true under a non-cosine metric,
+// searchLayer/nodeDistCalc would use cosine-with-norms while the shrink/delete
+// paths used h.distance, i.e. two metrics on one graph. When no metric option
+// is passed, the index defaults to cosine (see NewHNSWIndex).
+
+// WithCosineDistance selects cosine distance and enables precomputed-norm
+// optimizations. This is also the default when no metric option is given.
 func WithCosineDistance() Option {
 	return func(h *HNSWIndex) {
+		h.distance = CosineDistance
 		h.isCosine = true
 	}
 }
 
-// NewHNSWIndex creates a new HNSW index.
-func NewHNSWIndex(store NodeStore, distance DistanceFunc, opts ...Option) *HNSWIndex {
+// WithEuclideanDistance selects L2 (Euclidean) distance.
+func WithEuclideanDistance() Option {
+	return func(h *HNSWIndex) {
+		h.distance = EuclideanDistance
+		h.isCosine = false
+	}
+}
+
+// WithDotProductDistance selects dot-product distance (1 - dot), intended for
+// pre-normalized vectors.
+func WithDotProductDistance() Option {
+	return func(h *HNSWIndex) {
+		h.distance = DotProductDistance
+		h.isCosine = false
+	}
+}
+
+// WithDistanceFunc selects a custom distance metric. The norm-cache fast path
+// is disabled, as it is only valid for cosine distance.
+func WithDistanceFunc(fn DistanceFunc) Option {
+	return func(h *HNSWIndex) {
+		h.distance = fn
+		h.isCosine = false
+	}
+}
+
+// NewHNSWIndex creates a new HNSW index. The distance metric is chosen with a
+// With*Distance option; when none is given the index defaults to cosine
+// distance with norm caching.
+func NewHNSWIndex(store NodeStore, opts ...Option) *HNSWIndex {
 	h := &HNSWIndex{
 		store:          store,
-		distance:       distance,
+		distance:       CosineDistance,
+		isCosine:       true,
 		M:              DefaultM,
 		Mmax0:          DefaultMmax0,
 		efConstruction: DefaultEfConstruction,

--- a/internal/core/vectorindex/hnsw_concurrency_test.go
+++ b/internal/core/vectorindex/hnsw_concurrency_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConcurrentInsertAndSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	dim := 32
 	var wg sync.WaitGroup
@@ -59,7 +59,7 @@ func TestConcurrentInsertAndSearch(t *testing.T) {
 
 func TestConcurrentSearchOnly(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	dim := 32
 	n := 100
@@ -106,7 +106,7 @@ func TestConcurrentSearchOnly(t *testing.T) {
 
 func TestConcurrentInsertDeleteSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	dim := 32
 

--- a/internal/core/vectorindex/hnsw_coverage_test.go
+++ b/internal/core/vectorindex/hnsw_coverage_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRandomLevel(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	// Call many times, verify always >= 0
 	for i := 0; i < 1000; i++ {
@@ -19,7 +19,7 @@ func TestRandomLevel(t *testing.T) {
 
 func TestNodeDistance_NonExistentNode(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	// nodeDistance on non-existent node should return error
 	_, err := idx.nodeDistance(999, []float32{1, 2, 3})
@@ -28,7 +28,7 @@ func TestNodeDistance_NonExistentNode(t *testing.T) {
 
 func TestNodeDistanceWithNorm_NonExistentNode(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	_, err := idx.nodeDistanceWithNorm(999, []float32{1, 2, 3}, 1.0)
 	assert.Error(t, err)
@@ -36,7 +36,7 @@ func TestNodeDistanceWithNorm_NonExistentNode(t *testing.T) {
 
 func TestNodeDistance_ValidNode(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	err := idx.Insert("doc1", []float32{1, 0, 0})
 	assert.NoError(t, err)

--- a/internal/core/vectorindex/hnsw_integration_test.go
+++ b/internal/core/vectorindex/hnsw_integration_test.go
@@ -25,7 +25,7 @@ func TestIntegrationResultConsistency(t *testing.T) {
 	queries := randomVectors(rng, numQueries, dim)
 
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(hnswSeed))))
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(), WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 	for i, v := range vecs {
 		requireNoError(t, memIdx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -43,7 +43,7 @@ func TestIntegrationResultConsistency(t *testing.T) {
 // MemNodeStore.
 func TestIntegrationCRUD(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	// Insert 3 known vectors.
 	requireNoError(t, idx.Insert("alpha", []float32{1, 0, 0}))

--- a/internal/core/vectorindex/hnsw_test.go
+++ b/internal/core/vectorindex/hnsw_test.go
@@ -288,7 +288,7 @@ func bruteForceKNN(query []float32, vecs [][]float32, k int, dist DistanceFunc) 
 
 func TestHNSWEmptyIndex(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	results, err := idx.Search([]float32{1, 2, 3}, 10)
 	requireNoError(t, err)
@@ -297,7 +297,7 @@ func TestHNSWEmptyIndex(t *testing.T) {
 
 func TestHNSWSingleVector(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance())
+	idx := NewHNSWIndex(store, WithCosineDistance())
 
 	requireNoError(t, idx.Insert("doc-1", []float32{1, 0, 0}))
 
@@ -320,7 +320,7 @@ func TestHNSWRecallSmall(t *testing.T) {
 	queries := randomVectors(rng, numQueries, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -397,7 +397,7 @@ func TestHNSWRecallLarger(t *testing.T) {
 	queries := randomVectors(rng, numQueries, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -436,7 +436,7 @@ func TestHNSWNeighborLimits(t *testing.T) {
 	vecs := randomVectors(rng, n, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(88))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(88))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -464,7 +464,7 @@ func TestHNSWNeighborLimits(t *testing.T) {
 
 func TestHNSWEntryPointUpdate(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(1))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(1))))
 
 	// Insert many vectors; track the max level seen.
 	maxLevelSeen := 0
@@ -509,7 +509,7 @@ func TestHNSWDelete(t *testing.T) {
 
 	vecs := randomVectors(rng, n, dim)
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(100))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(100))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -544,7 +544,7 @@ func TestHNSWDelete(t *testing.T) {
 
 func TestHNSWWithEuclideanDistance(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, EuclideanDistance, WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithEuclideanDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("a", []float32{0, 0}))
 	requireNoError(t, idx.Insert("b", []float32{1, 0}))
@@ -561,7 +561,7 @@ func TestHNSWWithEuclideanDistance(t *testing.T) {
 
 func TestHNSWWithDotProductDistance(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, DotProductDistance, WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithDotProductDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	// Normalized vectors.
 	sqrt2 := float32(1.0 / math.Sqrt(2))
@@ -581,7 +581,7 @@ func TestHNSWWithDotProductDistance(t *testing.T) {
 
 func TestHNSWDeleteEntryPoint(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1}))
@@ -608,7 +608,7 @@ func TestHNSWDeleteEntryPoint(t *testing.T) {
 
 func TestHNSWDeleteAllVectors(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1}))
@@ -624,7 +624,7 @@ func TestHNSWDeleteAllVectors(t *testing.T) {
 
 func TestHNSWSearchKGreaterThanN(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1, 0}))
@@ -637,7 +637,7 @@ func TestHNSWSearchKGreaterThanN(t *testing.T) {
 
 func TestHNSWInsertUpsert(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	// Insert a vector
 	err := idx.Insert("doc1", []float32{1, 0, 0})
@@ -661,7 +661,7 @@ func TestHNSWInsertUpsert(t *testing.T) {
 
 func TestHNSWInsertUpsertMultiple(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	// Insert 5 vectors
 	for i := 0; i < 5; i++ {

--- a/internal/core/vectorindex/mmap_bench50k_test.go
+++ b/internal/core/vectorindex/mmap_bench50k_test.go
@@ -48,7 +48,7 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 			}
 			defer store.Close()
 
-			idx := NewHNSWIndex(store, EuclideanDistance)
+			idx := NewHNSWIndex(store, WithEuclideanDistance())
 
 			t.Logf("Inserting %d vectors: batch_size=%d, sync per batch...", nBase, bs)
 			start := time.Now()
@@ -124,7 +124,7 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, EuclideanDistance)
+		idx := NewHNSWIndex(store, WithEuclideanDistance())
 
 		t.Log("Inserting 50K vectors: deferred sync (single bulk)...")
 		if err := store.SetSyncMode(SyncDeferred); err != nil {

--- a/internal/core/vectorindex/mmap_store_bench_test.go
+++ b/internal/core/vectorindex/mmap_store_bench_test.go
@@ -224,7 +224,7 @@ func BenchmarkHNSW_MemStore_50K_Insert(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(42))))
 
 		start := time.Now()
@@ -258,7 +258,7 @@ func BenchmarkHNSW_MmapStore_50K_Insert(b *testing.B) {
 		}
 
 		start := time.Now()
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(42))))
 
 		for i, v := range vecs {
@@ -302,7 +302,7 @@ func BenchmarkHNSW_Search_MemStore_vs_MmapStore(b *testing.B) {
 
 	// Build MemStore index.
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range vecs {
 		if err := memIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
@@ -318,7 +318,7 @@ func BenchmarkHNSW_Search_MemStore_vs_MmapStore(b *testing.B) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, CosineDistance, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range vecs {
 		if err := mmapIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
@@ -391,7 +391,7 @@ func TestRecallAt10_SIFT(t *testing.T) {
 
 	// Test MemStore recall.
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
 		if err := memIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
@@ -420,7 +420,7 @@ func TestRecallAt10_SIFT(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, CosineDistance, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
 		if err := mmapIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -27,7 +27,7 @@ func TestMmapHNSW_InsertSearch(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+	idx := NewHNSWIndex(store, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -70,7 +70,7 @@ func TestMmapHNSW_InsertDeleteSearch(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+	idx := NewHNSWIndex(store, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -130,7 +130,7 @@ func TestMmapHNSW_DeleteReinsert(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+	idx := NewHNSWIndex(store, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -181,7 +181,7 @@ func TestMmapHNSW_Upsert(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+	idx := NewHNSWIndex(store, WithCosineDistance(),
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -301,7 +301,7 @@ func TestMmapHNSW_PersistenceReopen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i, v := range vecs {
@@ -324,7 +324,7 @@ func TestMmapHNSW_PersistenceReopen(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		postResults := mmapHNSWSearchResults(t, idx, queries, k)
@@ -352,7 +352,7 @@ func TestMmapHNSW_PersistenceReopenContinueInsert(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i := 0; i < n1; i++ {
@@ -373,7 +373,7 @@ func TestMmapHNSW_PersistenceReopenContinueInsert(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i := n1; i < n1+n2; i++ {
@@ -418,7 +418,7 @@ func TestMmapHNSW_PersistenceReopenDelete(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i, v := range vecs {
@@ -439,7 +439,7 @@ func TestMmapHNSW_PersistenceReopenDelete(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i := 0; i < numDeleted; i++ {
@@ -504,7 +504,7 @@ func TestMmapHNSW_WALReplayE2E(t *testing.T) {
 		}
 		t.Cleanup(crashCleanup)
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i, v := range vecs {
@@ -528,7 +528,7 @@ func TestMmapHNSW_WALReplayE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { store.Close() })
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		postResults := mmapHNSWSearchResults(t, idx, queries, k)
@@ -557,7 +557,7 @@ func TestMmapHNSW_UpperGraph_MultiLayer(t *testing.T) {
 	defer store.Close()
 
 	// Use efConstruction=200 and fixed seed to get deterministic upper layers.
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+	idx := NewHNSWIndex(store, WithCosineDistance(),
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(42))))
 
@@ -604,7 +604,7 @@ func TestMmapHNSW_UpperGraph_MultiLayer(t *testing.T) {
 
 	// Build MemStore baseline for structural comparison.
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(42))))
 	for i, v := range vecs {
@@ -667,7 +667,7 @@ func TestMmapHNSW_UpperGraph_PersistenceReopen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -694,7 +694,7 @@ func TestMmapHNSW_UpperGraph_PersistenceReopen(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -753,7 +753,7 @@ func TestMmapHNSW_UpperGraph_GrowCrashRecovery(t *testing.T) {
 		}
 		t.Cleanup(crashCleanup)
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -783,7 +783,7 @@ func TestMmapHNSW_UpperGraph_GrowCrashRecovery(t *testing.T) {
 		}
 		t.Cleanup(func() { store.Close() })
 
-		idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(),
+		idx := NewHNSWIndex(store, WithCosineDistance(),
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -873,7 +873,7 @@ func TestMmapHNSW_RecallAt10(t *testing.T) {
 
 	// --- MemStore recall ---
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
@@ -903,7 +903,7 @@ func TestMmapHNSW_RecallAt10(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, CosineDistance, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	insertAllBatch(t, mmapIdx, baseVecs)
@@ -949,7 +949,7 @@ func TestMmapHNSW_ExportRecall(t *testing.T) {
 	hnswSeed := int64(42)
 
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
@@ -967,7 +967,7 @@ func TestMmapHNSW_ExportRecall(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, CosineDistance, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -1007,7 +1007,7 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 	hnswSeed := int64(42)
 
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, CosineDistance, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i := 0; i < n; i++ {
@@ -1023,7 +1023,7 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, CosineDistance, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 

--- a/internal/core/vectorindex/recall_debug_test.go
+++ b/internal/core/vectorindex/recall_debug_test.go
@@ -27,7 +27,7 @@ func TestHNSWRecallDebug10K(t *testing.T) {
 
 	// Build the index once and reuse it for all efSearch values.
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance, WithCosineDistance(), WithRand(rand.New(rand.NewSource(seed))))
+	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(seed))))
 
 	for i, v := range vecs {
 		if err := idx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {

--- a/internal/core/vectorindex/upsert_test.go
+++ b/internal/core/vectorindex/upsert_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestHNSWUpsertEntryPoint(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	// Insert single node — becomes entry point
 	err := idx.Insert("doc1", []float32{1, 0, 0})
@@ -38,7 +38,7 @@ func TestHNSWUpsertEntryPoint(t *testing.T) {
 
 func TestHNSWInsertBatchDuplicateDocId(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, CosineDistance)
+	idx := NewHNSWIndex(store)
 
 	items := []InsertItem{
 		{DocId: "doc1", Vector: []float32{1, 0, 0}},
@@ -62,7 +62,7 @@ func TestHNSWInsertBatchDuplicateDocId(t *testing.T) {
 
 func TestHNSWInsertBatchPartialFailure(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, CosineDistance)
+	idx := NewHNSWIndex(es)
 
 	// Insert initial data
 	err := idx.Insert("existing", []float32{1, 0, 0})


### PR DESCRIPTION
## What

`NewHNSWIndex` used to take a positional `DistanceFunc` **and** a separate `WithCosineDistance()` flag that toggled the norm-cache fast path. Those were two independent sources of truth that had to be kept in sync by hand:

- Passing `CosineDistance` **without** the flag → correct but silently skipped the norm-cache optimization (slow). A bunch of existing tests did exactly this.
- Passing a non-cosine metric **with** the flag → **silently wrong** index: `nodeDistCalc` used cosine-with-norms while the shrink/delete paths used the positional func — two metrics on one graph. Nothing validated the pairing.

## Change

Drop the positional argument; the metric is now chosen with exactly one option, each of which sets **both** `h.distance` and `h.isCosine` together, so they can never disagree:

| Option | Metric | Norm cache |
|--------|--------|------------|
| `WithCosineDistance()` | cosine (**default**) | on |
| `WithEuclideanDistance()` | L2 | off |
| `WithDotProductDistance()` | 1 − dot | off |
| `WithDistanceFunc(fn)` | custom | off |

`NewHNSWIndex(store)` with no metric option defaults to cosine + norm cache.

```go
// before
NewHNSWIndex(store, CosineDistance, WithCosineDistance())
// after
NewHNSWIndex(store, WithCosineDistance())
```

## Scope / compatibility

Breaking signature change, but `vectorindex` is `internal/` with no external consumers. All ~90 call sites updated (nearly all tests + one in `cmd/insert-analysis`).

## Tests

- New `TestDistanceMetricOptions` (default / cosine / euclidean / dotproduct / last-wins) and `TestWithDistanceFunc` lock in the metric↔flag consistency guarantee.
- `go build ./...`, `go vet ./internal/core/vectorindex/ ./cmd/...`, and the full `vectorindex` package test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)