### PR TITLE
perf(vectorindex): normalized cosine storage via store-owned metric (insert -16%, search -17%)

### DIFF
--- a/.github/workflows/scripts/test_and_coverage.sh
+++ b/.github/workflows/scripts/test_and_coverage.sh
@@ -4,4 +4,4 @@
 
 set -e
 
-go run github.com/codetreker/go-cov/cmd/go-cov@v0.1.0
+go run github.com/codetreker/go-cov/cmd/go-cov@v0.1.1

--- a/cmd/insert-analysis/main.go
+++ b/cmd/insert-analysis/main.go
@@ -79,9 +79,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	inner := vi.NewMemNodeStore()
+	inner := vi.NewMemNodeStore(vi.Euclidean)
 	cs := &countingStore{NodeStore: inner}
-	idx := vi.NewHNSWIndex(cs, vi.WithEuclideanDistance())
+	idx := vi.NewHNSWIndex(cs)
 
 	samplePoints := map[int]bool{
 		1000: true, 2000: true, 3000: true, 5000: true,

--- a/internal/core/vectorindex/batch_options_test.go
+++ b/internal/core/vectorindex/batch_options_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,55 +61,22 @@ func TestMultipleOptions(t *testing.T) {
 	assert.Equal(t, 256, idx.efSearch)
 }
 
-// The metric options must set the distance function and the norm-cache flag
-// together, so the two can never disagree. The default (no metric option) is
-// cosine, and when several metric options are given the last one wins.
-func TestDistanceMetricOptions(t *testing.T) {
-	store := NewMemNodeStore()
-
-	cases := []struct {
-		name     string
-		opts     []Option
-		wantFn   DistanceFunc
-		isCosine bool
-	}{
-		{"default", nil, CosineDistance, true},
-		{"cosine", []Option{WithCosineDistance()}, CosineDistance, true},
-		{"euclidean", []Option{WithEuclideanDistance()}, EuclideanDistance, false},
-		{"dotproduct", []Option{WithDotProductDistance()}, DotProductDistance, false},
-		// Last metric option wins; the flag stays consistent with it.
-		{"last-wins", []Option{WithCosineDistance(), WithEuclideanDistance()}, EuclideanDistance, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			idx := NewHNSWIndex(store, tc.opts...)
-			assert.Equal(t, tc.isCosine, idx.isCosine)
-			assert.Equal(t,
-				reflect.ValueOf(tc.wantFn).Pointer(),
-				reflect.ValueOf(idx.distance).Pointer(),
-				"distance func mismatch")
+// The index takes its distance metric from the store, so the metric, the
+// on-disk vector form, and the graph can never disagree.
+func TestIndexMetricFromStore(t *testing.T) {
+	for _, m := range []Metric{Cosine, DotProduct, Euclidean} {
+		t.Run(m.String(), func(t *testing.T) {
+			idx := NewHNSWIndex(NewMemNodeStore(m))
+			assert.Equal(t, m, idx.metric)
 		})
 	}
-}
-
-// WithDistanceFunc installs a custom metric and disables the norm-cache fast
-// path (which is only valid for cosine).
-func TestWithDistanceFunc(t *testing.T) {
-	store := NewMemNodeStore()
-	custom := func(a, b []float32) float32 { return 0 }
-	idx := NewHNSWIndex(store, WithDistanceFunc(custom))
-
-	assert.False(t, idx.isCosine, "custom metric must not use the cosine fast path")
-	assert.Equal(t,
-		reflect.ValueOf(custom).Pointer(),
-		reflect.ValueOf(idx.distance).Pointer())
 }
 
 // --- InsertBatch tests ---
 
 func TestInsertBatchMemStore(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	items := []InsertItem{
 		{DocId: "doc-0", Vector: []float32{1, 0, 0}},
@@ -133,7 +99,7 @@ func TestInsertBatchMemStore(t *testing.T) {
 
 func TestInsertBatchEmpty(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	err := idx.InsertBatch(nil)
 	requireNoError(t, err)
@@ -145,7 +111,7 @@ func TestInsertBatchEmpty(t *testing.T) {
 
 func TestInsertBatchSingle(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	err := idx.InsertBatch([]InsertItem{
 		{DocId: "only", Vector: []float32{1, 2, 3}},
@@ -182,7 +148,7 @@ func TestMemNodeStoreGetNormNotFound(t *testing.T) {
 }
 
 func TestMemNodeStoreGetVectorRef(t *testing.T) {
-	store := NewMemNodeStore()
+	store := NewMemNodeStore(DotProduct)
 	requireNoError(t, store.PutNode(1, 0, []float32{1.5, 2.5, 3.5}))
 
 	ref, err := store.GetVectorRef(1)
@@ -360,7 +326,6 @@ func TestLoadVectorsTruncatedData(t *testing.T) {
 func TestInsertBatchWithCustomOptions(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store,
-		WithCosineDistance(),
 		WithM(4),
 		WithEfConstruction(50),
 		WithEfSearch(32),
@@ -432,7 +397,7 @@ func TestEncodeDecodeUint64Roundtrip(t *testing.T) {
 
 func TestHNSWWithMemStoreInsertAndSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1, 0}))

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -58,7 +58,6 @@ func TestBenchmarkSearchLatency(t *testing.T) {
 
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store,
-		WithCosineDistance(),
 		WithEfConstruction(200),
 		WithEfSearch(128),
 	)
@@ -153,7 +152,6 @@ func TestBenchmarkSearchLatency10K(t *testing.T) {
 
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store,
-		WithCosineDistance(),
 		WithEfConstruction(200),
 		WithEfSearch(128),
 	)
@@ -238,7 +236,7 @@ func BenchmarkHNSWInsert(b *testing.B) {
 	vecs := randomVectors(rng, b.N, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(99))))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -261,7 +259,7 @@ func BenchmarkHNSWSearch(b *testing.B) {
 	vecs := randomVectors(rng, n, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(99))))
 
 	for i, v := range vecs {
 		if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
@@ -297,7 +295,6 @@ func TestRecallAt10_1000Vectors(t *testing.T) {
 
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store,
-		WithCosineDistance(),
 		WithEfConstruction(200),
 		WithEfSearch(128),
 		WithRand(rand.New(rand.NewSource(seed))),
@@ -342,7 +339,7 @@ func TestEdgeCases(t *testing.T) {
 		vecs := randomVectors(rng, n, dim)
 
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+		idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 		for i, v := range vecs {
 			if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
@@ -358,7 +355,7 @@ func TestEdgeCases(t *testing.T) {
 
 	t.Run("empty_graph_search", func(t *testing.T) {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, WithCosineDistance())
+		idx := NewHNSWIndex(store)
 
 		query := make([]float32, 128)
 		for i := range query {
@@ -383,7 +380,7 @@ func TestEdgeCases(t *testing.T) {
 		vecs := randomVectors(rng, n, dim)
 
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+		idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 		for i, v := range vecs {
 			if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
@@ -808,8 +805,8 @@ func TestBenchmarkSIFT(t *testing.T) {
 	t.Logf("Ground truth computed")
 	efSearchValues := []int{128, 200, 400}
 
-	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithEuclideanDistance())
+	store := NewMemNodeStore(Euclidean)
+	idx := NewHNSWIndex(store)
 
 	t.Run("insert", func(t *testing.T) {
 		start := time.Now()

--- a/internal/core/vectorindex/error_path_test.go
+++ b/internal/core/vectorindex/error_path_test.go
@@ -62,7 +62,7 @@ func TestNodeDistanceGetVectorRefError(t *testing.T) {
 	idx := NewHNSWIndex(store)
 
 	// Node 999 does not exist — GetVectorRef returns an error.
-	_, err := idx.nodeDistance(999, []float32{1.0, 2.0})
+	_, err := idx.nodeDist(999, []float32{1.0, 2.0})
 	assert.Error(t, err, "nodeDistance should propagate GetVectorRef error")
 }
 
@@ -72,7 +72,7 @@ func TestNodeDistanceSuccess(t *testing.T) {
 
 	requireNoError(t, store.PutNode(1, 0, []float32{1.0, 0.0}))
 
-	dist, err := idx.nodeDistance(1, []float32{1.0, 0.0})
+	dist, err := idx.nodeDist(1, []float32{1.0, 0.0})
 	requireNoError(t, err)
 	assert.InDelta(t, 0.0, dist, 1e-6, "distance to self should be ~0")
 }

--- a/internal/core/vectorindex/error_store_test.go
+++ b/internal/core/vectorindex/error_store_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/viterin/vek/vek32"
 )
 
 // errorStore is a NodeStore mock that wraps MemNodeStore and lets callers
@@ -43,6 +42,8 @@ func (e *errorStore) getErr(err error) error {
 	defer e.mu.RUnlock()
 	return err
 }
+
+func (e *errorStore) Metric() Metric { return Cosine }
 
 func (e *errorStore) GetVector(id uint64) ([]float32, error) {
 	if err := e.getErr(e.GetVectorErr); err != nil {
@@ -355,28 +356,13 @@ func TestDeleteSetNeighborsError(t *testing.T) {
 // nodeDistanceWithNorm — fallback when GetNorm fails
 // =====================================================================
 
-func TestNodeDistanceWithNormFallback(t *testing.T) {
-	es := newErrorStore()
-	idx := NewHNSWIndex(es, WithCosineDistance())
-
-	requireNoError(t, es.inner.PutNode(1, 0, []float32{1, 0}))
-	requireNoError(t, es.inner.SetNorm(1, vek32.Norm([]float32{1, 0})))
-
-	// Inject GetNorm error — nodeDistanceWithNorm should fall back to
-	// computing the distance without precomputed norms.
-	es.GetNormErr = fmt.Errorf("injected: GetNorm")
-	dist, err := idx.nodeDistanceWithNorm(1, []float32{1, 0}, vek32.Norm([]float32{1, 0}))
-	requireNoError(t, err)
-	assert.InDelta(t, 0.0, dist, 1e-5)
-}
-
 // =====================================================================
 // Insert with cosine distance — exercises nodeDistCalc / norm path
 // =====================================================================
 
 func TestInsertWithCosineDistanceMultiNode(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, WithCosineDistance())
+	idx := NewHNSWIndex(es)
 
 	// Insert several nodes to exercise phase-1 greedy traversal and
 	// phase-2 neighbor selection with cosine + norm caching.
@@ -423,7 +409,7 @@ func TestDeleteNonExistentDoc(t *testing.T) {
 // via GetEntryPoint error after the index was previously populated.
 func TestInsertAfterDeleteAll(t *testing.T) {
 	es := newErrorStore()
-	idx := NewHNSWIndex(es, WithCosineDistance())
+	idx := NewHNSWIndex(es)
 
 	requireNoError(t, idx.Insert("doc1", []float32{1, 0}))
 	requireNoError(t, idx.Insert("doc2", []float32{0, 1}))

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -6,8 +6,6 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
-
-	"github.com/viterin/vek/vek32"
 )
 
 // Default HNSW parameters per arXiv:1603.09320.
@@ -23,8 +21,7 @@ const (
 type HNSWIndex struct {
 	mu             sync.RWMutex
 	store          NodeStore
-	distance       DistanceFunc
-	isCosine       bool // true when distance == CosineDistance, enables norm caching
+	metric         Metric // taken from the store; immutable for the index's life
 	M              int
 	Mmax0          int
 	efConstruction int
@@ -59,58 +56,17 @@ func WithRand(r *rand.Rand) Option {
 	return func(h *HNSWIndex) { h.rng = r }
 }
 
-// The distance metric is selected with one of the With*Distance options below.
-// Each sets both h.distance and h.isCosine together, so the metric and the
-// norm-cache fast path can never disagree — there is no separate distance
-// argument to fall out of sync. nodeDistCalc selects the norm-cache fast path
-// purely off isCosine; if isCosine were true under a non-cosine metric,
-// searchLayer/nodeDistCalc would use cosine-with-norms while the shrink/delete
-// paths used h.distance, i.e. two metrics on one graph. When no metric option
-// is passed, the index defaults to cosine (see NewHNSWIndex).
+// The distance metric is a property of the store, not the index: it is chosen
+// when the store is created, persisted in the store metadata, and read back via
+// store.Metric(). The index cannot override it, so the metric, the on-disk
+// vector form, and the graph can never disagree.
 
-// WithCosineDistance selects cosine distance and enables precomputed-norm
-// optimizations. This is also the default when no metric option is given.
-func WithCosineDistance() Option {
-	return func(h *HNSWIndex) {
-		h.distance = CosineDistance
-		h.isCosine = true
-	}
-}
-
-// WithEuclideanDistance selects L2 (Euclidean) distance.
-func WithEuclideanDistance() Option {
-	return func(h *HNSWIndex) {
-		h.distance = EuclideanDistance
-		h.isCosine = false
-	}
-}
-
-// WithDotProductDistance selects dot-product distance (1 - dot), intended for
-// pre-normalized vectors.
-func WithDotProductDistance() Option {
-	return func(h *HNSWIndex) {
-		h.distance = DotProductDistance
-		h.isCosine = false
-	}
-}
-
-// WithDistanceFunc selects a custom distance metric. The norm-cache fast path
-// is disabled, as it is only valid for cosine distance.
-func WithDistanceFunc(fn DistanceFunc) Option {
-	return func(h *HNSWIndex) {
-		h.distance = fn
-		h.isCosine = false
-	}
-}
-
-// NewHNSWIndex creates a new HNSW index. The distance metric is chosen with a
-// With*Distance option; when none is given the index defaults to cosine
-// distance with norm caching.
+// NewHNSWIndex creates a new HNSW index over store. The distance metric is taken
+// from store.Metric().
 func NewHNSWIndex(store NodeStore, opts ...Option) *HNSWIndex {
 	h := &HNSWIndex{
 		store:          store,
-		distance:       CosineDistance,
-		isCosine:       true,
+		metric:         store.Metric(),
 		M:              DefaultM,
 		Mmax0:          DefaultMmax0,
 		efConstruction: DefaultEfConstruction,
@@ -213,10 +169,8 @@ func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 
 	// Phase 1: From top layer down to l+1, greedy search with ef=1.
 	curEp := epId
-	var queryNorm float32
-	if h.isCosine {
-		queryNorm = vek32.Norm(vector)
-	}
+	// Compare against stored neighbors in stored form (cosine: unit vectors).
+	prepared, _ := h.metric.prepare(vector)
 	for layer := maxLayer; layer > l; layer-- {
 		changed := true
 		for changed {
@@ -225,12 +179,12 @@ func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 			if nerr != nil {
 				return nerr
 			}
-			curDist, derr := h.nodeDistCalc(curEp, vector, queryNorm)
+			curDist, derr := h.nodeDist(curEp, prepared)
 			if derr != nil {
 				return derr
 			}
 			for _, nb := range neighbors {
-				nbDist, derr := h.nodeDistCalc(nb, vector, queryNorm)
+				nbDist, derr := h.nodeDist(nb, prepared)
 				if derr != nil {
 					continue // node may have been deleted
 				}
@@ -249,7 +203,7 @@ func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 		topLayer = maxLayer
 	}
 	for layer := topLayer; layer >= 0; layer-- {
-		candidates, err := h.searchLayer(vector, curEp, h.efConstruction, layer)
+		candidates, err := h.searchLayer(prepared, curEp, h.efConstruction, layer)
 		if err != nil {
 			return err
 		}
@@ -295,7 +249,7 @@ func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 					shrinkVecCache[cid] = cVec
 					nbCandidates = append(nbCandidates, distItem{
 						id:   cid,
-						dist: h.distance(nbVec, cVec),
+						dist: h.metric.distance(nbVec, cVec),
 					})
 				}
 				shrunk := h.selectNeighborsHeuristic(nbVec, nbCandidates, mMax, shrinkVecCache)
@@ -379,10 +333,8 @@ func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {
 
 	// Phase 1: From top layer down to 1, greedy search with ef=1.
 	curEp := epId
-	var queryNorm float32
-	if h.isCosine {
-		queryNorm = vek32.Norm(query)
-	}
+	// Compare against stored vectors in stored form (cosine: unit vectors).
+	prepared, _ := h.metric.prepare(query)
 	for layer := maxLayer; layer >= 1; layer-- {
 		changed := true
 		for changed {
@@ -391,12 +343,12 @@ func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {
 			if nerr != nil {
 				return nil, nerr
 			}
-			curDist, derr := h.nodeDistCalc(curEp, query, queryNorm)
+			curDist, derr := h.nodeDist(curEp, prepared)
 			if derr != nil {
 				return nil, derr
 			}
 			for _, nb := range neighbors {
-				nbDist, derr := h.nodeDistCalc(nb, query, queryNorm)
+				nbDist, derr := h.nodeDist(nb, prepared)
 				if derr != nil {
 					continue // node may have been deleted
 				}
@@ -414,7 +366,7 @@ func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {
 	if k > ef {
 		ef = k
 	}
-	results, err := h.searchLayer(query, curEp, ef, 0)
+	results, err := h.searchLayer(prepared, curEp, ef, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -506,7 +458,7 @@ func (h *HNSWIndex) deleteNodeLocked(nodeId uint64, docId string) error {
 				}
 				candidates = append(candidates, distItem{
 					id:   cid,
-					dist: h.distance(nbVec, cVec),
+					dist: h.metric.distance(nbVec, cVec),
 				})
 			}
 
@@ -568,14 +520,9 @@ func (h *HNSWIndex) deleteNodeLocked(nodeId uint64, docId string) error {
 
 // searchLayer performs a beam search on a single layer with given ef width.
 // Uses a min-heap for candidates and a max-heap for the result set.
+// query is already in prepared (stored) form.
 func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer int) ([]distItem, error) {
-	// Precompute query norm for cosine distance optimization.
-	var queryNorm float32
-	if h.isCosine {
-		queryNorm = vek32.Norm(query)
-	}
-
-	entryDist, err := h.nodeDistCalc(entryId, query, queryNorm)
+	entryDist, err := h.nodeDist(entryId, query)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +560,7 @@ func (h *HNSWIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 			}
 			visited.mark(nbId)
 
-			nbDist, err := h.nodeDistCalc(nbId, query, queryNorm)
+			nbDist, err := h.nodeDist(nbId, query)
 			if err != nil {
 				continue // node may have been deleted
 			}
@@ -651,13 +598,12 @@ func (h *HNSWIndex) selectNeighborsHeuristic(query []float32, candidates []distI
 	// Sort candidates by distance to query.
 	sortDistItems(candidates)
 
-	// Resolve each candidate's vector (and norm) once into position-indexed
-	// slices. The diversity loop below is O(candidates*selected); reading from
-	// these slices instead of id-keyed maps removes the map hashing that
-	// dominated the insert CPU profile. vecs[i]/norms[i] correspond to the
-	// just-sorted candidates[i]. A nil vecs[i] means the vector was
-	// unavailable; norms[i] < 0 means the norm was unavailable (mirroring the
-	// previous "missing from cache" checks).
+	// Resolve each candidate's stored vector once into a position-indexed slice.
+	// Reading from this slice instead of an id-keyed map removes the map hashing
+	// that dominated the insert CPU profile. vecs[i] corresponds to the
+	// just-sorted candidates[i]; a nil vecs[i] means the vector was unavailable.
+	// Vectors are in stored form, so metric.distance compares them directly with
+	// no norm lookup.
 	n := len(candidates)
 	vecs := make([][]float32, n)
 	for i, c := range candidates {
@@ -667,19 +613,8 @@ func (h *HNSWIndex) selectNeighborsHeuristic(query []float32, candidates []distI
 			vecs[i] = v
 		}
 	}
-	var norms []float32
-	if h.isCosine {
-		norms = make([]float32, n)
-		for i, c := range candidates {
-			if nrm, err := h.store.GetNorm(c.id); err == nil {
-				norms[i] = nrm
-			} else {
-				norms[i] = -1 // sentinel: norm unavailable
-			}
-		}
-	}
 
-	selected := make([]int, 0, m) // indices into candidates/vecs/norms
+	selected := make([]int, 0, m) // indices into candidates/vecs
 	for i := range candidates {
 		if len(selected) >= m {
 			break
@@ -695,13 +630,7 @@ func (h *HNSWIndex) selectNeighborsHeuristic(query []float32, candidates []distI
 			if sVec == nil {
 				continue
 			}
-			var dist float32
-			if h.isCosine && norms[i] >= 0 && norms[sIdx] >= 0 {
-				dist = CosineDistanceWithNorms(cVec, sVec, norms[i], norms[sIdx])
-			} else {
-				dist = h.distance(cVec, sVec)
-			}
-			if dist < candidates[i].dist {
+			if h.metric.distance(cVec, sVec) < candidates[i].dist {
 				good = false
 				break
 			}
@@ -735,37 +664,15 @@ func (h *HNSWIndex) selectNeighborsHeuristic(query []float32, candidates []distI
 	return out
 }
 
-// nodeDistance computes distance between a stored node and a query vector.
-func (h *HNSWIndex) nodeDistance(nodeId uint64, query []float32) (float32, error) {
+// nodeDist computes the distance between a stored node and an already-prepared
+// query vector. Both operands are in stored form (cosine: unit vectors), so the
+// metric handles cosine as a plain 1 - dot with no norm lookup.
+func (h *HNSWIndex) nodeDist(nodeId uint64, query []float32) (float32, error) {
 	vec, err := h.store.GetVectorRef(nodeId)
 	if err != nil {
 		return 0, err
 	}
-	return h.distance(vec, query), nil
-}
-
-// nodeDistanceWithNorm computes cosine distance between a stored node and a
-// query vector, using precomputed norms to avoid redundant norm calculations.
-// queryNorm is the precomputed L2 norm of the query vector.
-func (h *HNSWIndex) nodeDistanceWithNorm(nodeId uint64, query []float32, queryNorm float32) (float32, error) {
-	vec, err := h.store.GetVectorRef(nodeId)
-	if err != nil {
-		return 0, err
-	}
-	nodeNorm, err := h.store.GetNorm(nodeId)
-	if err != nil {
-		// Fallback to standard distance if norm not available.
-		return h.distance(vec, query), nil
-	}
-	return CosineDistanceWithNorms(vec, query, nodeNorm, queryNorm), nil
-}
-
-// nodeDistCalc computes distance, using precomputed norms when available.
-func (h *HNSWIndex) nodeDistCalc(nodeId uint64, query []float32, queryNorm float32) (float32, error) {
-	if h.isCosine {
-		return h.nodeDistanceWithNorm(nodeId, query, queryNorm)
-	}
-	return h.nodeDistance(nodeId, query)
+	return h.metric.distance(vec, query), nil
 }
 
 func removeId(ids []uint64, target uint64) []uint64 {

--- a/internal/core/vectorindex/hnsw_concurrency_test.go
+++ b/internal/core/vectorindex/hnsw_concurrency_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConcurrentInsertAndSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	dim := 32
 	var wg sync.WaitGroup
@@ -59,7 +59,7 @@ func TestConcurrentInsertAndSearch(t *testing.T) {
 
 func TestConcurrentSearchOnly(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	dim := 32
 	n := 100
@@ -106,7 +106,7 @@ func TestConcurrentSearchOnly(t *testing.T) {
 
 func TestConcurrentInsertDeleteSearch(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	dim := 32
 

--- a/internal/core/vectorindex/hnsw_coverage_test.go
+++ b/internal/core/vectorindex/hnsw_coverage_test.go
@@ -22,15 +22,7 @@ func TestNodeDistance_NonExistentNode(t *testing.T) {
 	idx := NewHNSWIndex(store)
 
 	// nodeDistance on non-existent node should return error
-	_, err := idx.nodeDistance(999, []float32{1, 2, 3})
-	assert.Error(t, err)
-}
-
-func TestNodeDistanceWithNorm_NonExistentNode(t *testing.T) {
-	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store)
-
-	_, err := idx.nodeDistanceWithNorm(999, []float32{1, 2, 3}, 1.0)
+	_, err := idx.nodeDist(999, []float32{1, 2, 3})
 	assert.Error(t, err)
 }
 
@@ -41,7 +33,7 @@ func TestNodeDistance_ValidNode(t *testing.T) {
 	err := idx.Insert("doc1", []float32{1, 0, 0})
 	assert.NoError(t, err)
 
-	dist, err := idx.nodeDistance(1, []float32{0, 1, 0})
+	dist, err := idx.nodeDist(1, []float32{0, 1, 0})
 	assert.NoError(t, err)
 	assert.InDelta(t, 1.0, dist, 0.01) // orthogonal vectors -> cosine distance ~1.0
 }

--- a/internal/core/vectorindex/hnsw_integration_test.go
+++ b/internal/core/vectorindex/hnsw_integration_test.go
@@ -25,7 +25,7 @@ func TestIntegrationResultConsistency(t *testing.T) {
 	queries := randomVectors(rng, numQueries, dim)
 
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(), WithRand(rand.New(rand.NewSource(hnswSeed))))
+	memIdx := NewHNSWIndex(memStore, WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 	for i, v := range vecs {
 		requireNoError(t, memIdx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -43,7 +43,7 @@ func TestIntegrationResultConsistency(t *testing.T) {
 // MemNodeStore.
 func TestIntegrationCRUD(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	// Insert 3 known vectors.
 	requireNoError(t, idx.Insert("alpha", []float32{1, 0, 0}))

--- a/internal/core/vectorindex/hnsw_test.go
+++ b/internal/core/vectorindex/hnsw_test.go
@@ -145,7 +145,7 @@ func TestDotProductDistance(t *testing.T) {
 // --- MemNodeStore tests ---
 
 func TestMemStoreBasicOperations(t *testing.T) {
-	store := NewMemNodeStore()
+	store := NewMemNodeStore(DotProduct)
 	defer store.Close()
 
 	// NextNodeId
@@ -288,7 +288,7 @@ func bruteForceKNN(query []float32, vecs [][]float32, k int, dist DistanceFunc) 
 
 func TestHNSWEmptyIndex(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	results, err := idx.Search([]float32{1, 2, 3}, 10)
 	requireNoError(t, err)
@@ -297,7 +297,7 @@ func TestHNSWEmptyIndex(t *testing.T) {
 
 func TestHNSWSingleVector(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance())
+	idx := NewHNSWIndex(store)
 
 	requireNoError(t, idx.Insert("doc-1", []float32{1, 0, 0}))
 
@@ -320,7 +320,7 @@ func TestHNSWRecallSmall(t *testing.T) {
 	queries := randomVectors(rng, numQueries, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -397,7 +397,7 @@ func TestHNSWRecallLarger(t *testing.T) {
 	queries := randomVectors(rng, numQueries, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(99))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(99))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -436,7 +436,7 @@ func TestHNSWNeighborLimits(t *testing.T) {
 	vecs := randomVectors(rng, n, dim)
 
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(88))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(88))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -464,7 +464,7 @@ func TestHNSWNeighborLimits(t *testing.T) {
 
 func TestHNSWEntryPointUpdate(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(1))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(1))))
 
 	// Insert many vectors; track the max level seen.
 	maxLevelSeen := 0
@@ -509,7 +509,7 @@ func TestHNSWDelete(t *testing.T) {
 
 	vecs := randomVectors(rng, n, dim)
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(100))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(100))))
 
 	for i, v := range vecs {
 		requireNoError(t, idx.Insert(fmt.Sprintf("doc-%d", i), v))
@@ -543,8 +543,8 @@ func TestHNSWDelete(t *testing.T) {
 }
 
 func TestHNSWWithEuclideanDistance(t *testing.T) {
-	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithEuclideanDistance(), WithRand(rand.New(rand.NewSource(42))))
+	store := NewMemNodeStore(Euclidean)
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("a", []float32{0, 0}))
 	requireNoError(t, idx.Insert("b", []float32{1, 0}))
@@ -560,8 +560,8 @@ func TestHNSWWithEuclideanDistance(t *testing.T) {
 }
 
 func TestHNSWWithDotProductDistance(t *testing.T) {
-	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithDotProductDistance(), WithRand(rand.New(rand.NewSource(42))))
+	store := NewMemNodeStore(DotProduct)
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	// Normalized vectors.
 	sqrt2 := float32(1.0 / math.Sqrt(2))
@@ -581,7 +581,7 @@ func TestHNSWWithDotProductDistance(t *testing.T) {
 
 func TestHNSWDeleteEntryPoint(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1}))
@@ -608,7 +608,7 @@ func TestHNSWDeleteEntryPoint(t *testing.T) {
 
 func TestHNSWDeleteAllVectors(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1}))
@@ -624,7 +624,7 @@ func TestHNSWDeleteAllVectors(t *testing.T) {
 
 func TestHNSWSearchKGreaterThanN(t *testing.T) {
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(42))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
 	requireNoError(t, idx.Insert("doc-0", []float32{1, 0, 0}))
 	requireNoError(t, idx.Insert("doc-1", []float32{0, 1, 0}))

--- a/internal/core/vectorindex/mem_store.go
+++ b/internal/core/vectorindex/mem_store.go
@@ -3,16 +3,15 @@ package vectorindex
 import (
 	"fmt"
 	"sync"
-
-	"github.com/viterin/vek/vek32"
 )
 
 // MemNodeStore is an in-memory implementation of NodeStore for testing.
 type MemNodeStore struct {
 	mu        sync.RWMutex
-	vectors   map[uint64][]float32
+	metric    Metric
+	vectors   map[uint64][]float32 // stored form (normalized for cosine)
 	levels    map[uint64]int
-	norms     map[uint64]float32
+	norms     map[uint64]float32          // original norm, used only to restore vectors
 	neighbors map[uint64]map[int][]uint64 // nodeId -> layer -> neighbor ids
 	docToNode map[string]uint64
 	nodeToDoc map[uint64]string
@@ -22,9 +21,15 @@ type MemNodeStore struct {
 	nextID    uint64
 }
 
-// NewMemNodeStore creates a new in-memory NodeStore.
-func NewMemNodeStore() *MemNodeStore {
+// NewMemNodeStore creates a new in-memory NodeStore. The distance metric
+// defaults to Cosine when not specified.
+func NewMemNodeStore(metric ...Metric) *MemNodeStore {
+	m := Cosine
+	if len(metric) > 0 {
+		m = metric[0]
+	}
 	return &MemNodeStore{
+		metric:    m,
 		vectors:   make(map[uint64][]float32),
 		levels:    make(map[uint64]int),
 		norms:     make(map[uint64]float32),
@@ -35,8 +40,11 @@ func NewMemNodeStore() *MemNodeStore {
 	}
 }
 
-// GetVector returns a copy of the vector for the given node.
-// The returned slice is safe to modify.
+// Metric returns the store's distance metric.
+func (m *MemNodeStore) Metric() Metric { return m.metric }
+
+// GetVector returns a copy of the original vector for the given node. For cosine
+// the stored unit vector is restored to its original scale via the stored norm.
 func (m *MemNodeStore) GetVector(id uint64) ([]float32, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -44,13 +52,11 @@ func (m *MemNodeStore) GetVector(id uint64) ([]float32, error) {
 	if !ok {
 		return nil, fmt.Errorf("node %d not found", id)
 	}
-	cp := make([]float32, len(v))
-	copy(cp, v)
-	return cp, nil
+	return m.metric.restore(v, m.norms[id]), nil
 }
 
-// GetVectorRef returns the internal vector slice directly without copying.
-// The caller MUST NOT modify the returned slice.
+// GetVectorRef returns the internal stored vector slice directly without
+// copying. The caller MUST NOT modify the returned slice.
 func (m *MemNodeStore) GetVectorRef(id uint64) ([]float32, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -64,11 +70,12 @@ func (m *MemNodeStore) GetVectorRef(id uint64) ([]float32, error) {
 func (m *MemNodeStore) PutNode(id uint64, level int, vector []float32) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	cp := make([]float32, len(vector))
-	copy(cp, vector)
+	stored, norm := m.metric.prepare(vector)
+	cp := make([]float32, len(stored))
+	copy(cp, stored)
 	m.vectors[id] = cp
 	m.levels[id] = level
-	m.norms[id] = vek32.Norm(vector)
+	m.norms[id] = norm
 	if _, ok := m.neighbors[id]; !ok {
 		m.neighbors[id] = make(map[int][]uint64)
 	}

--- a/internal/core/vectorindex/metric.go
+++ b/internal/core/vectorindex/metric.go
@@ -1,0 +1,73 @@
+package vectorindex
+
+import "github.com/viterin/vek/vek32"
+
+// Metric is the immutable distance metric of an index. It is chosen when the
+// index is created, persisted in the store metadata, and must never change for
+// a given index: both the graph structure and the on-disk vector form depend on
+// it (see the package docs on why a metric cannot be swapped after build).
+type Metric uint8
+
+const (
+	// Cosine stores vectors normalized to unit length, so cosine distance
+	// reduces to 1 - dot(a, b) with no per-distance norm division.
+	Cosine Metric = 0
+	// DotProduct stores raw vectors; distance is 1 - dot(a, b).
+	DotProduct Metric = 1
+	// Euclidean stores raw vectors; distance is the L2 norm of a - b.
+	Euclidean Metric = 2
+)
+
+func (m Metric) String() string {
+	switch m {
+	case Cosine:
+		return "cosine"
+	case DotProduct:
+		return "dot"
+	case Euclidean:
+		return "euclidean"
+	default:
+		return "unknown"
+	}
+}
+
+// storesNormalized reports whether vectors are normalized before being stored.
+func (m Metric) storesNormalized() bool { return m == Cosine }
+
+// prepare maps a raw vector to the form stored on disk and returns the raw
+// vector's L2 norm (persisted so GetVector can restore the original). For
+// cosine it returns a new unit-length slice; for the raw metrics it returns the
+// input slice unchanged. A zero vector is stored as-is (norm 0).
+func (m Metric) prepare(v []float32) (stored []float32, norm float32) {
+	norm = vek32.Norm(v)
+	if m != Cosine || norm == 0 {
+		return v, norm
+	}
+	out := make([]float32, len(v))
+	inv := 1.0 / norm
+	for i, x := range v {
+		out[i] = x * inv
+	}
+	return out, norm
+}
+
+// restore maps a stored vector back to its original raw form. For cosine it
+// multiplies the unit vector by the stored norm; otherwise it is the identity.
+func (m Metric) restore(stored []float32, norm float32) []float32 {
+	if m != Cosine {
+		return stored
+	}
+	out := make([]float32, len(stored))
+	for i, x := range stored {
+		out[i] = x * norm
+	}
+	return out
+}
+
+// distance compares two vectors that are already in stored form.
+func (m Metric) distance(a, b []float32) float32 {
+	if m == Euclidean {
+		return vek32.Distance(a, b)
+	}
+	return 1 - vek32.Dot(a, b)
+}

--- a/internal/core/vectorindex/metric.go
+++ b/internal/core/vectorindex/metric.go
@@ -34,21 +34,28 @@ func (m Metric) String() string {
 // storesNormalized reports whether vectors are normalized before being stored.
 func (m Metric) storesNormalized() bool { return m == Cosine }
 
-// prepare maps a raw vector to the form stored on disk and returns the raw
-// vector's L2 norm (persisted so GetVector can restore the original). For
-// cosine it returns a new unit-length slice; for the raw metrics it returns the
-// input slice unchanged. A zero vector is stored as-is (norm 0).
+// norm returns the L2 norm to persist for a vector. Only cosine needs it: it
+// stores unit vectors and uses the norm to restore the original scale in
+// GetVector. The raw metrics store the original vector verbatim, so they have
+// no use for a norm and skip the computation, reporting 0.
+func (m Metric) norm(v []float32) float32 {
+	if m != Cosine {
+		return 0
+	}
+	return vek32.Norm(v)
+}
+
+// prepare maps a raw vector to the form stored on disk and returns the norm to
+// persist alongside it. For cosine it returns a new unit-length slice and the
+// original L2 norm (so GetVector can restore the original scale). For the raw
+// metrics it returns the input slice unchanged with norm 0. A zero vector is
+// stored as-is (norm 0).
 func (m Metric) prepare(v []float32) (stored []float32, norm float32) {
-	norm = vek32.Norm(v)
+	norm = m.norm(v)
 	if m != Cosine || norm == 0 {
 		return v, norm
 	}
-	out := make([]float32, len(v))
-	inv := 1.0 / norm
-	for i, x := range v {
-		out[i] = x * inv
-	}
-	return out, norm
+	return vek32.MulNumber(v, 1.0/norm), norm // SIMD scale into a fresh slice
 }
 
 // restore maps a stored vector back to its original raw form. For cosine it

--- a/internal/core/vectorindex/metric_test.go
+++ b/internal/core/vectorindex/metric_test.go
@@ -1,0 +1,86 @@
+package vectorindex
+
+import (
+	"math"
+	"testing"
+)
+
+func approxEqual(t *testing.T, got, want []float32, eps float32) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range got {
+		if d := float32(math.Abs(float64(got[i] - want[i]))); d > eps {
+			t.Fatalf("index %d: got %v want %v (|d|=%v > %v)", i, got[i], want[i], d, eps)
+		}
+	}
+}
+
+func TestMetricCosine(t *testing.T) {
+	raw := []float32{3, 0, 4, 0} // |raw| = 5
+	stored, norm := Cosine.prepare(raw)
+	if math.Abs(float64(norm-5)) > 1e-5 {
+		t.Fatalf("norm: got %v want 5", norm)
+	}
+	approxEqual(t, stored, []float32{0.6, 0, 0.8, 0}, 1e-6) // unit vector
+	// raw must be untouched (prepare returns a new slice for cosine).
+	approxEqual(t, raw, []float32{3, 0, 4, 0}, 0)
+	// restore round-trips back to the original.
+	approxEqual(t, Cosine.restore(stored, norm), raw, 1e-4)
+
+	// distance on stored (unit) vectors is 1 - dot.
+	a, _ := Cosine.prepare([]float32{1, 0, 0, 0})
+	b, _ := Cosine.prepare([]float32{1, 0, 0, 0})
+	if d := Cosine.distance(a, b); math.Abs(float64(d)) > 1e-6 {
+		t.Fatalf("identical-direction distance: got %v want 0", d)
+	}
+	c, _ := Cosine.prepare([]float32{0, 1, 0, 0})
+	if d := Cosine.distance(a, c); math.Abs(float64(d-1)) > 1e-6 {
+		t.Fatalf("orthogonal distance: got %v want 1", d)
+	}
+}
+
+func TestMetricCosineZeroVector(t *testing.T) {
+	stored, norm := Cosine.prepare([]float32{0, 0, 0, 0})
+	if norm != 0 {
+		t.Fatalf("zero-vector norm: got %v want 0", norm)
+	}
+	approxEqual(t, stored, []float32{0, 0, 0, 0}, 0)
+	approxEqual(t, Cosine.restore(stored, norm), []float32{0, 0, 0, 0}, 0)
+	// distance to anything is 1 (dot is 0).
+	if d := Cosine.distance(stored, []float32{1, 0, 0, 0}); math.Abs(float64(d-1)) > 1e-6 {
+		t.Fatalf("zero-vector distance: got %v want 1", d)
+	}
+}
+
+func TestMetricRawStored(t *testing.T) {
+	raw := []float32{3, 0, 4, 0}
+	for _, m := range []Metric{DotProduct, Euclidean} {
+		stored, norm := m.prepare(raw)
+		// Raw metrics store the vector unchanged.
+		approxEqual(t, stored, raw, 0)
+		if math.Abs(float64(norm-5)) > 1e-5 {
+			t.Fatalf("%s norm: got %v want 5", m, norm)
+		}
+		approxEqual(t, m.restore(stored, norm), raw, 0)
+	}
+
+	// DotProduct distance = 1 - dot.
+	if d := DotProduct.distance([]float32{1, 2}, []float32{3, 4}); math.Abs(float64(d-(1-11))) > 1e-5 {
+		t.Fatalf("dot distance: got %v want %v", d, 1-11)
+	}
+	// Euclidean distance = L2.
+	if d := Euclidean.distance([]float32{0, 0}, []float32{3, 4}); math.Abs(float64(d-5)) > 1e-5 {
+		t.Fatalf("euclidean distance: got %v want 5", d)
+	}
+}
+
+func TestMetricStringAndStoresNormalized(t *testing.T) {
+	if Cosine.String() != "cosine" || DotProduct.String() != "dot" || Euclidean.String() != "euclidean" {
+		t.Fatalf("unexpected String(): %s/%s/%s", Cosine, DotProduct, Euclidean)
+	}
+	if !Cosine.storesNormalized() || DotProduct.storesNormalized() || Euclidean.storesNormalized() {
+		t.Fatal("storesNormalized() should be true only for cosine")
+	}
+}

--- a/internal/core/vectorindex/metric_test.go
+++ b/internal/core/vectorindex/metric_test.go
@@ -58,10 +58,11 @@ func TestMetricRawStored(t *testing.T) {
 	raw := []float32{3, 0, 4, 0}
 	for _, m := range []Metric{DotProduct, Euclidean} {
 		stored, norm := m.prepare(raw)
-		// Raw metrics store the vector unchanged.
+		// Raw metrics store the vector unchanged and skip the norm computation
+		// (the norm is never used to restore or compare them).
 		approxEqual(t, stored, raw, 0)
-		if math.Abs(float64(norm-5)) > 1e-5 {
-			t.Fatalf("%s norm: got %v want 5", m, norm)
+		if norm != 0 {
+			t.Fatalf("%s norm: got %v want 0", m, norm)
 		}
 		approxEqual(t, m.restore(stored, norm), raw, 0)
 	}
@@ -76,9 +77,26 @@ func TestMetricRawStored(t *testing.T) {
 	}
 }
 
+func TestMetricNorm(t *testing.T) {
+	v := []float32{3, 0, 4, 0} // |v| = 5
+	// Only cosine computes a norm; the raw metrics report 0.
+	if n := Cosine.norm(v); math.Abs(float64(n-5)) > 1e-5 {
+		t.Fatalf("cosine norm: got %v want 5", n)
+	}
+	if n := DotProduct.norm(v); n != 0 {
+		t.Fatalf("dot norm: got %v want 0", n)
+	}
+	if n := Euclidean.norm(v); n != 0 {
+		t.Fatalf("euclidean norm: got %v want 0", n)
+	}
+}
+
 func TestMetricStringAndStoresNormalized(t *testing.T) {
 	if Cosine.String() != "cosine" || DotProduct.String() != "dot" || Euclidean.String() != "euclidean" {
 		t.Fatalf("unexpected String(): %s/%s/%s", Cosine, DotProduct, Euclidean)
+	}
+	if Metric(99).String() != "unknown" {
+		t.Fatalf("unknown metric String(): got %q want %q", Metric(99).String(), "unknown")
 	}
 	if !Cosine.storesNormalized() || DotProduct.storesNormalized() || Euclidean.storesNormalized() {
 		t.Fatal("storesNormalized() should be true only for cosine")

--- a/internal/core/vectorindex/mmap_bench50k_test.go
+++ b/internal/core/vectorindex/mmap_bench50k_test.go
@@ -42,13 +42,13 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 		bs := bs
 		t.Run(fmt.Sprintf("batch%d", bs), func(t *testing.T) {
 			dir := t.TempDir()
-			store, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: mParam})
+			store, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: mParam, Metric: Euclidean})
 			if err != nil {
 				t.Fatalf("OpenMmapStore: %v", err)
 			}
 			defer store.Close()
 
-			idx := NewHNSWIndex(store, WithEuclideanDistance())
+			idx := NewHNSWIndex(store)
 
 			t.Logf("Inserting %d vectors: batch_size=%d, sync per batch...", nBase, bs)
 			start := time.Now()
@@ -124,7 +124,7 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, WithEuclideanDistance())
+		idx := NewHNSWIndex(store)
 
 		t.Log("Inserting 50K vectors: deferred sync (single bulk)...")
 		if err := store.SetSyncMode(SyncDeferred); err != nil {

--- a/internal/core/vectorindex/mmap_checkpoint_test.go
+++ b/internal/core/vectorindex/mmap_checkpoint_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCheckpoint_MetaAndWALTruncated(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestCheckpoint_MetaAndWALTruncated(t *testing.T) {
 
 func TestCheckpoint_ContinueWriteAndReplay(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestCheckpoint_ContinueWriteAndReplay(t *testing.T) {
 	}
 
 	// Reopen — replay should only see the 2 new records.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestCheckpoint_ContinueWriteAndReplay(t *testing.T) {
 
 func TestClose_WALTruncated(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestClose_WALTruncated(t *testing.T) {
 
 func TestOpen_ReplayThenCheckpoint(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestOpen_ReplayThenCheckpoint(t *testing.T) {
 	s.upperFile.Close()
 
 	// Reopen — should replay WAL and then auto-checkpoint.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +214,7 @@ func TestOpen_ReplayThenCheckpoint(t *testing.T) {
 
 func TestAutoCheckpoint_TriggeredAtInterval(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4, CheckpointInterval: 10})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +248,7 @@ func TestAutoCheckpoint_TriggeredAtInterval(t *testing.T) {
 
 func TestAutoCheckpoint_NotTriggeredBelowInterval(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4, CheckpointInterval: 1000})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1000})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestAutoCheckpoint_NotTriggeredBelowInterval(t *testing.T) {
 
 func TestAutoCheckpoint_BatchMode(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4, CheckpointInterval: 5})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 5})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestAutoCheckpoint_BatchMode(t *testing.T) {
 
 func TestCrashRecovery_BasicReplay(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func TestCrashRecovery_BasicReplay(t *testing.T) {
 	s.upperFile.Close()
 
 	// Reopen — WAL replay should recover all data.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestCrashRecovery_BasicReplay(t *testing.T) {
 
 func TestCrashRecovery_AfterCheckpoint(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestCrashRecovery_AfterCheckpoint(t *testing.T) {
 	s.upperFile.Close()
 
 	// Reopen — should recover all 15 nodes.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,7 +436,7 @@ func TestCrashRecovery_AfterCheckpoint(t *testing.T) {
 
 func TestCheckpoint_LSNMonotonic(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -489,7 +489,7 @@ func simulateCrash(s *MmapStore) {
 // 6a: WAL written, msync not done → WAL replay recovers data.
 func TestCrashPoint_AfterWALWrite(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,7 +528,7 @@ func TestCrashPoint_AfterWALWrite(t *testing.T) {
 	simulateCrash(s)
 
 	// Reopen — WAL replay should recover node 5.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func TestCrashPoint_AfterWALWrite(t *testing.T) {
 // 6b: Checkpoint msync done, meta.bin not written → old checkpoint LSN, WAL replays.
 func TestCrashPoint_AfterMsync(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestCrashPoint_AfterMsync(t *testing.T) {
 	s.crashAfterMsync = nil
 	simulateCrash(s)
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -594,7 +594,7 @@ func TestCrashPoint_AfterMsync(t *testing.T) {
 // filter skips them because meta.WalCheckpointLSN is already advanced.
 func TestCrashPoint_AfterMeta(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -620,7 +620,7 @@ func TestCrashPoint_AfterMeta(t *testing.T) {
 	s.crashAfterMeta = nil
 	simulateCrash(s)
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestCrashPoint_AfterMeta(t *testing.T) {
 // 6c-b: crash BEFORE WAL truncate (uses crashBeforeTruncate hook).
 func TestCrashPoint_BeforeTruncate(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -665,7 +665,7 @@ func TestCrashPoint_BeforeTruncate(t *testing.T) {
 	s.crashBeforeTruncate = nil
 	simulateCrash(s)
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -684,7 +684,7 @@ func TestCrashPoint_BeforeTruncate(t *testing.T) {
 // 6d: Partial WAL record — incomplete bytes appended to wal.bin.
 func TestCrashPoint_PartialWALRecord(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,7 +701,7 @@ func TestCrashPoint_PartialWALRecord(t *testing.T) {
 	s.Close()
 
 	// Reopen, write more, close raw, append junk.
-	s, err = OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err = OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -718,7 +718,7 @@ func TestCrashPoint_PartialWALRecord(t *testing.T) {
 	f.Write([]byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB})
 	f.Close()
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -737,7 +737,7 @@ func TestCrashPoint_PartialWALRecord(t *testing.T) {
 // 6e: Partial meta.bin write — meta truncated to 32 bytes (corrupt).
 func TestCrashPoint_PartialMeta(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -753,7 +753,7 @@ func TestCrashPoint_PartialMeta(t *testing.T) {
 	f.Truncate(32)
 	f.Close()
 
-	_, err = OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	_, err = OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err == nil {
 		t.Fatal("expected error on corrupt meta.bin")
 	}
@@ -762,7 +762,7 @@ func TestCrashPoint_PartialMeta(t *testing.T) {
 // 6f: grow during write, crash before meta update → replay re-grows.
 func TestCrashPoint_GrowMidWrite(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -781,7 +781,7 @@ func TestCrashPoint_GrowMidWrite(t *testing.T) {
 	s.wal.Sync()
 	simulateCrash(s)
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -800,7 +800,7 @@ func TestCrashPoint_GrowMidWrite(t *testing.T) {
 // 6g: SetNeighbors WAL written, crash before msync.
 func TestCrashPoint_SetNeighborsCrash(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -821,7 +821,7 @@ func TestCrashPoint_SetNeighborsCrash(t *testing.T) {
 
 	simulateCrash(s)
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -838,7 +838,7 @@ func TestCrashPoint_SetNeighborsCrash(t *testing.T) {
 // 6h: DeleteNode WAL written, crash before msync.
 func TestCrashPoint_DeleteNodeCrash(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -859,7 +859,7 @@ func TestCrashPoint_DeleteNodeCrash(t *testing.T) {
 
 	simulateCrash(s)
 
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/vectorindex/mmap_checkpoint_test.go
+++ b/internal/core/vectorindex/mmap_checkpoint_test.go
@@ -1,9 +1,7 @@
 package vectorindex
 
 import (
-	"encoding/binary"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -876,9 +874,8 @@ func TestCrashPoint_DeleteNodeCrash(t *testing.T) {
 		if nflags&nodeFlagDeleted != 0 {
 			t.Fatalf("node %d should not be deleted", id)
 		}
-		norm := math.Float32frombits(binary.LittleEndian.Uint32(s2.nodes[noff+4:]))
-		if norm == 0 {
-			t.Fatalf("node %d norm should be non-zero", id)
+		if nflags&nodeFlagOccupied == 0 {
+			t.Fatalf("node %d should be marked occupied after replay", id)
 		}
 	}
 

--- a/internal/core/vectorindex/mmap_crash_test.go
+++ b/internal/core/vectorindex/mmap_crash_test.go
@@ -2,7 +2,6 @@ package vectorindex
 
 import (
 	"fmt"
-	"math"
 	"testing"
 )
 
@@ -92,21 +91,19 @@ func TestKill9Recovery_E2E(t *testing.T) {
 		}
 	}
 
-	// Verify norms for non-deleted nodes are positive.
+	// Verify non-deleted nodes are marked occupied after recovery.
 	for i := 0; i < N; i++ {
 		id := uint64(i)
 		if deletedSet[id] {
 			continue
 		}
 		nodeOff := int64(pageSize) + int64(id)*int64(nodeSlotSize)
-		norm := math.Float32frombits(
-			uint32(s2.nodes[nodeOff+4]) |
-				uint32(s2.nodes[nodeOff+5])<<8 |
-				uint32(s2.nodes[nodeOff+6])<<16 |
-				uint32(s2.nodes[nodeOff+7])<<24,
-		)
-		if norm <= 0 {
-			t.Fatalf("node %d norm should be positive, got %f", i, norm)
+		flags := s2.nodes[nodeOff+1]
+		if flags&nodeFlagOccupied == 0 {
+			t.Fatalf("node %d should be marked occupied after recovery", i)
+		}
+		if flags&nodeFlagDeleted != 0 {
+			t.Fatalf("node %d should not be deleted after recovery", i)
 		}
 	}
 

--- a/internal/core/vectorindex/mmap_crash_test.go
+++ b/internal/core/vectorindex/mmap_crash_test.go
@@ -14,7 +14,7 @@ func TestKill9Recovery_E2E(t *testing.T) {
 	const dim = 32
 
 	// Phase 1: Write 1000 vectors in batches, then crash (no Close).
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: 8, CheckpointInterval: 200})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: dim, M: 8, CheckpointInterval: 200})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestKill9Recovery_E2E(t *testing.T) {
 	simulateCrash(s)
 
 	// Phase 2: Reopen and verify everything recovered.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: 8})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: dim, M: 8})
 	if err != nil {
 		t.Fatalf("reopen after crash: %v", err)
 	}

--- a/internal/core/vectorindex/mmap_format.go
+++ b/internal/core/vectorindex/mmap_format.go
@@ -100,7 +100,10 @@ type NodeSlot struct {
 	_         [4]byte // reserved
 }
 
-const nodeFlagDeleted = 0x01
+const (
+	nodeFlagDeleted  = 0x01 // slot's node was tombstoned by DeleteNode
+	nodeFlagOccupied = 0x02 // slot holds a real node (set on PutNode / WAL replay)
+)
 
 // graphL0SlotSize returns the slot size for a level-0 neighbor list.
 func graphL0SlotSize(mmax0 int) int {

--- a/internal/core/vectorindex/mmap_format.go
+++ b/internal/core/vectorindex/mmap_format.go
@@ -34,7 +34,7 @@ var (
 // pageSize is the header size for mmap data files (page-aligned).
 const pageSize = 4096
 
-// MetaHeader is the on-disk format for meta.bin (exactly 64 bytes).
+// MetaHeader is the on-disk format for meta.bin (exactly 72 bytes).
 // Fields are ordered to avoid implicit padding: uint32 group first, then uint64 group.
 type MetaHeader struct {
 	Magic      [4]byte // "HNSW"
@@ -43,6 +43,8 @@ type MetaHeader struct {
 	M          uint32  // HNSW M parameter
 	MaxLevel   uint32  // current max level
 	EntryLevel uint32  // entry point level
+	Metric     uint32  // distance metric (0=cosine, 1=dot, 2=euclidean)
+	_          uint32  // pad so the uint64 group is 8-byte aligned
 
 	NodeCount        uint64 // active node count (excl. tombstones)
 	TotalSlots       uint64 // allocated slots (incl. tombstones)
@@ -51,8 +53,8 @@ type MetaHeader struct {
 	WalCheckpointLSN uint64 // WAL checkpoint LSN
 }
 
-// Compile-time size check: MetaHeader must be exactly 64 bytes.
-var _ [64]byte = [unsafe.Sizeof(MetaHeader{})]byte{}
+// Compile-time size check: MetaHeader must be exactly 72 bytes.
+var _ [72]byte = [unsafe.Sizeof(MetaHeader{})]byte{}
 
 // VectorsHeader is the on-disk header for vectors.dat (lives in the first pageSize bytes).
 type VectorsHeader struct {

--- a/internal/core/vectorindex/mmap_format_test.go
+++ b/internal/core/vectorindex/mmap_format_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestMetaHeaderSize(t *testing.T) {
-	if s := unsafe.Sizeof(MetaHeader{}); s != 64 {
-		t.Fatalf("MetaHeader size = %d, want 64", s)
+	if s := unsafe.Sizeof(MetaHeader{}); s != 72 {
+		t.Fatalf("MetaHeader size = %d, want 72", s)
 	}
 }
 
@@ -65,8 +65,8 @@ func TestMetaHeaderWriteRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Size() != 64 {
-		t.Errorf("meta.bin size = %d, want 64", info.Size())
+	if info.Size() != 72 {
+		t.Errorf("meta.bin size = %d, want 72", info.Size())
 	}
 }
 

--- a/internal/core/vectorindex/mmap_integration_test.go
+++ b/internal/core/vectorindex/mmap_integration_test.go
@@ -93,6 +93,7 @@ func TestMmapStoreIntegration(t *testing.T) {
 		Version:    1,
 		Dim:        dim,
 		M:          m,
+		Metric:     uint32(DotProduct),
 		MaxLevel:   2,
 		EntryLevel: 2,
 		NodeCount:  3,
@@ -106,7 +107,7 @@ func TestMmapStoreIntegration(t *testing.T) {
 
 	// --- Open and verify ---
 
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: dim, M: m})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: dim, M: m})
 	if err != nil {
 		t.Fatalf("OpenMmapStore: %v", err)
 	}

--- a/internal/core/vectorindex/mmap_phase2_test.go
+++ b/internal/core/vectorindex/mmap_phase2_test.go
@@ -28,12 +28,13 @@ func TestMmapStorePutNodeWritesMmapContents(t *testing.T) {
 		assert.Equal(t, v, got, "vector[%d]", i)
 	}
 
-	// Read raw node bytes: level=0, flags=0, norm=sqrt(1+4+9+16)=sqrt(30).
+	// Read raw node bytes: level=0, occupied flag set. The store is DotProduct
+	// (a raw metric), so no norm is stored — occupancy is marked by the flag.
 	nodeOff := pageSize + 0*nodeSlotSize
-	assert.Equal(t, uint8(0), s.nodes[nodeOff])   // level
-	assert.Equal(t, uint8(0), s.nodes[nodeOff+1]) // flags (not deleted)
+	assert.Equal(t, uint8(0), s.nodes[nodeOff])                  // level
+	assert.Equal(t, uint8(nodeFlagOccupied), s.nodes[nodeOff+1]) // flags: occupied, not deleted
 	norm := math.Float32frombits(binary.LittleEndian.Uint32(s.nodes[nodeOff+4:]))
-	assert.InDelta(t, float32(math.Sqrt(30)), norm, 0.01)
+	assert.Equal(t, float32(0), norm) // raw metric: no norm persisted
 }
 
 func TestMmapStorePutNodeWithUpperLevel(t *testing.T) {

--- a/internal/core/vectorindex/mmap_phase2_test.go
+++ b/internal/core/vectorindex/mmap_phase2_test.go
@@ -87,7 +87,7 @@ func TestMmapStoreSetNeighborsUpperMultipleLayers(t *testing.T) {
 
 func TestMmapStoreGrowUpperGraph(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	requireNoError(t, err)
 	defer s.Close()
 
@@ -110,7 +110,7 @@ func TestMmapStoreGrowUpperGraph(t *testing.T) {
 
 func TestMmapStoreCloseReopenPersistence(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -172,7 +172,7 @@ func TestMmapStoreCloseReopenPersistence(t *testing.T) {
 
 func TestMmapStoreLoadIdmap(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	// Write multiple mappings, close, reopen — all should be present.
 	s, err := OpenMmapStore(dir, opts)
@@ -197,7 +197,7 @@ func TestMmapStoreLoadIdmap(t *testing.T) {
 
 func TestMmapStoreLoadIdmapCorrupt(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -248,7 +248,7 @@ func TestMmapStoreSyncAll(t *testing.T) {
 
 func TestMmapStoreDeleteNodeAndReopen(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -279,7 +279,7 @@ func TestMmapStoreDeleteNodeAndReopen(t *testing.T) {
 
 func TestMmapStoreRebuildNodeCount(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -306,7 +306,7 @@ func TestMmapStoreRebuildNodeCount(t *testing.T) {
 
 func TestMmapStoreCommitBatchSyncs(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -22,9 +22,10 @@ const (
 
 // MmapStoreOptions configures OpenMmapStore.
 type MmapStoreOptions struct {
-	Dim                int // vector dimension (required)
-	M                  int // HNSW M parameter (required)
-	CheckpointInterval int // auto-checkpoint every N WAL appends (0 = default 1000)
+	Dim                int    // vector dimension (required)
+	M                  int    // HNSW M parameter (required)
+	Metric             Metric // distance metric (default Cosine); immutable once created
+	CheckpointInterval int    // auto-checkpoint every N WAL appends (0 = default 1000)
 }
 
 // MmapStore implements NodeStore backed by mmap'd flat files.
@@ -41,6 +42,8 @@ type MmapStoreOptions struct {
 type MmapStore struct {
 	dir  string
 	meta MetaHeader
+
+	metric Metric
 
 	vectors    []byte // vectors.dat mmap
 	nodes      []byte // nodes.dat mmap
@@ -91,6 +94,9 @@ type MmapStore struct {
 	crashBeforeTruncate func() // called before WAL Reset in Checkpoint
 }
 
+// Metric returns the store's immutable distance metric.
+func (s *MmapStore) Metric() Metric { return s.metric }
+
 // OpenMmapStore opens or creates an mmap-backed store in dir.
 func OpenMmapStore(dir string, opts MmapStoreOptions) (*MmapStore, error) {
 	if opts.Dim <= 0 {
@@ -106,6 +112,7 @@ func OpenMmapStore(dir string, opts MmapStoreOptions) (*MmapStore, error) {
 
 	s := &MmapStore{
 		dir:         dir,
+		metric:      opts.Metric,
 		dim:         opts.Dim,
 		m:           opts.M,
 		mmax0:       opts.M * 2,
@@ -141,6 +148,10 @@ func OpenMmapStore(dir string, opts MmapStoreOptions) (*MmapStore, error) {
 		if int(h.M) != opts.M {
 			return nil, fmt.Errorf("MmapStore: M mismatch: file=%d, opts=%d", h.M, opts.M)
 		}
+		if Metric(h.Metric) != opts.Metric {
+			return nil, fmt.Errorf("MmapStore: metric mismatch: file=%s, opts=%s", Metric(h.Metric), opts.Metric)
+		}
+		s.metric = Metric(h.Metric)
 		s.meta = *h
 	}
 
@@ -234,6 +245,7 @@ func (s *MmapStore) initAllFiles(cap uint64) error {
 		Version:    1,
 		Dim:        uint32(s.dim),
 		M:          uint32(s.m),
+		Metric:     uint32(s.metric),
 		EntryPoint: ^uint64(0), // sentinel: no entry point
 	}
 

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -455,10 +455,10 @@ func (s *MmapStore) replayWAL() error {
 				binary.LittleEndian.PutUint32(s.vectors[vecOff+int64(i*4):], math.Float32bits(v))
 			}
 
-			// Write node metadata to nodes.dat (level, flags=0, norm).
+			// Write node metadata to nodes.dat (level, flags, norm).
 			nodeOff := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
 			s.nodes[nodeOff] = uint8(level)
-			s.nodes[nodeOff+1] = 0 // flags: not deleted
+			s.nodes[nodeOff+1] = nodeFlagOccupied // flags: occupied, not deleted
 			s.nodes[nodeOff+2] = 0
 			s.nodes[nodeOff+3] = 0
 			binary.LittleEndian.PutUint32(s.nodes[nodeOff+4:], math.Float32bits(norm))
@@ -538,16 +538,16 @@ func (s *MmapStore) replayWAL() error {
 }
 
 // rebuildNodeCount scans nodes.dat and counts occupied, non-tombstone slots,
-// replacing the WAL-replayed NodeCount with the authoritative value.
-// An empty (never-written) slot is distinguished by having norm == 0.0;
-// every real node carries a positive pre-computed norm.
+// replacing the WAL-replayed NodeCount with the authoritative value. Occupancy
+// is marked explicitly by nodeFlagOccupied (set on insert and on WAL replay);
+// a never-written slot is all-zero, so the flag is clear. This is independent
+// of the stored norm, which is metric-specific (zero for the raw metrics).
 func (s *MmapStore) rebuildNodeCount() {
 	var count uint64
 	for i := uint64(0); i < s.meta.TotalSlots; i++ {
 		off := int64(pageSize) + int64(i)*int64(nodeSlotSize)
 		flags := s.nodes[off+1]
-		norm := math.Float32frombits(binary.LittleEndian.Uint32(s.nodes[off+4:]))
-		if flags&nodeFlagDeleted == 0 && norm != 0 {
+		if flags&nodeFlagDeleted == 0 && flags&nodeFlagOccupied != 0 {
 			count++
 		}
 	}

--- a/internal/core/vectorindex/mmap_store_bench_test.go
+++ b/internal/core/vectorindex/mmap_store_bench_test.go
@@ -224,7 +224,7 @@ func BenchmarkHNSW_MemStore_50K_Insert(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		store := NewMemNodeStore()
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(42))))
 
 		start := time.Now()
@@ -258,7 +258,7 @@ func BenchmarkHNSW_MmapStore_50K_Insert(b *testing.B) {
 		}
 
 		start := time.Now()
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(42))))
 
 		for i, v := range vecs {
@@ -302,7 +302,7 @@ func BenchmarkHNSW_Search_MemStore_vs_MmapStore(b *testing.B) {
 
 	// Build MemStore index.
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore,
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range vecs {
 		if err := memIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
@@ -318,7 +318,7 @@ func BenchmarkHNSW_Search_MemStore_vs_MmapStore(b *testing.B) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore,
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range vecs {
 		if err := mmapIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
@@ -391,7 +391,7 @@ func TestRecallAt10_SIFT(t *testing.T) {
 
 	// Test MemStore recall.
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore,
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
 		if err := memIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
@@ -420,7 +420,7 @@ func TestRecallAt10_SIFT(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore,
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
 		if err := mmapIdx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {

--- a/internal/core/vectorindex/mmap_store_grow_test.go
+++ b/internal/core/vectorindex/mmap_store_grow_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMmapStoreGrowOnInsert(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	requireNoError(t, err)
 	defer s.Close()
 
@@ -27,7 +27,7 @@ func TestMmapStoreGrowOnInsert(t *testing.T) {
 
 func TestMmapStoreGrowMultiple(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	requireNoError(t, err)
 	defer s.Close()
 
@@ -43,7 +43,7 @@ func TestMmapStoreGrowMultiple(t *testing.T) {
 
 func TestMmapStoreGrowPreservesOldData(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	requireNoError(t, err)
 	defer s.Close()
 
@@ -68,7 +68,7 @@ func TestMmapStoreGrowPreservesOldData(t *testing.T) {
 
 func TestMmapStoreGrowConcurrent(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	requireNoError(t, err)
 	defer s.Close()
 

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -27,7 +27,7 @@ func TestMmapHNSW_InsertSearch(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, WithCosineDistance(),
+	idx := NewHNSWIndex(store,
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -70,7 +70,7 @@ func TestMmapHNSW_InsertDeleteSearch(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, WithCosineDistance(),
+	idx := NewHNSWIndex(store,
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -130,7 +130,7 @@ func TestMmapHNSW_DeleteReinsert(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, WithCosineDistance(),
+	idx := NewHNSWIndex(store,
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -181,7 +181,7 @@ func TestMmapHNSW_Upsert(t *testing.T) {
 	}
 	defer store.Close()
 
-	idx := NewHNSWIndex(store, WithCosineDistance(),
+	idx := NewHNSWIndex(store,
 		WithRand(rand.New(rand.NewSource(42))))
 
 	rng := rand.New(rand.NewSource(99))
@@ -301,7 +301,7 @@ func TestMmapHNSW_PersistenceReopen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i, v := range vecs {
@@ -324,7 +324,7 @@ func TestMmapHNSW_PersistenceReopen(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		postResults := mmapHNSWSearchResults(t, idx, queries, k)
@@ -352,7 +352,7 @@ func TestMmapHNSW_PersistenceReopenContinueInsert(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i := 0; i < n1; i++ {
@@ -373,7 +373,7 @@ func TestMmapHNSW_PersistenceReopenContinueInsert(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i := n1; i < n1+n2; i++ {
@@ -418,7 +418,7 @@ func TestMmapHNSW_PersistenceReopenDelete(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i, v := range vecs {
@@ -439,7 +439,7 @@ func TestMmapHNSW_PersistenceReopenDelete(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i := 0; i < numDeleted; i++ {
@@ -504,7 +504,7 @@ func TestMmapHNSW_WALReplayE2E(t *testing.T) {
 		}
 		t.Cleanup(crashCleanup)
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		for i, v := range vecs {
@@ -528,7 +528,7 @@ func TestMmapHNSW_WALReplayE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { store.Close() })
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 		postResults := mmapHNSWSearchResults(t, idx, queries, k)
@@ -557,7 +557,7 @@ func TestMmapHNSW_UpperGraph_MultiLayer(t *testing.T) {
 	defer store.Close()
 
 	// Use efConstruction=200 and fixed seed to get deterministic upper layers.
-	idx := NewHNSWIndex(store, WithCosineDistance(),
+	idx := NewHNSWIndex(store,
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(42))))
 
@@ -604,7 +604,7 @@ func TestMmapHNSW_UpperGraph_MultiLayer(t *testing.T) {
 
 	// Build MemStore baseline for structural comparison.
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore,
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(42))))
 	for i, v := range vecs {
@@ -667,7 +667,7 @@ func TestMmapHNSW_UpperGraph_PersistenceReopen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -694,7 +694,7 @@ func TestMmapHNSW_UpperGraph_PersistenceReopen(t *testing.T) {
 		}
 		defer store.Close()
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -753,7 +753,7 @@ func TestMmapHNSW_UpperGraph_GrowCrashRecovery(t *testing.T) {
 		}
 		t.Cleanup(crashCleanup)
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -783,7 +783,7 @@ func TestMmapHNSW_UpperGraph_GrowCrashRecovery(t *testing.T) {
 		}
 		t.Cleanup(func() { store.Close() })
 
-		idx := NewHNSWIndex(store, WithCosineDistance(),
+		idx := NewHNSWIndex(store,
 			WithEfConstruction(200),
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -873,7 +873,7 @@ func TestMmapHNSW_RecallAt10(t *testing.T) {
 
 	// --- MemStore recall ---
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore,
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
@@ -903,7 +903,7 @@ func TestMmapHNSW_RecallAt10(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore,
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	insertAllBatch(t, mmapIdx, baseVecs)
@@ -949,7 +949,7 @@ func TestMmapHNSW_ExportRecall(t *testing.T) {
 	hnswSeed := int64(42)
 
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore,
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i, v := range baseVecs {
@@ -967,7 +967,7 @@ func TestMmapHNSW_ExportRecall(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore,
 		WithEfConstruction(200), WithEfSearch(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 
@@ -1007,7 +1007,7 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 	hnswSeed := int64(42)
 
 	memStore := NewMemNodeStore()
-	memIdx := NewHNSWIndex(memStore, WithCosineDistance(),
+	memIdx := NewHNSWIndex(memStore,
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 	for i := 0; i < n; i++ {
@@ -1023,7 +1023,7 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 	}
 	defer mmapStore.Close()
 
-	mmapIdx := NewHNSWIndex(mmapStore, WithCosineDistance(),
+	mmapIdx := NewHNSWIndex(mmapStore,
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 

--- a/internal/core/vectorindex/mmap_store_read.go
+++ b/internal/core/vectorindex/mmap_store_read.go
@@ -7,12 +7,21 @@ import (
 	"unsafe"
 )
 
-// GetVector returns a copy of the vector for the given node ID. The returned
-// slice is owned by the caller and is safe to retain and mutate.
+// GetVector returns a copy of the original vector for the given node ID. The
+// returned slice is owned by the caller. For cosine the stored unit vector is
+// restored to its original scale via the stored norm; for the raw metrics the
+// stored vector is the original.
 func (s *MmapStore) GetVector(id uint64) ([]float32, error) {
 	ref, err := s.GetVectorRef(id)
 	if err != nil {
 		return nil, err
+	}
+	if s.metric.storesNormalized() {
+		norm, err := s.GetNorm(id)
+		if err != nil {
+			return nil, err
+		}
+		return s.metric.restore(ref, norm), nil // allocates a fresh slice
 	}
 	vec := make([]float32, len(ref))
 	copy(vec, ref)

--- a/internal/core/vectorindex/mmap_store_read_test.go
+++ b/internal/core/vectorindex/mmap_store_read_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMmapStoreGetVector(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestMmapStoreGetVector(t *testing.T) {
 
 func TestMmapStoreGetVectorOutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestMmapStoreGetVectorOutOfRange(t *testing.T) {
 
 func TestMmapStoreGetNeighborsL0(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestMmapStoreGetNeighborsL0(t *testing.T) {
 
 func TestMmapStoreGetNeighborsUpper(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestMmapStoreGetNeighborsUpper(t *testing.T) {
 
 func TestMmapStoreGetNormAndLevel(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestMmapStoreGetNormAndLevel(t *testing.T) {
 
 func TestMmapStoreGetNodeLevelDeleted(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestMmapStoreGetNodeLevelDeleted(t *testing.T) {
 
 func TestMmapStoreGetEntryPoint(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestMmapStoreGetEntryPoint(t *testing.T) {
 
 func TestMmapStoreGetNodeId(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestMmapStoreGetNodeId(t *testing.T) {
 
 func TestMmapStoreReadUpperSlotOutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestMmapStoreReadUpperSlotOutOfRange(t *testing.T) {
 
 func TestMmapStoreGetNeighborsL0OutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestMmapStoreGetNeighborsL0OutOfRange(t *testing.T) {
 
 func TestMmapStoreGetNeighborsUpperOutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +262,7 @@ func TestMmapStoreGetNeighborsUpperOutOfRange(t *testing.T) {
 
 func TestMmapStoreGetNeighborsUpperSlotZero(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestMmapStoreGetNeighborsUpperSlotZero(t *testing.T) {
 
 func TestMmapStoreGetNeighborsUpperBadLayer(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestMmapStoreGetNeighborsUpperBadLayer(t *testing.T) {
 
 func TestMmapStoreGetNeighborsUpperSlotOutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestMmapStoreGetNeighborsUpperSlotOutOfRange(t *testing.T) {
 
 func TestMmapStoreGetNormOutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestMmapStoreGetNormOutOfRange(t *testing.T) {
 
 func TestMmapStoreGetNodeLevelOutOfRange(t *testing.T) {
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/vectorindex/mmap_store_test.go
+++ b/internal/core/vectorindex/mmap_store_test.go
@@ -10,7 +10,7 @@ import (
 func TestMmapStoreOpenClose(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 128, M: 16})
 	if err != nil {
 		t.Fatalf("OpenMmapStore: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestMmapStoreOpenClose(t *testing.T) {
 	}
 
 	// Re-open should succeed with same params.
-	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 16})
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 128, M: 16})
 	if err != nil {
 		t.Fatalf("re-open: %v", err)
 	}
@@ -66,20 +66,20 @@ func TestMmapStoreOpenClose(t *testing.T) {
 func TestMmapStoreOpenMismatch(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 16})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 128, M: 16})
 	if err != nil {
 		t.Fatal(err)
 	}
 	s.Close()
 
 	// Dim mismatch.
-	_, err = OpenMmapStore(dir, MmapStoreOptions{Dim: 256, M: 16})
+	_, err = OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 256, M: 16})
 	if err == nil {
 		t.Fatal("expected error for dim mismatch")
 	}
 
 	// M mismatch.
-	_, err = OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 32})
+	_, err = OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 128, M: 32})
 	if err == nil {
 		t.Fatal("expected error for M mismatch")
 	}
@@ -88,10 +88,10 @@ func TestMmapStoreOpenMismatch(t *testing.T) {
 func TestMmapStoreInvalidOpts(t *testing.T) {
 	dir := t.TempDir()
 
-	if _, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 0, M: 16}); err == nil {
+	if _, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 0, M: 16}); err == nil {
 		t.Fatal("expected error for dim=0")
 	}
-	if _, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 128, M: 0}); err == nil {
+	if _, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 128, M: 0}); err == nil {
 		t.Fatal("expected error for M=0")
 	}
 }
@@ -102,7 +102,7 @@ func TestMmapStoreInitBadDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		badPath = "NUL\\impossible"
 	}
-	_, err := OpenMmapStore(badPath, MmapStoreOptions{Dim: 4, M: 4})
+	_, err := OpenMmapStore(badPath, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err == nil {
 		t.Fatal("expected error for non-writable path")
 	}
@@ -115,7 +115,7 @@ func TestMmapStoreInitSmallCap(t *testing.T) {
 	// Instead, verify upperCapacity is at least 64 when default cap is 1024 (256/4=256>=64 is fine,
 	// but let's verify the files are correct).
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -64,10 +64,10 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 
 	// Write node metadata (level, norm, upper slot).
 	nodeOff := int64(pageSize) + int64(id)*int64(nodeSlotSize)
-	s.nodes[nodeOff] = uint8(level) // Level
-	s.nodes[nodeOff+1] = 0          // Flags (not deleted)
-	s.nodes[nodeOff+2] = 0          // padding
-	s.nodes[nodeOff+3] = 0          // padding
+	s.nodes[nodeOff] = uint8(level)       // Level
+	s.nodes[nodeOff+1] = nodeFlagOccupied // Flags: occupied, not deleted
+	s.nodes[nodeOff+2] = 0                // padding
+	s.nodes[nodeOff+3] = 0                // padding
 	binary.LittleEndian.PutUint32(s.nodes[nodeOff+4:], math.Float32bits(norm))
 	binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], upperSlotVal)
 

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-
-	"github.com/viterin/vek/vek32"
 )
 
 // PutNode stores a node's vector, level, and norm into the mmap files.
@@ -20,13 +18,15 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
 
-	norm := vek32.Norm(vector)
+	// Convert to stored form (cosine: unit vector) and keep the original norm
+	// for GetVector restore. norm never participates in distance computation.
+	stored, norm := s.metric.prepare(vector)
 
 	// Look up docId from the in-memory mapping (may be empty if not yet set).
 	docId := s.nodeToDoc[id]
 
-	// WAL
-	if _, err := s.wal.Append(WalInsert, EncodeInsert(id, level, vector, norm, docId), s.batchMode); err != nil {
+	// WAL — record the stored form so replay writes it back verbatim.
+	if _, err := s.wal.Append(WalInsert, EncodeInsert(id, level, stored, norm, docId), s.batchMode); err != nil {
 		return fmt.Errorf("MmapStore.PutNode: WAL: %w", err)
 	}
 	if s.crashAfterWALWrite != nil {
@@ -44,9 +44,9 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 		return err
 	}
 
-	// Write vector.
+	// Write vector (stored form).
 	vecOff := int64(pageSize) + int64(id)*int64(s.vecSlotSize)
-	for i, v := range vector {
+	for i, v := range stored {
 		binary.LittleEndian.PutUint32(s.vectors[vecOff+int64(i*4):], math.Float32bits(v))
 	}
 	if !s.batchMode {

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -10,7 +10,7 @@ import (
 func openTestMmapStore(t *testing.T) *MmapStore {
 	t.Helper()
 	dir := t.TempDir()
-	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
 	requireNoError(t, err)
 	return s
 }
@@ -124,7 +124,7 @@ func TestMmapStoreNodeMapping(t *testing.T) {
 
 func TestMmapStoreNodeMappingPersistence(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -233,7 +233,7 @@ func TestMmapStoreNextNodeId(t *testing.T) {
 
 func TestMmapStoreNextNodeIdPersistence(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -256,7 +256,7 @@ func TestMmapStoreNextNodeIdPersistence(t *testing.T) {
 
 func TestDeferredSync_InsertSyncReopen(t *testing.T) {
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -29,7 +29,11 @@ func TestMmapStorePutNodeAndGetVector(t *testing.T) {
 }
 
 func TestMmapStorePutNodeAndGetNorm(t *testing.T) {
-	s := openTestMmapStore(t)
+	// Only cosine persists a norm (to restore the original scale); the raw
+	// metrics store the vector verbatim and skip the norm computation.
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: Cosine, Dim: 4, M: 4})
+	requireNoError(t, err)
 	defer s.Close()
 
 	vec := []float32{3.0, 4.0, 0.0, 0.0} // norm = 5.0
@@ -38,6 +42,19 @@ func TestMmapStorePutNodeAndGetNorm(t *testing.T) {
 	norm, err := s.GetNorm(0)
 	requireNoError(t, err)
 	assert.InDelta(t, float32(5.0), norm, 0.01)
+}
+
+func TestMmapStorePutNodeRawMetricNoNorm(t *testing.T) {
+	// A raw metric (dot/euclidean) stores the original vector and reports norm 0,
+	// since the norm is never needed to restore or compare it.
+	s := openTestMmapStore(t) // DotProduct
+	defer s.Close()
+
+	requireNoError(t, s.PutNode(0, 0, []float32{3.0, 4.0, 0.0, 0.0}))
+
+	norm, err := s.GetNorm(0)
+	requireNoError(t, err)
+	assert.Equal(t, float32(0), norm)
 }
 
 func TestMmapStorePutNodeWithLevel(t *testing.T) {

--- a/internal/core/vectorindex/mmap_wal_test.go
+++ b/internal/core/vectorindex/mmap_wal_test.go
@@ -180,7 +180,7 @@ func TestWALReplayInsertWithUpperLevel(t *testing.T) {
 	// Write a node at level>0, close, reopen → replayWAL must allocate upper
 	// slot and restore vectors/nodes/meta correctly.
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -215,7 +215,7 @@ func TestWALReplayInsertWithUpperLevel(t *testing.T) {
 func TestWALReplaySetNeighborsUpperPath(t *testing.T) {
 	// Exercises the WalSetNeighbors → setNeighborsUpper path in replayWAL.
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -242,7 +242,7 @@ func TestWALReplaySetNeighborsUpperPath(t *testing.T) {
 func TestWALReplaySetNormAndDelete(t *testing.T) {
 	// Exercises WalSetNorm and WalDelete record types in replayWAL.
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
@@ -274,7 +274,7 @@ func TestWALReplayGrowsDuringReplay(t *testing.T) {
 	// Insert a node beyond initial capacity, close, reopen.
 	// replayWAL must call ensureCapacity and grow files during replay.
 	dir := t.TempDir()
-	opts := MmapStoreOptions{Dim: 4, M: 4}
+	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)

--- a/internal/core/vectorindex/recall_debug_test.go
+++ b/internal/core/vectorindex/recall_debug_test.go
@@ -27,7 +27,7 @@ func TestHNSWRecallDebug10K(t *testing.T) {
 
 	// Build the index once and reuse it for all efSearch values.
 	store := NewMemNodeStore()
-	idx := NewHNSWIndex(store, WithCosineDistance(), WithRand(rand.New(rand.NewSource(seed))))
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(seed))))
 
 	for i, v := range vecs {
 		if err := idx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {

--- a/internal/core/vectorindex/store.go
+++ b/internal/core/vectorindex/store.go
@@ -6,10 +6,17 @@ import (
 )
 
 // NodeStore defines the persistence interface for HNSW graph nodes.
+//
+// Vectors are stored in the form dictated by the store's Metric: cosine stores
+// unit vectors (so distance reduces to 1 - dot), the raw metrics store vectors
+// unchanged. GetVectorRef returns the *stored* form (ready for metric.distance);
+// GetVector returns the original vector (cosine restores via the stored norm).
 type NodeStore interface {
+	// Metric returns the immutable distance metric this store was created with.
+	Metric() Metric
 	GetVector(id uint64) ([]float32, error)
-	// GetVectorRef returns the vector without copying. The caller MUST NOT
-	// modify the returned slice. Use GetVector when a mutable copy is needed.
+	// GetVectorRef returns the stored vector form without copying. The caller
+	// MUST NOT modify the returned slice. Use GetVector for the original vector.
 	GetVectorRef(id uint64) ([]float32, error)
 	PutNode(id uint64, level int, vector []float32) error
 	DeleteNode(id uint64) error


### PR DESCRIPTION
## What

Makes cosine distance store **unit vectors** so it collapses to `1 - dot` — no per-distance norm division, no `GetNorm` lookup (and no lock). The distance metric becomes an **immutable property of the store** (persisted in `meta.bin`, validated on `Open`) instead of an index option, so the metric, the on-disk vector form, and the graph can never disagree.

## Design

A small `Metric` type owns the storage form:

| | Distance | Stored form (`prepare`) | Restore |
|---|---|---|---|
| **Cosine** | `1 - dot` | `v / \|v\|` (unit) | `v × norm` |
| **DotProduct** | `1 - dot` | `v` (raw) | `v` |
| **Euclidean** | `\|a-b\|` | `v` (raw) | `v` |

- `NodeStore.Metric()`; `MmapStoreOptions`/`NewMemNodeStore` take a metric (default `Cosine`); `MetaHeader` carries it (64→72 bytes) and `OpenMmapStore` validates it like `Dim`/`M`.
- `GetVectorRef` returns the **stored** (normalized) form for the hot path; `GetVector` **restores** the original (`× norm`). The norm is still stored but **never participates in distance** — only in restore.
- `HNSWIndex` reads the metric from the store and prepares queries once. Removed: the `isCosine` flag, `nodeDistCalc`/`nodeDistanceWithNorm`, the per-distance norm fetch, and the `With*Distance` options.

## Results

Benchmarks (MemStore, default cosine, fixed iteration count):

| | Before (#67) | After | Δ |
|---|---|---|---|
| `BenchmarkHNSWInsert` | 873k ns/op | 736k ns/op | **−15.7%** |
| `BenchmarkHNSWSearch` | 121k ns/op | 100k ns/op | **−17.2%** |

This is the win the earlier "reuse the stored norm" attempt couldn't get (that was a wash because `GetNorm` takes a lock); normalizing on store removes the norm from the distance path entirely.

## Correctness / tests
- **Recall preserved** — all recall and mmap-vs-mem exact-match tests pass throughout.
- The cosine round-trip (`â × norm`) is lossy by ~1e-6, so storage-fidelity tests that assert *exact* vectors now use a non-normalizing metric (`DotProduct`); `GetVector` of a cosine store returns the original within ~1e-6.
- `go test` green; `-race` clean.

## Note
Pre-release library, so the `meta.bin` format change needs **no migration** (per the maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)