### PR TITLE
refactor(vectorindex): crash-atomic Batch API replacing the legacy batch machinery

### DIFF
--- a/internal/core/vectorindex/batch.go
+++ b/internal/core/vectorindex/batch.go
@@ -1,0 +1,97 @@
+package vectorindex
+
+// batchOpKind distinguishes buffered Put from Delete.
+type batchOpKind int
+
+const (
+	opPut batchOpKind = iota
+	opDelete
+)
+
+type batchOp struct {
+	kind   batchOpKind
+	docId  string
+	vector []float32 // populated for opPut (already copied); nil for opDelete
+}
+
+// Batch is the unit of mutation. Created via HNSWIndex.NewBatch and owned by a
+// single goroutine. Put/Delete buffer operations in memory (coalesced per
+// docId, last-op-wins); Commit applies them to the graph atomically inside one
+// store transaction; Discard drops the buffer without touching the graph.
+type Batch struct {
+	idx  *HNSWIndex
+	ops  []batchOp
+	seen map[string]int // docId -> index in ops (coalescing)
+}
+
+// NewBatch returns an empty Batch bound to this index.
+func (h *HNSWIndex) NewBatch() *Batch {
+	return &Batch{idx: h, seen: make(map[string]int)}
+}
+
+// Put buffers an insert/replace of docId with vector. The vector is copied, so
+// the caller may reuse its slice. A later Put/Delete of the same docId in this
+// batch supersedes this one.
+func (b *Batch) Put(docId string, vector []float32) {
+	cp := make([]float32, len(vector))
+	copy(cp, vector)
+	b.set(batchOp{kind: opPut, docId: docId, vector: cp})
+}
+
+// Delete buffers a removal of docId. Coalesces with any prior op for docId.
+func (b *Batch) Delete(docId string) {
+	b.set(batchOp{kind: opDelete, docId: docId})
+}
+
+// set inserts or overwrites the op for op.docId, preserving first-seen order.
+func (b *Batch) set(op batchOp) {
+	if i, ok := b.seen[op.docId]; ok {
+		b.ops[i] = op
+		return
+	}
+	b.seen[op.docId] = len(b.ops)
+	b.ops = append(b.ops, op)
+}
+
+// Len returns the number of pending (coalesced) operations.
+func (b *Batch) Len() int { return len(b.ops) }
+
+// Discard drops all buffered operations. The graph is untouched (nothing was
+// applied), so no rollback is needed. The batch is reusable afterward.
+func (b *Batch) Discard() {
+	b.ops = b.ops[:0]
+	b.seen = make(map[string]int)
+}
+
+// Commit applies all buffered operations to the graph atomically inside one
+// store transaction, then empties the batch (reusable). An empty batch is a
+// no-op (no transaction opened). On error the store is faulted (for persistent
+// stores) and the batch is emptied; the error is returned.
+func (b *Batch) Commit() error {
+	if len(b.ops) == 0 {
+		return nil
+	}
+	h := b.idx
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	err := h.runInTxnLocked(func() error {
+		for _, op := range b.ops {
+			switch op.kind {
+			case opPut:
+				if e := h.insertOneLocked(op.docId, op.vector); e != nil {
+					return e
+				}
+			case opDelete:
+				if e := h.deleteOneLocked(op.docId); e != nil {
+					return e
+				}
+			}
+		}
+		return nil
+	})
+
+	b.ops = b.ops[:0]
+	b.seen = make(map[string]int)
+	return err
+}

--- a/internal/core/vectorindex/batch.go
+++ b/internal/core/vectorindex/batch.go
@@ -18,6 +18,8 @@ type batchOp struct {
 // single goroutine. Put/Delete buffer operations in memory (coalesced per
 // docId, last-op-wins); Commit applies them to the graph atomically inside one
 // store transaction; Discard drops the buffer without touching the graph.
+// It is not safe to call Put, Delete, Commit, or Discard concurrently from
+// multiple goroutines.
 type Batch struct {
 	idx  *HNSWIndex
 	ops  []batchOp

--- a/internal/core/vectorindex/batch_options_test.go
+++ b/internal/core/vectorindex/batch_options_test.go
@@ -72,9 +72,9 @@ func TestIndexMetricFromStore(t *testing.T) {
 	}
 }
 
-// --- InsertBatch tests ---
+// --- Batch tests ---
 
-func TestInsertBatchMemStore(t *testing.T) {
+func TestBatchCommitMemStore(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
@@ -95,7 +95,7 @@ func TestInsertBatchMemStore(t *testing.T) {
 	assert.InDelta(t, 0.0, results[0].Distance, 1e-6)
 }
 
-func TestInsertBatchEmpty(t *testing.T) {
+func TestBatchEmptyNoItems(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store)
 
@@ -107,7 +107,7 @@ func TestInsertBatchEmpty(t *testing.T) {
 	assert.Empty(t, results)
 }
 
-func TestInsertBatchSingle(t *testing.T) {
+func TestBatchSinglePut(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
@@ -318,9 +318,9 @@ func TestLoadVectorsTruncatedData(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// --- InsertBatch with WithM/WithEfConstruction/WithEfSearch ---
+// --- Batch with WithM/WithEfConstruction/WithEfSearch ---
 
-func TestInsertBatchWithCustomOptions(t *testing.T) {
+func TestBatchWithCustomOptions(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store,
 		WithM(4),

--- a/internal/core/vectorindex/batch_options_test.go
+++ b/internal/core/vectorindex/batch_options_test.go
@@ -416,3 +416,17 @@ func requireNoError(t *testing.T, err error) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestMemNodeStoreTxnNoOps(t *testing.T) {
+	var ns NodeStore = NewMemNodeStore()
+	if err := ns.txnBegin(); err != nil {
+		t.Fatalf("txnBegin: %v", err)
+	}
+	if err := ns.txnCommit(); err != nil {
+		t.Fatalf("txnCommit: %v", err)
+	}
+	cause := fmt.Errorf("boom")
+	if err := ns.txnAbort(cause); err != cause {
+		t.Fatalf("txnAbort must return its cause, got %v", err)
+	}
+}

--- a/internal/core/vectorindex/batch_options_test.go
+++ b/internal/core/vectorindex/batch_options_test.go
@@ -78,13 +78,11 @@ func TestInsertBatchMemStore(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
-	items := []InsertItem{
-		{DocId: "doc-0", Vector: []float32{1, 0, 0}},
-		{DocId: "doc-1", Vector: []float32{0, 1, 0}},
-		{DocId: "doc-2", Vector: []float32{0, 0, 1}},
-	}
-
-	err := idx.InsertBatch(items)
+	b := idx.NewBatch()
+	b.Put("doc-0", []float32{1, 0, 0})
+	b.Put("doc-1", []float32{0, 1, 0})
+	b.Put("doc-2", []float32{0, 0, 1})
+	err := b.Commit()
 	requireNoError(t, err)
 
 	// Verify all items are searchable.
@@ -101,7 +99,7 @@ func TestInsertBatchEmpty(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store)
 
-	err := idx.InsertBatch(nil)
+	err := idx.NewBatch().Commit() // empty batch is a no-op
 	requireNoError(t, err)
 
 	results, err := idx.Search([]float32{1, 0, 0}, 1)
@@ -113,10 +111,9 @@ func TestInsertBatchSingle(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(42))))
 
-	err := idx.InsertBatch([]InsertItem{
-		{DocId: "only", Vector: []float32{1, 2, 3}},
-	})
-	requireNoError(t, err)
+	b := idx.NewBatch()
+	b.Put("only", []float32{1, 2, 3})
+	requireNoError(t, b.Commit())
 
 	results, err := idx.Search([]float32{1, 2, 3}, 1)
 	requireNoError(t, err)
@@ -332,22 +329,22 @@ func TestInsertBatchWithCustomOptions(t *testing.T) {
 		WithRand(rand.New(rand.NewSource(42))),
 	)
 
-	items := make([]InsertItem, 20)
-	for i := range items {
+	b := idx.NewBatch()
+	for i := 0; i < 20; i++ {
 		v := make([]float32, 8)
 		for j := range v {
 			v[j] = float32(i*8+j) + 0.1
 		}
-		items[i] = InsertItem{
-			DocId:  fmt.Sprintf("doc-%d", i),
-			Vector: v,
-		}
+		b.Put(fmt.Sprintf("doc-%d", i), v)
 	}
-
-	requireNoError(t, idx.InsertBatch(items))
+	requireNoError(t, b.Commit())
 
 	// Verify search works with custom efSearch.
-	results, err := idx.Search(items[0].Vector, 5)
+	v0 := make([]float32, 8)
+	for j := range v0 {
+		v0[j] = float32(0*8+j) + 0.1
+	}
+	results, err := idx.Search(v0, 5)
 	requireNoError(t, err)
 	assert.NotEmpty(t, results)
 	assert.Equal(t, uint64(1), results[0].ID, "closest result should be the query itself")

--- a/internal/core/vectorindex/batch_test.go
+++ b/internal/core/vectorindex/batch_test.go
@@ -1,6 +1,7 @@
 package vectorindex
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -110,6 +111,44 @@ func TestBatchUpsertReplacesCommittedDoc(t *testing.T) {
 	requireNoError(t, err)
 	requireLen(t, res2, 1)
 	assert.Greater(t, res2[0].Distance, float32(0.5), "old [1,0,0] node must no longer exist")
+}
+
+// failingStore wraps a MemNodeStore and fails the Nth PutNode, recording
+// whether the transaction was aborted.
+type failingStore struct {
+	*MemNodeStore
+	failOnPut int
+	puts      int
+	aborted   bool
+}
+
+func (f *failingStore) PutNode(id uint64, level int, vec []float32) error {
+	f.puts++
+	if f.puts == f.failOnPut {
+		return fmt.Errorf("injected PutNode failure")
+	}
+	return f.MemNodeStore.PutNode(id, level, vec)
+}
+
+func (f *failingStore) txnAbort(cause error) error {
+	f.aborted = true
+	return f.MemNodeStore.txnAbort(cause)
+}
+
+func TestBatchCommitAbortsOnApplyError(t *testing.T) {
+	fs := &failingStore{MemNodeStore: NewMemNodeStore(), failOnPut: 3}
+	idx := NewHNSWIndex(fs, WithRand(rand.New(rand.NewSource(5))))
+
+	b := idx.NewBatch()
+	for i := 0; i < 5; i++ {
+		b.Put(fmt.Sprintf("doc-%d", i), []float32{float32(i), 1, 0})
+	}
+	if err := b.Commit(); err == nil {
+		t.Fatal("Commit must return the injected error")
+	}
+	if !fs.aborted {
+		t.Fatal("Commit must abort the transaction on a mid-apply error")
+	}
 }
 
 func TestBatchReusableAcrossCommits(t *testing.T) {

--- a/internal/core/vectorindex/batch_test.go
+++ b/internal/core/vectorindex/batch_test.go
@@ -1,0 +1,89 @@
+package vectorindex
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestIndex() *HNSWIndex {
+	return NewHNSWIndex(NewMemNodeStore(), WithRand(rand.New(rand.NewSource(42))))
+}
+
+func TestBatchCoalescePutThenPut(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	b.Put("d", []float32{1, 0, 0})
+	b.Put("d", []float32{0, 1, 0}) // overwrites
+	assert.Equal(t, 1, b.Len(), "same docId must coalesce to one op")
+
+	requireNoError(t, b.Commit())
+
+	// Only the second vector should be present.
+	res, err := idx.Search([]float32{0, 1, 0}, 1)
+	requireNoError(t, err)
+	requireLen(t, res, 1)
+	assert.InDelta(t, 0.0, res[0].Distance, 1e-6)
+}
+
+func TestBatchCoalescePutThenDelete(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	b.Put("d", []float32{1, 0, 0})
+	b.Delete("d") // net: delete, nothing inserted
+	assert.Equal(t, 1, b.Len())
+
+	requireNoError(t, b.Commit())
+
+	res, err := idx.Search([]float32{1, 0, 0}, 1)
+	requireNoError(t, err)
+	assert.Empty(t, res, "Put then Delete in one batch inserts nothing")
+}
+
+func TestBatchCoalesceDeleteThenPutIsUpsert(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	b.Delete("d")
+	b.Put("d", []float32{0, 0, 1})
+	assert.Equal(t, 1, b.Len())
+
+	requireNoError(t, b.Commit())
+
+	res, err := idx.Search([]float32{0, 0, 1}, 1)
+	requireNoError(t, err)
+	requireLen(t, res, 1)
+	assert.InDelta(t, 0.0, res[0].Distance, 1e-6)
+}
+
+func TestBatchDeleteAbsentIsNoop(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	b.Delete("never-existed")
+	assert.Equal(t, 1, b.Len())
+	requireNoError(t, b.Commit()) // must not error
+
+	res, err := idx.Search([]float32{1, 0, 0}, 1)
+	requireNoError(t, err)
+	assert.Empty(t, res)
+}
+
+func TestBatchEmptyCommitNoop(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	assert.Equal(t, 0, b.Len())
+	requireNoError(t, b.Commit())
+}
+
+func TestBatchDiscardDropsBuffer(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	b.Put("d", []float32{1, 0, 0})
+	b.Discard()
+	assert.Equal(t, 0, b.Len())
+
+	requireNoError(t, b.Commit()) // discarded → nothing applied
+	res, err := idx.Search([]float32{1, 0, 0}, 1)
+	requireNoError(t, err)
+	assert.Empty(t, res)
+}

--- a/internal/core/vectorindex/batch_test.go
+++ b/internal/core/vectorindex/batch_test.go
@@ -87,3 +87,27 @@ func TestBatchDiscardDropsBuffer(t *testing.T) {
 	requireNoError(t, err)
 	assert.Empty(t, res)
 }
+
+func TestBatchUpsertReplacesCommittedDoc(t *testing.T) {
+	idx := newTestIndex()
+
+	// Commit an initial value.
+	requireNoError(t, idx.Insert("d", []float32{1, 0, 0}))
+
+	// A second batch Puts the same docId with a new vector.
+	b := idx.NewBatch()
+	b.Put("d", []float32{0, 0, 1})
+	requireNoError(t, b.Commit())
+
+	// docId maps to exactly one node, and it is the new vector.
+	res, err := idx.Search([]float32{0, 0, 1}, 2)
+	requireNoError(t, err)
+	requireLen(t, res, 1) // only one node exists for "d"
+	assert.InDelta(t, 0.0, res[0].Distance, 1e-6)
+
+	// The old vector is gone.
+	res2, err := idx.Search([]float32{1, 0, 0}, 1)
+	requireNoError(t, err)
+	requireLen(t, res2, 1)
+	assert.Greater(t, res2[0].Distance, float32(0.5), "old [1,0,0] node must no longer exist")
+}

--- a/internal/core/vectorindex/batch_test.go
+++ b/internal/core/vectorindex/batch_test.go
@@ -111,3 +111,20 @@ func TestBatchUpsertReplacesCommittedDoc(t *testing.T) {
 	requireLen(t, res2, 1)
 	assert.Greater(t, res2[0].Distance, float32(0.5), "old [1,0,0] node must no longer exist")
 }
+
+func TestBatchReusableAcrossCommits(t *testing.T) {
+	idx := newTestIndex()
+	b := idx.NewBatch()
+	b.Put("a", []float32{1, 0, 0})
+	requireNoError(t, b.Commit())
+	assert.Equal(t, 0, b.Len(), "batch must be empty after Commit")
+
+	b.Put("b", []float32{0, 1, 0})
+	assert.Equal(t, 1, b.Len(), "reused batch sees only the new op")
+	requireNoError(t, b.Commit())
+
+	res, err := idx.Search([]float32{0, 1, 0}, 1)
+	requireNoError(t, err)
+	requireLen(t, res, 1)
+	assert.InDelta(t, 0.0, res[0].Distance, 1e-6)
+}

--- a/internal/core/vectorindex/benchmark_test.go
+++ b/internal/core/vectorindex/benchmark_test.go
@@ -278,6 +278,50 @@ func BenchmarkHNSWSearch(b *testing.B) {
 	}
 }
 
+// BenchmarkHNSWBatchInsert measures per-item throughput of inserting b.N items
+// through a single NewBatch + Commit (one transaction, one fsync). It is the
+// batch-throughput counterpart to BenchmarkHNSWInsert (one txn per item).
+func BenchmarkHNSWBatchInsert(b *testing.B) {
+	const dim = 128
+	rng := rand.New(rand.NewSource(42))
+	vecs := randomVectors(rng, b.N, dim)
+
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(99))))
+
+	b.ResetTimer()
+	batch := idx.NewBatch()
+	for i := 0; i < b.N; i++ {
+		batch.Put(fmt.Sprintf("%d", i), vecs[i])
+	}
+	if err := batch.Commit(); err != nil {
+		b.Fatalf("commit: %v", err)
+	}
+}
+
+// BenchmarkHNSWDelete measures the latency of deleting existing nodes. The
+// index is pre-built with b.N nodes (untimed); the timed loop deletes each.
+func BenchmarkHNSWDelete(b *testing.B) {
+	const dim = 128
+	rng := rand.New(rand.NewSource(42))
+	vecs := randomVectors(rng, b.N, dim)
+
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(99))))
+	for i := 0; i < b.N; i++ {
+		if err := idx.Insert(fmt.Sprintf("%d", i), vecs[i]); err != nil {
+			b.Fatalf("setup insert %d: %v", i, err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := idx.Delete(fmt.Sprintf("%d", i)); err != nil {
+			b.Fatalf("delete %d: %v", i, err)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Recall@10 test with 1000 vectors
 // ---------------------------------------------------------------------------

--- a/internal/core/vectorindex/error_store_test.go
+++ b/internal/core/vectorindex/error_store_test.go
@@ -150,8 +150,8 @@ func (e *errorStore) SetNorm(id uint64, norm float32) error {
 	return e.inner.SetNorm(id, norm)
 }
 
-func (e *errorStore) txnBegin() error  { return e.inner.txnBegin() }
-func (e *errorStore) txnCommit() error { return e.inner.txnCommit() }
+func (e *errorStore) txnBegin() error            { return e.inner.txnBegin() }
+func (e *errorStore) txnCommit() error           { return e.inner.txnCommit() }
 func (e *errorStore) txnAbort(cause error) error { return e.inner.txnAbort(cause) }
 
 func (e *errorStore) Close() error {
@@ -397,6 +397,7 @@ func TestInsertBatchPropagatesError(t *testing.T) {
 	err := b.Commit()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "PutNode")
+	assert.Equal(t, 0, b.Len(), "batch must be drained after a failed Commit")
 }
 
 // Delete a doc that was never inserted — should be a no-op.

--- a/internal/core/vectorindex/error_store_test.go
+++ b/internal/core/vectorindex/error_store_test.go
@@ -150,6 +150,10 @@ func (e *errorStore) SetNorm(id uint64, norm float32) error {
 	return e.inner.SetNorm(id, norm)
 }
 
+func (e *errorStore) txnBegin() error  { return e.inner.txnBegin() }
+func (e *errorStore) txnCommit() error { return e.inner.txnCommit() }
+func (e *errorStore) txnAbort(cause error) error { return e.inner.txnAbort(cause) }
+
 func (e *errorStore) Close() error {
 	if err := e.getErr(e.CloseErr); err != nil {
 		return err

--- a/internal/core/vectorindex/error_store_test.go
+++ b/internal/core/vectorindex/error_store_test.go
@@ -382,10 +382,10 @@ func TestInsertWithCosineDistanceMultiNode(t *testing.T) {
 }
 
 // =====================================================================
-// InsertBatch error paths
+// Batch error paths
 // =====================================================================
 
-func TestInsertBatchPropagatesError(t *testing.T) {
+func TestBatchCommitPropagatesError(t *testing.T) {
 	es := newErrorStore()
 	idx := NewHNSWIndex(es)
 

--- a/internal/core/vectorindex/error_store_test.go
+++ b/internal/core/vectorindex/error_store_test.go
@@ -389,13 +389,12 @@ func TestInsertBatchPropagatesError(t *testing.T) {
 	es := newErrorStore()
 	idx := NewHNSWIndex(es)
 
-	items := []InsertItem{
-		{DocId: "a", Vector: []float32{1, 0}},
-		{DocId: "b", Vector: []float32{0, 1}},
-	}
+	b := idx.NewBatch()
+	b.Put("a", []float32{1, 0})
+	b.Put("b", []float32{0, 1})
 
 	es.PutNodeErr = fmt.Errorf("injected: PutNode in batch")
-	err := idx.InsertBatch(items)
+	err := b.Commit()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "PutNode")
 }

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -292,7 +292,6 @@ func (h *HNSWIndex) deleteOneLocked(docId string) error {
 	return h.deleteNodeLocked(nodeId, docId)
 }
 
-
 // Search returns the k nearest neighbors of query (Algorithm 2).
 func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {
 	h.mu.RLock()

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -292,30 +292,6 @@ func (h *HNSWIndex) deleteOneLocked(docId string) error {
 	return h.deleteNodeLocked(nodeId, docId)
 }
 
-// InsertItem holds a document ID and its vector for batch insertion.
-type InsertItem struct {
-	DocId  string
-	Vector []float32
-}
-
-// InsertBatch inserts multiple items in a single batch when the store
-// supports batching. The outer batch commits once at the end.
-func (h *HNSWIndex) InsertBatch(items []InsertItem) error {
-	bs, batchable := h.store.(BatchableStore)
-	if batchable {
-		bs.BeginBatch()
-		defer bs.DiscardBatch()
-	}
-	for _, item := range items {
-		if err := h.Insert(item.DocId, item.Vector); err != nil {
-			return err
-		}
-	}
-	if batchable {
-		return bs.CommitBatch(true)
-	}
-	return nil
-}
 
 // Search returns the k nearest neighbors of query (Algorithm 2).
 func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {

--- a/internal/core/vectorindex/hnsw.go
+++ b/internal/core/vectorindex/hnsw.go
@@ -90,33 +90,41 @@ func (h *HNSWIndex) randomLevel() int {
 	return int(math.Floor(-math.Log(r) * h.mL))
 }
 
-// Insert adds a document's vector to the index (Algorithm 1).
+// runInTxnLocked brackets apply() in a store transaction. On apply error it
+// aborts (which faults a persistent store) and returns the original error;
+// otherwise it commits. Caller must hold h.mu.
+func (h *HNSWIndex) runInTxnLocked(apply func() error) error {
+	if err := h.store.txnBegin(); err != nil {
+		return err
+	}
+	if err := apply(); err != nil {
+		_ = h.store.txnAbort(err)
+		return err
+	}
+	return h.store.txnCommit()
+}
+
+// Insert adds (or replaces) a document's vector. Equivalent to a single-op
+// batch: it wraps one insert in a store transaction.
 func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.runInTxnLocked(func() error { return h.insertOneLocked(docId, vector) })
+}
 
+// insertOneLocked performs upsert-delete (if docId exists) followed by a fresh
+// HNSW insert (Algorithm 1). Caller must hold h.mu AND have an open store
+// transaction; it performs no batch/transaction management itself.
+func (h *HNSWIndex) insertOneLocked(docId string, vector []float32) error {
 	// Upsert: if docId already exists, delete the old node first to avoid
-	// orphan nodes and inconsistent mappings (HAY-005).
+	// orphan nodes and inconsistent mappings (HAY-005). This now runs inside
+	// the same transaction as the insert, so an upsert is atomic.
 	if existingId, found, err := h.store.GetNodeId(docId); err != nil {
 		return fmt.Errorf("failed to check existing docId %q: %v", docId, err)
 	} else if found {
 		if err := h.deleteNodeLocked(existingId, docId); err != nil {
 			return fmt.Errorf("failed to delete existing node for docId %q: %v", docId, err)
 		}
-	}
-
-	// If the store supports batching, wrap this insert in a batch.
-	// Nested calls (e.g. from InsertBatch) just increment depth.
-	bs, batchable := h.store.(BatchableStore)
-	batchStarted := false
-	if batchable {
-		bs.BeginBatch()
-		batchStarted = true
-		defer func() {
-			if batchStarted {
-				bs.DiscardBatch()
-			}
-		}()
 	}
 
 	// Allocate a new node ID.
@@ -145,26 +153,12 @@ func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 	epId, maxLayer, err := h.store.GetEntryPoint()
 	if err != nil {
 		// First node — set as entry point and return.
-		if err := h.store.SetEntryPoint(nodeId, l); err != nil {
-			return err
-		}
-		if batchable {
-			batchStarted = false
-			return bs.CommitBatch(true)
-		}
-		return nil
+		return h.store.SetEntryPoint(nodeId, l)
 	}
 
 	// Verify entry point node still exists (may have been deleted).
 	if _, err := h.store.GetVectorRef(epId); err != nil {
-		if err := h.store.SetEntryPoint(nodeId, l); err != nil {
-			return err
-		}
-		if batchable {
-			batchStarted = false
-			return bs.CommitBatch(true)
-		}
-		return nil
+		return h.store.SetEntryPoint(nodeId, l)
 	}
 
 	// Phase 1: From top layer down to l+1, greedy search with ef=1.
@@ -282,12 +276,20 @@ func (h *HNSWIndex) Insert(docId string, vector []float32) error {
 			return err
 		}
 	}
-
-	if batchable {
-		batchStarted = false
-		return bs.CommitBatch(true)
-	}
 	return nil
+}
+
+// deleteOneLocked removes a docId from the graph if present. Caller must hold
+// h.mu AND have an open store transaction.
+func (h *HNSWIndex) deleteOneLocked(docId string) error {
+	nodeId, found, err := h.store.GetNodeId(docId)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+	return h.deleteNodeLocked(nodeId, docId)
 }
 
 // InsertItem holds a document ID and its vector for batch insertion.
@@ -387,20 +389,11 @@ func (h *HNSWIndex) Search(query []float32, k int) ([]SearchResult, error) {
 	return out, nil
 }
 
-// Delete removes a document from the index.
+// Delete removes a document from the index inside a store transaction.
 func (h *HNSWIndex) Delete(docId string) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-
-	nodeId, found, err := h.store.GetNodeId(docId)
-	if err != nil {
-		return err
-	}
-	if !found {
-		return nil
-	}
-
-	return h.deleteNodeLocked(nodeId, docId)
+	return h.runInTxnLocked(func() error { return h.deleteOneLocked(docId) })
 }
 
 // deleteNodeLocked removes a node from the HNSW graph. Caller must hold h.mu.

--- a/internal/core/vectorindex/hnsw_concurrency_test.go
+++ b/internal/core/vectorindex/hnsw_concurrency_test.go
@@ -104,6 +104,107 @@ func TestConcurrentSearchOnly(t *testing.T) {
 	wg.Wait()
 }
 
+func TestConcurrentBatchCommitsAndSearch(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store)
+
+	const dim = 24
+	var wg sync.WaitGroup
+
+	// 8 goroutines each committing its own batches (no shared batch state).
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(gid)))
+			for round := 0; round < 5; round++ {
+				b := idx.NewBatch()
+				for i := 0; i < 5; i++ {
+					vec := make([]float32, dim)
+					for d := range vec {
+						vec[d] = rng.Float32()
+					}
+					b.Put(fmt.Sprintf("doc-%d-%d-%d", gid, round, i), vec)
+				}
+				if err := b.Commit(); err != nil {
+					t.Errorf("commit g=%d round=%d: %v", gid, round, err)
+					return
+				}
+			}
+		}(g)
+	}
+
+	// 4 concurrent searchers.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(1000 + gid)))
+			for i := 0; i < 30; i++ {
+				q := make([]float32, dim)
+				for d := range q {
+					q[d] = rng.Float32()
+				}
+				if _, err := idx.Search(q, 5); err != nil {
+					t.Errorf("search: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+}
+
+func TestSearchNeverSeesPartialBatch(t *testing.T) {
+	store := NewMemNodeStore()
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(3))))
+
+	const dim, batch = 16, 40
+	rng := rand.New(rand.NewSource(9))
+	q := make([]float32, dim)
+	for d := range q {
+		q[d] = rng.Float32()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b := idx.NewBatch()
+		for i := 0; i < batch; i++ {
+			v := make([]float32, dim)
+			for d := range v {
+				v[d] = rng.Float32()
+			}
+			b.Put(fmt.Sprintf("doc-%d", i), v)
+		}
+		_ = b.Commit() // one transaction; either all 40 visible or none
+	}()
+
+	// Hammer Search during the commit. Because Commit holds h.mu (write) and
+	// Search holds h.mu (read), Search never overlaps a commit: result count is
+	// the pre-state (0) or the post-state (batch), never in between.
+	for {
+		res, err := idx.Search(q, batch)
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if n := len(res); n != 0 && n != batch {
+			t.Fatalf("partial batch observed: %d results (want 0 or %d)", n, batch)
+		}
+		select {
+		case <-done:
+			final, err := idx.Search(q, batch)
+			requireNoError(t, err)
+			if len(final) != batch {
+				t.Fatalf("after commit: %d results, want %d", len(final), batch)
+			}
+			return
+		default:
+		}
+	}
+}
+
 func TestConcurrentInsertDeleteSearch(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store)

--- a/internal/core/vectorindex/mem_store.go
+++ b/internal/core/vectorindex/mem_store.go
@@ -204,6 +204,17 @@ func (m *MemNodeStore) SetNorm(id uint64, norm float32) error {
 	return nil
 }
 
+// txnBegin is a no-op: MemNodeStore is in-memory and not a durability target.
+func (m *MemNodeStore) txnBegin() error { return nil }
+
+// txnCommit is a no-op. Atomicity for MemNodeStore is bounded by the index
+// write lock held across Batch.Commit (no crash recovery to provide).
+func (m *MemNodeStore) txnCommit() error { return nil }
+
+// txnAbort returns the cause so callers propagate the original error. There is
+// no in-memory rollback (the spec scopes crash-atomicity to MmapStore).
+func (m *MemNodeStore) txnAbort(cause error) error { return cause }
+
 func (m *MemNodeStore) Close() error {
 	return nil
 }

--- a/internal/core/vectorindex/mmap_bench50k_test.go
+++ b/internal/core/vectorindex/mmap_bench50k_test.go
@@ -55,15 +55,13 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 			nBatches := nBase / bs
 			remainder := nBase % bs
 			for i := 0; i < nBatches; i++ {
-				store.BeginBatch()
+				b := idx.NewBatch()
 				for j := 0; j < bs; j++ {
 					vecIdx := i*bs + j
-					if err := idx.Insert(fmt.Sprintf("%d", vecIdx), base[vecIdx]); err != nil {
-						t.Fatalf("insert vector %d: %v", vecIdx, err)
-					}
+					b.Put(fmt.Sprintf("%d", vecIdx), base[vecIdx])
 				}
-				if err := store.CommitBatch(true); err != nil {
-					t.Fatalf("CommitBatch at batch %d: %v", i, err)
+				if err := b.Commit(); err != nil {
+					t.Fatalf("batch Commit at batch %d: %v", i, err)
 				}
 				if (i+1)%200 == 0 {
 					t.Logf("  completed %d/%d batches (%d vectors, elapsed %v)",
@@ -71,15 +69,13 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 				}
 			}
 			if remainder > 0 {
-				store.BeginBatch()
+				b := idx.NewBatch()
 				for j := 0; j < remainder; j++ {
 					vecIdx := nBatches*bs + j
-					if err := idx.Insert(fmt.Sprintf("%d", vecIdx), base[vecIdx]); err != nil {
-						t.Fatalf("insert vector %d: %v", vecIdx, err)
-					}
+					b.Put(fmt.Sprintf("%d", vecIdx), base[vecIdx])
 				}
-				if err := store.CommitBatch(true); err != nil {
-					t.Fatalf("CommitBatch remainder: %v", err)
+				if err := b.Commit(); err != nil {
+					t.Fatalf("batch Commit remainder: %v", err)
 				}
 			}
 			insertElapsed := time.Since(start)
@@ -126,26 +122,19 @@ func TestBenchmark50K_MmapStore(t *testing.T) {
 
 		idx := NewHNSWIndex(store)
 
-		t.Log("Inserting 50K vectors: deferred sync (single bulk)...")
-		if err := store.SetSyncMode(SyncDeferred); err != nil {
-			t.Fatalf("SetSyncMode(Deferred): %v", err)
-		}
+		t.Log("Inserting 50K vectors: single batch bulk insert...")
+		b := idx.NewBatch()
 		start := time.Now()
 		for i, v := range base {
-			if err := idx.Insert(fmt.Sprintf("%d", i), v); err != nil {
-				t.Fatalf("insert vector %d: %v", i, err)
-			}
+			b.Put(fmt.Sprintf("%d", i), v)
 			if (i+1)%10000 == 0 {
-				t.Logf("  inserted %d/%d vectors (elapsed %v)",
+				t.Logf("  staged %d/%d vectors (elapsed %v)",
 					i+1, len(base), time.Since(start).Round(time.Millisecond))
 			}
 		}
 		insertElapsed := time.Since(start)
-		if err := store.Sync(); err != nil {
-			t.Fatalf("store.Sync: %v", err)
-		}
-		if err := store.SetSyncMode(SyncImmediate); err != nil {
-			t.Fatalf("SetSyncMode(Immediate): %v", err)
+		if err := b.Commit(); err != nil {
+			t.Fatalf("batch Commit: %v", err)
 		}
 
 		t.Logf("Insert complete: %v (%.4fms/op)",

--- a/internal/core/vectorindex/mmap_checkpoint_test.go
+++ b/internal/core/vectorindex/mmap_checkpoint_test.go
@@ -38,13 +38,14 @@ func TestCheckpoint_MetaAndWALTruncated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify meta.bin WalCheckpointLSN = n+2 (n data records + TxnBegin + TxnCommit).
+	// Verify meta.bin WalCheckpointLSN = n+2 (n WalInsert records framed by one
+	// WalTxnBegin + one WalTxnCommit marker; LSNs run 1..n+2).
 	meta, err := readMetaHeader(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if meta.WalCheckpointLSN == 0 {
-		t.Fatalf("WalCheckpointLSN: got %d, want > 0", meta.WalCheckpointLSN)
+	if got, want := meta.WalCheckpointLSN, uint64(n+2); got != want {
+		t.Fatalf("WalCheckpointLSN: got %d, want %d", got, want)
 	}
 
 	// Verify WAL is truncated to 0.
@@ -145,10 +146,11 @@ func TestClose_WALTruncated(t *testing.T) {
 		t.Fatalf("WAL size after Close: got %d, want 0", info.Size())
 	}
 	meta, _ := readMetaHeader(dir)
-	if meta.WalCheckpointLSN == 0 {
-		t.Fatalf("WalCheckpointLSN: got 0, want > 0")
+	// Close runs a final checkpoint, recording the latest LSN: n WalInsert
+	// records framed by one WalTxnBegin + one WalTxnCommit marker => n+2.
+	if got, want := meta.WalCheckpointLSN, uint64(n+2); got != want {
+		t.Fatalf("WalCheckpointLSN: got %d, want %d", got, want)
 	}
-	_ = n
 }
 
 func TestOpen_ReplayThenCheckpoint(t *testing.T) {

--- a/internal/core/vectorindex/mmap_checkpoint_test.go
+++ b/internal/core/vectorindex/mmap_checkpoint_test.go
@@ -252,14 +252,21 @@ func TestAutoCheckpoint_NotTriggeredBelowInterval(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write 5 records — well below 1000.
+	// Write 5 records inside a txn — well below the 1000 threshold.
+	// txnCommit flushes the WAL to disk without triggering a checkpoint.
+	if err := s.txnBegin(); err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
+	if err := s.txnCommit(); err != nil {
+		t.Fatal(err)
+	}
 
-	// WAL should still have data (no auto-checkpoint).
+	// WAL should still have data (no auto-checkpoint — ops < interval).
 	walPath := filepath.Join(dir, "wal.bin")
 	info, _ := os.Stat(walPath)
 	if info.Size() == 0 {

--- a/internal/core/vectorindex/mmap_checkpoint_test.go
+++ b/internal/core/vectorindex/mmap_checkpoint_test.go
@@ -14,16 +14,16 @@ func TestCheckpoint_MetaAndWALTruncated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write N records via batch.
+	// Write N records via txn.
 	n := 5
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < n; i++ {
 		vec := []float32{float32(i), 0, 0, 1}
 		if err := s.PutNode(uint64(i), 0, vec); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -38,13 +38,13 @@ func TestCheckpoint_MetaAndWALTruncated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify meta.bin WalCheckpointLSN = n.
+	// Verify meta.bin WalCheckpointLSN = n+2 (n data records + TxnBegin + TxnCommit).
 	meta, err := readMetaHeader(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if meta.WalCheckpointLSN != uint64(n) {
-		t.Fatalf("WalCheckpointLSN: got %d, want %d", meta.WalCheckpointLSN, n)
+	if meta.WalCheckpointLSN == 0 {
+		t.Fatalf("WalCheckpointLSN: got %d, want > 0", meta.WalCheckpointLSN)
 	}
 
 	// Verify WAL is truncated to 0.
@@ -66,13 +66,13 @@ func TestCheckpoint_ContinueWriteAndReplay(t *testing.T) {
 	}
 
 	// Write 3 records, checkpoint.
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 3; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Checkpoint(); err != nil {
@@ -80,13 +80,13 @@ func TestCheckpoint_ContinueWriteAndReplay(t *testing.T) {
 	}
 
 	// Write 2 more records after checkpoint.
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 3; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,13 +124,13 @@ func TestClose_WALTruncated(t *testing.T) {
 	}
 
 	n := 5
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < n; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,16 +138,17 @@ func TestClose_WALTruncated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// After clean Close, WAL should be empty and meta should have checkpoint LSN.
+	// After clean Close, WAL should be empty.
 	walPath := filepath.Join(dir, "wal.bin")
 	info, _ := os.Stat(walPath)
 	if info.Size() != 0 {
 		t.Fatalf("WAL size after Close: got %d, want 0", info.Size())
 	}
 	meta, _ := readMetaHeader(dir)
-	if meta.WalCheckpointLSN != uint64(n) {
-		t.Fatalf("WalCheckpointLSN: got %d, want %d", meta.WalCheckpointLSN, n)
+	if meta.WalCheckpointLSN == 0 {
+		t.Fatalf("WalCheckpointLSN: got 0, want > 0")
 	}
+	_ = n
 }
 
 func TestOpen_ReplayThenCheckpoint(t *testing.T) {
@@ -159,13 +160,13 @@ func TestOpen_ReplayThenCheckpoint(t *testing.T) {
 
 	// Write records.
 	n := 5
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < n; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -217,7 +218,7 @@ func TestAutoCheckpoint_TriggeredAtInterval(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write 15 records (non-batch, so each PutNode triggers maybeCheckpoint).
+	// Write 15 records (non-txn, so each PutNode triggers maybeCheckpoint).
 	for i := 0; i < 15; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
@@ -270,28 +271,28 @@ func TestAutoCheckpoint_NotTriggeredBelowInterval(t *testing.T) {
 	}
 }
 
-func TestAutoCheckpoint_BatchMode(t *testing.T) {
+func TestAutoCheckpoint_TxnMode(t *testing.T) {
 	dir := t.TempDir()
 	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 5})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Batch mode: checkpoint should trigger at CommitBatch, not during writes.
-	s.BeginBatch()
+	// Txn mode: checkpoint should trigger at txnCommit, not during writes.
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 10; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
 	// After commit with 10 ops and interval=5, checkpoint should have fired.
 	meta, _ := readMetaHeader(dir)
 	if meta.WalCheckpointLSN == 0 {
-		t.Fatal("expected auto-checkpoint after CommitBatch")
+		t.Fatal("expected auto-checkpoint after txnCommit")
 	}
 
 	if err := s.Close(); err != nil {
@@ -307,7 +308,7 @@ func TestCrashRecovery_BasicReplay(t *testing.T) {
 	}
 
 	n := 20
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < n; i++ {
 		vec := []float32{float32(i), float32(i + 1), float32(i + 2), float32(i + 3)}
 		if err := s.PutNode(uint64(i), 0, vec); err != nil {
@@ -317,7 +318,7 @@ func TestCrashRecovery_BasicReplay(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -370,13 +371,13 @@ func TestCrashRecovery_AfterCheckpoint(t *testing.T) {
 	}
 
 	// Write N=10 records and checkpoint.
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 10; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Checkpoint(); err != nil {
@@ -384,13 +385,13 @@ func TestCrashRecovery_AfterCheckpoint(t *testing.T) {
 	}
 
 	// Write M=5 more records (post-checkpoint).
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 10; i < 15; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -493,13 +494,13 @@ func TestCrashPoint_AfterWALWrite(t *testing.T) {
 	}
 
 	// Write 5 nodes normally.
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.Checkpoint(); err != nil {
@@ -550,13 +551,13 @@ func TestCrashPoint_AfterMsync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -597,13 +598,13 @@ func TestCrashPoint_AfterMeta(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -642,13 +643,13 @@ func TestCrashPoint_BeforeTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -687,13 +688,13 @@ func TestCrashPoint_PartialWALRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 	s.Close()
@@ -766,13 +767,13 @@ func TestCrashPoint_GrowMidWrite(t *testing.T) {
 	}
 
 	n := 1030
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < n; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -803,13 +804,13 @@ func TestCrashPoint_SetNeighborsCrash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -841,13 +842,13 @@ func TestCrashPoint_DeleteNodeCrash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < 5; i++ {
 		if err := s.PutNode(uint64(i), 0, []float32{float32(i), 0, 0, 1}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/core/vectorindex/mmap_coverage_test.go
+++ b/internal/core/vectorindex/mmap_coverage_test.go
@@ -47,7 +47,11 @@ func TestWALReplayPayloadTooLarge(t *testing.T) {
 	}
 	defer w.Close()
 
-	if _, err := w.Append(WalInsert, []byte("x"), false); err != nil {
+	if _, err := w.Append(WalInsert, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	// Flush the buffer to disk so the record is on-disk before we corrupt it.
+	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/core/vectorindex/mmap_crash_test.go
+++ b/internal/core/vectorindex/mmap_crash_test.go
@@ -8,8 +8,7 @@ import (
 // TestKill9Recovery_E2E simulates a kill -9 scenario:
 // Insert vectors → "crash" (skip Close) → reopen → verify all data intact.
 // N and CheckpointInterval are kept proportional (N/interval ≈ 4) so recovery
-// still replays a WAL that spans several mid-stream checkpoints; the absolute
-// counts are modest to keep the per-op msync cost (heaviest on Windows) low.
+// still replays a WAL that spans several mid-stream checkpoints.
 func TestKill9Recovery_E2E(t *testing.T) {
 	dir := t.TempDir()
 	const N = 200

--- a/internal/core/vectorindex/mmap_crash_test.go
+++ b/internal/core/vectorindex/mmap_crash_test.go
@@ -22,7 +22,7 @@ func TestKill9Recovery_E2E(t *testing.T) {
 	}
 
 	// Build vectors and insert with doc mappings.
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < N; i++ {
 		vec := make([]float32, dim)
 		for d := 0; d < dim; d++ {
@@ -35,7 +35,7 @@ func TestKill9Recovery_E2E(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := s.CommitBatch(true); err != nil {
+	if err := s.txnCommit(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/core/vectorindex/mmap_fault3_test.go
+++ b/internal/core/vectorindex/mmap_fault3_test.go
@@ -1,14 +1,19 @@
 package vectorindex
 
 import (
+	"bufio"
 	"testing"
 )
 
 // failWALNextWrite makes the store's WAL fail its next buffered flush, so the
-// next non-batch Append (and the write method calling it) returns an error.
+// next Append (and the write method calling it) returns an error. The existing
+// buffer is flushed first, then replaced with a 1-byte buffer backed by a
+// fault-injecting file so that the very next buf.Write triggers a flush/error.
 func failWALNextWrite(s *MmapStore) {
-	s.wal.file = &faultFile{osFile: s.wal.file, failWrite: true}
-	s.wal.buf.Reset(s.wal.file)
+	_ = s.wal.buf.Flush() // drain any pending bytes
+	ff := &faultFile{osFile: s.wal.file, failWrite: true}
+	s.wal.file = ff
+	s.wal.buf = bufio.NewWriterSize(ff, 1) // 1-byte buffer: any Write triggers immediate flush
 }
 
 // --- grow dispatch / re-check / newCap==0 ---
@@ -108,31 +113,6 @@ func TestDeleteNodeWALError(t *testing.T) {
 
 // --- WAL method error branches ---
 
-func TestWALAppendFlushError(t *testing.T) {
-	w, err := OpenWAL(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer w.Close()
-	w.file = &faultFile{osFile: w.file, failWrite: true}
-	w.buf.Reset(w.file)
-	if _, err := w.Append(WalInsert, []byte("x"), false); err == nil {
-		t.Fatal("expected flush error from Append")
-	}
-}
-
-func TestWALAppendSyncError(t *testing.T) {
-	w, err := OpenWAL(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer w.Close()
-	w.file = &faultFile{osFile: w.file, failSync: true}
-	if _, err := w.Append(WalInsert, []byte("x"), false); err == nil {
-		t.Fatal("expected sync error from Append")
-	}
-}
-
 func TestWALSyncFlushError(t *testing.T) {
 	w, err := OpenWAL(t.TempDir())
 	if err != nil {
@@ -195,7 +175,7 @@ func TestWALReplayTruncateError(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer w.Close()
-	if _, err := w.Append(WalInsert, []byte("x"), false); err != nil {
+	if _, err := w.Append(WalInsert, []byte("x")); err != nil {
 		t.Fatal(err)
 	}
 	w.file = &faultFile{osFile: w.file, failTruncate: true}

--- a/internal/core/vectorindex/mmap_fault4_test.go
+++ b/internal/core/vectorindex/mmap_fault4_test.go
@@ -99,40 +99,37 @@ func TestStoreSyncCheckpointError(t *testing.T) {
 	}
 }
 
-// --- CommitBatch branches ---
+// --- txnCommit error branches ---
 
-func TestCommitBatchNestedNoCommit(t *testing.T) {
+func TestTxnCommitNestedRejected(t *testing.T) {
 	s := openTestStore(t)
 	defer s.Close()
-	s.BeginBatch()
-	s.BeginBatch()
-	// depth still > 0: returns without flushing/syncing.
-	if err := s.CommitBatch(true); err != nil {
-		t.Fatal(err)
+	requireNoError(t, s.txnBegin())
+	// A second txnBegin while one is open must fail.
+	if err := s.txnBegin(); err == nil {
+		t.Fatal("expected txnBegin to reject nesting")
 	}
-	if err := s.CommitBatch(true); err != nil {
-		t.Fatal(err)
-	}
+	requireNoError(t, s.txnCommit())
 }
 
-func TestCommitBatchSyncError(t *testing.T) {
+func TestTxnCommitSyncError(t *testing.T) {
 	s := openTestStore(t)
 	defer s.Close()
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	s.wal.file = &faultFile{osFile: s.wal.file, failSync: true}
-	if err := s.CommitBatch(true); err == nil {
-		t.Fatal("expected WAL sync error from CommitBatch")
+	if err := s.txnCommit(); err == nil {
+		t.Fatal("expected WAL sync error from txnCommit")
 	}
 }
 
-func TestCommitBatchMsyncError(t *testing.T) {
+func TestTxnCommitMsyncError(t *testing.T) {
 	s := openTestStore(t)
 	defer s.Close()
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	orig := mmapSync
 	defer func() { mmapSync = orig }()
 	mmapSync = func([]byte) error { return errInjected }
-	if err := s.CommitBatch(true); err == nil {
-		t.Fatal("expected msync error from CommitBatch")
+	if err := s.txnCommit(); err == nil {
+		t.Fatal("expected msync error from txnCommit")
 	}
 }

--- a/internal/core/vectorindex/mmap_fault4_test.go
+++ b/internal/core/vectorindex/mmap_fault4_test.go
@@ -86,16 +86,21 @@ func TestCheckpointCompactError(t *testing.T) {
 	}
 }
 
-// --- store Sync: checkpoint error branch ---
+// --- txnCommit fault: msync error surfaces as faulted store ---
 
 func TestStoreSyncCheckpointError(t *testing.T) {
 	s := openTestStore(t)
 	defer s.Close()
+	requireNoError(t, s.txnBegin())
+	requireNoError(t, s.PutNode(0, 0, []float32{1, 2, 3, 4}))
 	orig := mmapSync
 	defer func() { mmapSync = orig }()
 	mmapSync = func([]byte) error { return errInjected }
-	if err := s.Sync(); err == nil {
-		t.Fatal("expected checkpoint error from Sync")
+	if err := s.txnCommit(); err == nil {
+		t.Fatal("expected msync error from txnCommit")
+	}
+	if s.faulted == nil {
+		t.Fatal("store must be faulted after txnCommit msync error")
 	}
 }
 

--- a/internal/core/vectorindex/mmap_fault4_test.go
+++ b/internal/core/vectorindex/mmap_fault4_test.go
@@ -138,3 +138,53 @@ func TestTxnCommitMsyncError(t *testing.T) {
 		t.Fatal("expected msync error from txnCommit")
 	}
 }
+
+// --- AC6: Batch.Commit I/O fault → store faulted → reopen recovers pre-batch state ---
+
+func TestBatchCommitIOFaultReopensClean(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build an index with one doc so NodeCount == 1 before the faulted batch.
+	idx := NewHNSWIndex(s)
+	if err := idx.Insert("pre-existing", []float32{1, 0, 0, 0}); err != nil {
+		t.Fatal(err)
+	}
+	preCount := s.meta.NodeCount // should be 1
+
+	// Inject a WAL write fault so txnBegin's WalTxnBegin append fails,
+	// causing the store to fault before any new data is committed.
+	failWALNextWrite(s)
+
+	// A batch with a new doc: Commit must return an error.
+	b := idx.NewBatch()
+	b.Put("new-doc", []float32{0, 1, 0, 0})
+	commitErr := b.Commit()
+	if commitErr == nil {
+		t.Fatal("expected Batch.Commit to return an error after WAL write fault")
+	}
+	// Store must now be faulted.
+	if s.faulted == nil {
+		t.Fatal("store must be faulted after failed Batch.Commit")
+	}
+	// A subsequent write must be rejected.
+	if err := idx.Insert("another", []float32{0, 0, 1, 0}); err == nil {
+		t.Fatal("expected faulted store to reject further writes")
+	}
+
+	// Simulate a crash (force WAL flush / close files) so the reopen sees disk state.
+	simulateCrash(s)
+
+	// Reopen and verify the pre-batch state is intact.
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+	if s2.meta.NodeCount != preCount {
+		t.Fatalf("NodeCount after reopen = %d, want %d (pre-batch state)", s2.meta.NodeCount, preCount)
+	}
+}

--- a/internal/core/vectorindex/mmap_fault_test.go
+++ b/internal/core/vectorindex/mmap_fault_test.go
@@ -225,12 +225,17 @@ func TestOpenWALScanError(t *testing.T) {
 	}
 }
 
-// --- store Sync WAL flush/sync errors ---
+// --- txnCommit fault: WAL sync error surfaces as faulted store ---
 
 func TestStoreSyncWALErrors(t *testing.T) {
 	s := openTestStore(t)
+	requireNoError(t, s.txnBegin())
+	requireNoError(t, s.PutNode(0, 0, []float32{1, 2, 3, 4}))
 	s.wal.file = &faultFile{osFile: s.wal.file, failSync: true}
-	if err := s.Sync(); err == nil {
-		t.Fatal("expected WAL sync error from store Sync")
+	if err := s.txnCommit(); err == nil {
+		t.Fatal("expected WAL sync error from txnCommit")
+	}
+	if s.faulted == nil {
+		t.Fatal("store must be faulted after txnCommit WAL sync error")
 	}
 }

--- a/internal/core/vectorindex/mmap_phase2_test.go
+++ b/internal/core/vectorindex/mmap_phase2_test.go
@@ -305,7 +305,7 @@ func TestMmapStoreRebuildNodeCount(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CommitBatch exercises WAL flush + syncAll paths
+// txnCommit exercises WAL flush + syncAll paths
 // ---------------------------------------------------------------------------
 
 func TestMmapStoreTxnCommitSyncs(t *testing.T) {

--- a/internal/core/vectorindex/mmap_phase2_test.go
+++ b/internal/core/vectorindex/mmap_phase2_test.go
@@ -99,11 +99,11 @@ func TestMmapStoreGrowUpperGraph(t *testing.T) {
 	// Each level>0 node allocates one upper slot. Upper starts at cap/4 = 256 (for default 1024).
 	// We need ~256+ upper slots to trigger a grow. Batched so the grow still fires
 	// without paying a per-insert msync (the heaviest cost on Windows).
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := uint64(0); i < initialUpperCap+10; i++ {
 		requireNoError(t, s.PutNode(i, 1, vec))
 	}
-	requireNoError(t, s.CommitBatch(true))
+	requireNoError(t, s.txnCommit())
 
 	assert.Greater(t, s.upperCapacity, initialUpperCap, "upper capacity should have grown")
 }
@@ -308,7 +308,7 @@ func TestMmapStoreRebuildNodeCount(t *testing.T) {
 // CommitBatch exercises WAL flush + syncAll paths
 // ---------------------------------------------------------------------------
 
-func TestMmapStoreCommitBatchSyncs(t *testing.T) {
+func TestMmapStoreTxnCommitSyncs(t *testing.T) {
 	dir := t.TempDir()
 	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
@@ -316,12 +316,12 @@ func TestMmapStoreCommitBatchSyncs(t *testing.T) {
 	requireNoError(t, err)
 	defer s.Close()
 
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	vec := []float32{1.0, 2.0, 3.0, 4.0}
 	for i := uint64(0); i < 5; i++ {
 		requireNoError(t, s.PutNode(i, 0, vec))
 	}
-	requireNoError(t, s.CommitBatch(true))
+	requireNoError(t, s.txnCommit())
 
 	// After commit, data should be readable.
 	for i := uint64(0); i < 5; i++ {

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -500,6 +500,18 @@ func (s *MmapStore) applyWALRecord(typ WalRecordType, payload []byte) error {
 		if s.meta.NodeCount > 0 {
 			s.meta.NodeCount--
 		}
+
+	case WalSetMapping:
+		nodeId, docId := DecodeSetMapping(payload)
+		s.docToNode[docId] = nodeId
+		s.nodeToDoc[nodeId] = docId
+
+	case WalDeleteMapping:
+		docId := DecodeDeleteMapping(payload)
+		if nodeId, ok := s.docToNode[docId]; ok {
+			delete(s.nodeToDoc, nodeId)
+		}
+		delete(s.docToNode, docId)
 	}
 	return nil
 }

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -412,9 +412,6 @@ func (s *MmapStore) loadIdmap() error {
 		off = entryEnd
 	}
 
-	if _, err := f.Seek(0, 2); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -523,6 +523,11 @@ func (s *MmapStore) replayWAL() error {
 	// unterminated trailing transaction (BEGIN with no COMMIT) is discarded.
 	// Un-framed records (no open transaction) apply immediately — this keeps
 	// pre-redesign WAL files and single-record streams working.
+	//
+	// Nested BEGIN contract: a WalTxnBegin while a transaction is already open
+	// discards the prior (un-committed) buffer and restarts — consistent with
+	// "uncommitted ⇒ discarded". The write side never emits nested BEGINs
+	// (Phase 2's txnBegin rejects nesting); this is purely defensive on replay.
 	type pending struct {
 		typ     WalRecordType
 		payload []byte
@@ -551,7 +556,9 @@ func (s *MmapStore) replayWAL() error {
 			return nil
 		default:
 			if inTxn {
-				// Copy payload: Replay reuses the backing array across records.
+				// Defensive copy: Replay currently allocates a fresh payload per
+				// record, but we don't depend on that — own the slice so a future
+				// Replay change cannot silently alias buffered payloads.
 				cp := make([]byte, len(payload))
 				copy(cp, payload)
 				buf = append(buf, pending{typ, cp})

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -518,13 +518,53 @@ func (s *MmapStore) replayWAL() error {
 	s.batchMode = true
 	defer func() { s.batchMode = prevBatchMode }()
 
+	// Transaction framing: records between WalTxnBegin and its matching
+	// WalTxnCommit are buffered and applied atomically on COMMIT. An
+	// unterminated trailing transaction (BEGIN with no COMMIT) is discarded.
+	// Un-framed records (no open transaction) apply immediately — this keeps
+	// pre-redesign WAL files and single-record streams working.
+	type pending struct {
+		typ     WalRecordType
+		payload []byte
+	}
+	var inTxn bool
+	var buf []pending
+
 	err := s.wal.Replay(s.meta.WalCheckpointLSN, func(lsn uint64, typ WalRecordType, payload []byte) error {
-		replayed++
-		return s.applyWALRecord(typ, payload)
+		switch typ {
+		case WalTxnBegin:
+			inTxn = true
+			buf = buf[:0]
+			return nil
+		case WalTxnCommit:
+			if !inTxn {
+				return nil // stray commit — ignore
+			}
+			for _, p := range buf {
+				if err := s.applyWALRecord(p.typ, p.payload); err != nil {
+					return err
+				}
+				replayed++
+			}
+			inTxn = false
+			buf = buf[:0]
+			return nil
+		default:
+			if inTxn {
+				// Copy payload: Replay reuses the backing array across records.
+				cp := make([]byte, len(payload))
+				copy(cp, payload)
+				buf = append(buf, pending{typ, cp})
+				return nil
+			}
+			replayed++
+			return s.applyWALRecord(typ, payload)
+		}
 	})
 	if err != nil {
 		return err
 	}
+	// Unterminated trailing transaction (inTxn still true): buf is dropped.
 	if replayed > 0 {
 		s.rebuildNodeCount()
 		if err := s.syncAll(); err != nil {

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -209,7 +209,11 @@ func (s *MmapStore) Close() error {
 	}
 
 	// 1. Checkpoint: msync + writeMeta + WAL truncate + idmap compact.
-	setErr(s.checkpointLocked())
+	// A faulted store has uncommitted in-place writes; checkpointing here would
+	// persist them and truncate the WAL, defeating crash-recovery discard. Skip it.
+	if s.faulted == nil {
+		setErr(s.checkpointLocked())
+	}
 
 	// 2. Close WAL.
 	if s.wal != nil {

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -423,6 +423,92 @@ func (s *MmapStore) loadIdmap() error {
 	return nil
 }
 
+// applyWALRecord applies a single decoded WAL record to mmap + meta state.
+// Caller must hold muWrite (replay holds it implicitly: single-threaded Open).
+// It contains exactly the logic previously inlined in the replayWAL callback.
+func (s *MmapStore) applyWALRecord(typ WalRecordType, payload []byte) error {
+	switch typ {
+	case WalInsert:
+		nodeId, level, vec, norm, _ := DecodeInsert(payload)
+		if err := s.ensureVecCapacity(nodeId); err != nil {
+			return err
+		}
+		if err := s.ensureNodeCapacity(nodeId); err != nil {
+			return err
+		}
+		if err := s.ensureL0Capacity(nodeId); err != nil {
+			return err
+		}
+		vecOff := int64(pageSize) + int64(nodeId)*int64(s.vecSlotSize)
+		for i, v := range vec {
+			binary.LittleEndian.PutUint32(s.vectors[vecOff+int64(i*4):], math.Float32bits(v))
+		}
+		nodeOff := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
+		s.nodes[nodeOff] = uint8(level)
+		s.nodes[nodeOff+1] = nodeFlagOccupied
+		s.nodes[nodeOff+2] = 0
+		s.nodes[nodeOff+3] = 0
+		binary.LittleEndian.PutUint32(s.nodes[nodeOff+4:], math.Float32bits(norm))
+		if level > 0 {
+			if err := s.ensureUpperCapacity(s.readGraphUpperNextSlot()); err != nil {
+				return err
+			}
+			slot := s.allocUpperSlot()
+			binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], slot)
+		} else {
+			binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], 0)
+		}
+		if nodeId >= s.meta.TotalSlots {
+			s.meta.TotalSlots = nodeId + 1
+		}
+		if nodeId+1 > s.meta.NextNodeId {
+			s.meta.NextNodeId = nodeId + 1
+		}
+		s.meta.NodeCount++
+		if uint32(level) > s.meta.MaxLevel {
+			s.meta.MaxLevel = uint32(level)
+		}
+
+	case WalSetNeighbors:
+		nodeId, layer, neighbors := DecodeSetNeighbors(payload)
+		if layer == 0 {
+			if err := s.setNeighborsL0(nodeId, neighbors); err != nil {
+				return err
+			}
+		} else {
+			if err := s.setNeighborsUpper(nodeId, layer, neighbors); err != nil {
+				return err
+			}
+		}
+
+	case WalSetNorm:
+		nodeId, norm := DecodeSetNorm(payload)
+		if nodeId < s.nodeCapacity {
+			offset := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
+			binary.LittleEndian.PutUint32(s.nodes[offset+4:], math.Float32bits(norm))
+		}
+
+	case WalSetEntry:
+		entryId, maxLevel := DecodeSetEntry(payload)
+		s.meta.EntryPoint = entryId
+		s.meta.EntryLevel = uint32(maxLevel)
+		if uint32(maxLevel) > s.meta.MaxLevel {
+			s.meta.MaxLevel = uint32(maxLevel)
+		}
+
+	case WalDelete:
+		nodeId, _ := DecodeDelete(payload)
+		if nodeId < s.nodeCapacity {
+			offset := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
+			s.nodes[offset+1] |= nodeFlagDeleted
+		}
+		if s.meta.NodeCount > 0 {
+			s.meta.NodeCount--
+		}
+	}
+	return nil
+}
+
 // replayWAL replays WAL records after the checkpoint LSN to restore both
 // mmap data and meta state. All 5 record types are handled so that crash
 // recovery fully reconstructs the index.
@@ -434,96 +520,7 @@ func (s *MmapStore) replayWAL() error {
 
 	err := s.wal.Replay(s.meta.WalCheckpointLSN, func(lsn uint64, typ WalRecordType, payload []byte) error {
 		replayed++
-		switch typ {
-		case WalInsert:
-			nodeId, level, vec, norm, _ := DecodeInsert(payload)
-
-			// Ensure capacity for all regions before writing.
-			if err := s.ensureVecCapacity(nodeId); err != nil {
-				return err
-			}
-			if err := s.ensureNodeCapacity(nodeId); err != nil {
-				return err
-			}
-			if err := s.ensureL0Capacity(nodeId); err != nil {
-				return err
-			}
-
-			// Write vector to vectors.dat.
-			vecOff := int64(pageSize) + int64(nodeId)*int64(s.vecSlotSize)
-			for i, v := range vec {
-				binary.LittleEndian.PutUint32(s.vectors[vecOff+int64(i*4):], math.Float32bits(v))
-			}
-
-			// Write node metadata to nodes.dat (level, flags, norm).
-			nodeOff := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
-			s.nodes[nodeOff] = uint8(level)
-			s.nodes[nodeOff+1] = nodeFlagOccupied // flags: occupied, not deleted
-			s.nodes[nodeOff+2] = 0
-			s.nodes[nodeOff+3] = 0
-			binary.LittleEndian.PutUint32(s.nodes[nodeOff+4:], math.Float32bits(norm))
-
-			// If level > 0, allocate an upper slot.
-			if level > 0 {
-				if err := s.ensureUpperCapacity(s.readGraphUpperNextSlot()); err != nil {
-					return err
-				}
-				slot := s.allocUpperSlot()
-				binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], slot)
-			} else {
-				binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], 0)
-			}
-
-			// Update meta.
-			if nodeId >= s.meta.TotalSlots {
-				s.meta.TotalSlots = nodeId + 1
-			}
-			if nodeId+1 > s.meta.NextNodeId {
-				s.meta.NextNodeId = nodeId + 1
-			}
-			s.meta.NodeCount++
-			if uint32(level) > s.meta.MaxLevel {
-				s.meta.MaxLevel = uint32(level)
-			}
-
-		case WalSetNeighbors:
-			nodeId, layer, neighbors := DecodeSetNeighbors(payload)
-			if layer == 0 {
-				if err := s.setNeighborsL0(nodeId, neighbors); err != nil {
-					return err
-				}
-			} else {
-				if err := s.setNeighborsUpper(nodeId, layer, neighbors); err != nil {
-					return err
-				}
-			}
-
-		case WalSetNorm:
-			nodeId, norm := DecodeSetNorm(payload)
-			if nodeId < s.nodeCapacity {
-				offset := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
-				binary.LittleEndian.PutUint32(s.nodes[offset+4:], math.Float32bits(norm))
-			}
-
-		case WalSetEntry:
-			entryId, maxLevel := DecodeSetEntry(payload)
-			s.meta.EntryPoint = entryId
-			s.meta.EntryLevel = uint32(maxLevel)
-			if uint32(maxLevel) > s.meta.MaxLevel {
-				s.meta.MaxLevel = uint32(maxLevel)
-			}
-
-		case WalDelete:
-			nodeId, _ := DecodeDelete(payload)
-			if nodeId < s.nodeCapacity {
-				offset := int64(pageSize) + int64(nodeId)*int64(nodeSlotSize)
-				s.nodes[offset+1] |= nodeFlagDeleted
-			}
-			if s.meta.NodeCount > 0 {
-				s.meta.NodeCount--
-			}
-		}
-		return nil
+		return s.applyWALRecord(typ, payload)
 	})
 	if err != nil {
 		return err

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -25,7 +25,9 @@ type MmapStoreOptions struct {
 // Concurrency model:
 //
 //   - All write methods (PutNode, SetNeighbors, SetNorm, SetEntryPoint,
-//     DeleteNode, SetNodeMapping, NextNodeId) are serialised by muWrite.Lock().
+//     DeleteNode, SetNodeMapping, DeleteNodeMapping, NextNodeId, and the
+//     transaction primitive txnBegin, txnCommit, txnAbort) are serialised by
+//     muWrite.Lock().
 //   - Read methods use fine-grained RLocks (muVec, muGraph, muNodes, muDoc).
 //   - GetEntryPoint uses muWrite.RLock to safely read meta fields.
 //   - Grow functions (ensureCapacity / growFile) are called under muWrite

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -59,6 +59,8 @@ type MmapStore struct {
 	wal                *WAL
 	batchMode          bool
 	batchDepth         int
+	inTxn              bool  // a store transaction (txnBegin..txnCommit) is open
+	faulted            error // first fatal write error; once set, writes are rejected
 	opsSinceCheckpoint uint64
 	checkpointInterval uint64
 

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -12,14 +12,6 @@ import (
 
 const defaultInitialCapacity = 1024
 
-// SyncMode controls fsync behavior in CommitBatch.
-type SyncMode int
-
-const (
-	SyncImmediate SyncMode = 0 // WAL flush + file sync + msync (default, durable)
-	SyncDeferred  SyncMode = 1 // WAL flush only (caller must call Sync() later)
-)
-
 // MmapStoreOptions configures OpenMmapStore.
 type MmapStoreOptions struct {
 	Dim                int    // vector dimension (required)
@@ -33,8 +25,7 @@ type MmapStoreOptions struct {
 // Concurrency model:
 //
 //   - All write methods (PutNode, SetNeighbors, SetNorm, SetEntryPoint,
-//     DeleteNode, SetNodeMapping, NextNodeId, BeginBatch, CommitBatch,
-//     DiscardBatch) are serialised by muWrite.Lock().
+//     DeleteNode, SetNodeMapping, NextNodeId) are serialised by muWrite.Lock().
 //   - Read methods use fine-grained RLocks (muVec, muGraph, muNodes, muDoc).
 //   - GetEntryPoint uses muWrite.RLock to safely read meta fields.
 //   - Grow functions (ensureCapacity / growFile) are called under muWrite
@@ -55,10 +46,8 @@ type MmapStore struct {
 	l0File    osFile
 	upperFile osFile
 
-	// WAL and batch support
+	// WAL and transaction support
 	wal                *WAL
-	batchMode          bool
-	batchDepth         int
 	inTxn              bool  // a store transaction (txnBegin..txnCommit) is open
 	faulted            error // first fatal write error; once set, writes are rejected
 	opsSinceCheckpoint uint64
@@ -68,8 +57,6 @@ type MmapStore struct {
 	docToNode map[string]uint64
 	nodeToDoc map[uint64]string
 	idmapFile osFile // idmap.dat append handle
-
-	syncMode SyncMode
 
 	muWrite sync.RWMutex // serialises all write methods; readers use RLock for meta fields
 	muVec   sync.RWMutex
@@ -520,9 +507,9 @@ func (s *MmapStore) applyWALRecord(typ WalRecordType, payload []byte) error {
 // recovery fully reconstructs the index.
 func (s *MmapStore) replayWAL() error {
 	var replayed int
-	prevBatchMode := s.batchMode
-	s.batchMode = true
-	defer func() { s.batchMode = prevBatchMode }()
+	prevInTxn := s.inTxn
+	s.inTxn = true
+	defer func() { s.inTxn = prevInTxn }()
 
 	// Transaction framing: records between WalTxnBegin and its matching
 	// WalTxnCommit are buffered and applied atomically on COMMIT. An

--- a/internal/core/vectorindex/mmap_store.go
+++ b/internal/core/vectorindex/mmap_store.go
@@ -522,7 +522,7 @@ func (s *MmapStore) replayWAL() error {
 	// Nested BEGIN contract: a WalTxnBegin while a transaction is already open
 	// discards the prior (un-committed) buffer and restarts — consistent with
 	// "uncommitted ⇒ discarded". The write side never emits nested BEGINs
-	// (Phase 2's txnBegin rejects nesting); this is purely defensive on replay.
+	// (txnBegin rejects nesting); this is purely defensive on replay.
 	type pending struct {
 		typ     WalRecordType
 		payload []byte

--- a/internal/core/vectorindex/mmap_store_bench_test.go
+++ b/internal/core/vectorindex/mmap_store_bench_test.go
@@ -141,7 +141,9 @@ func BenchmarkMmapStore50KInsert(b *testing.B) {
 
 		start := time.Now()
 
-		s.BeginBatch()
+		if err := s.txnBegin(); err != nil {
+			b.Fatal(err)
+		}
 		for i := 0; i < numVectors; i++ {
 			id, err := s.NextNodeId()
 			if err != nil {
@@ -170,7 +172,7 @@ func BenchmarkMmapStore50KInsert(b *testing.B) {
 				}
 			}
 		}
-		if err := s.CommitBatch(true); err != nil {
+		if err := s.txnCommit(); err != nil {
 			b.Fatal(err)
 		}
 

--- a/internal/core/vectorindex/mmap_store_grow_test.go
+++ b/internal/core/vectorindex/mmap_store_grow_test.go
@@ -74,12 +74,12 @@ func TestMmapStoreGrowConcurrent(t *testing.T) {
 
 	// Pre-populate some data (batched: this is just setup, the concurrent grow
 	// below is what's under test, so avoid a per-insert msync here).
-	s.BeginBatch()
+	requireNoError(t, s.txnBegin())
 	for i := uint64(0); i < 100; i++ {
 		vec := []float32{float32(i), 0, 0, 0}
 		requireNoError(t, s.PutNode(i, 0, vec))
 	}
-	requireNoError(t, s.CommitBatch(true))
+	requireNoError(t, s.txnCommit())
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 20)

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -232,19 +232,18 @@ func TestMmapHNSW_Upsert(t *testing.T) {
 // Task 2: Persistence verification tests
 // ---------------------------------------------------------------------------
 
-// mmapHNSWSearchResults runs search and returns results for comparison.
-// insertAllBatch builds an index from vecs via a single InsertBatch using doc
+// insertAllBatch builds an index from vecs via a single batch using doc
 // IDs "doc-%d". For MmapStore this collapses ~N per-insert WAL syncs into one,
 // which is far faster than a serial Insert loop while producing an identical
 // graph (same insertion order → same random levels → same topology).
 func insertAllBatch(t *testing.T, idx *HNSWIndex, vecs [][]float32) {
 	t.Helper()
-	items := make([]InsertItem, len(vecs))
+	b := idx.NewBatch()
 	for i, v := range vecs {
-		items[i] = InsertItem{DocId: fmt.Sprintf("doc-%d", i), Vector: v}
+		b.Put(fmt.Sprintf("doc-%d", i), v)
 	}
-	if err := idx.InsertBatch(items); err != nil {
-		t.Fatalf("InsertBatch (%d items): %v", len(vecs), err)
+	if err := b.Commit(); err != nil {
+		t.Fatalf("Batch.Commit (%d items): %v", len(vecs), err)
 	}
 }
 

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -506,8 +506,7 @@ func TestMmapHNSW_WALReplayE2E(t *testing.T) {
 		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
-		// Build using a single index batch: all inserts committed as one durable txn,
-		// deferring per-op msync without weakening the test.
+		// Build using a single index batch: all inserts committed as one durable txn.
 		b := idx.NewBatch()
 		for i, v := range vecs {
 			b.Put(fmt.Sprintf("doc-%d", i), v)
@@ -1079,8 +1078,7 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 
 	// Use an index-level batch to group post-export inserts + deletes: each HNSW op
-	// is a PutNode plus several SetNeighbors, and a per-op msync makes this ~13s on
-	// Windows. One batch Commit defers all syncing without changing what's tested.
+	// is a PutNode plus several SetNeighbors. One batch Commit defers all syncing.
 	b := mmapIdx.NewBatch()
 	for i := n; i < n+nExtra; i++ {
 		b.Put(fmt.Sprintf("doc-%d", i), baseVecs[i])

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -998,7 +998,55 @@ func TestMmapHNSW_ExportRecall(t *testing.T) {
 	assert.Greater(t, recall, 0.95, "exported MmapStore recall@10 should be > 0.95")
 }
 
-// TestMmapHNSW_ExportThenInsertDelete verifies incremental ops work after export.
+func TestBatchCommitDurableAfterCrash(t *testing.T) {
+	dir := t.TempDir()
+	const N, dim = 60, 16
+	store, err := OpenMmapStore(dir, MmapStoreOptions{Metric: Cosine, Dim: dim, M: 16, CheckpointInterval: 1_000_000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(7))))
+
+	rng := rand.New(rand.NewSource(1))
+	vecs := make([][]float32, N)
+	b := idx.NewBatch()
+	for i := 0; i < N; i++ {
+		v := make([]float32, dim)
+		for d := range v {
+			v[d] = rng.Float32()
+		}
+		vecs[i] = v
+		b.Put(fmt.Sprintf("doc-%d", i), v)
+	}
+	if err := b.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	simulateCrash(store) // no Close — committed WAL transaction must survive
+
+	store2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: Cosine, Dim: dim, M: 16})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store2.Close()
+	idx2 := NewHNSWIndex(store2, WithRand(rand.New(rand.NewSource(7))))
+
+	// Every committed doc is its own nearest neighbor after recovery.
+	for i := 0; i < N; i++ {
+		res, err := idx2.Search(vecs[i], 1)
+		if err != nil {
+			t.Fatalf("search %d: %v", i, err)
+		}
+		if len(res) == 0 {
+			t.Fatalf("doc-%d not found after crash recovery", i)
+		}
+		if res[0].Distance > 1e-4 {
+			t.Fatalf("doc-%d nearest distance %f, want ~0", i, res[0].Distance)
+		}
+	}
+	if store2.meta.NodeCount != N {
+		t.Fatalf("NodeCount = %d, want %d", store2.meta.NodeCount, N)
+	}
+}
 func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 	const (
 		n       = 500

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -506,17 +506,14 @@ func TestMmapHNSW_WALReplayE2E(t *testing.T) {
 		idx := NewHNSWIndex(store,
 			WithRand(rand.New(rand.NewSource(hnswSeed))))
 
-		// Build under a batch: defers the per-op msync (the dominant cost on
-		// Windows) without weakening the test — CommitBatch(false) flushes the
-		// WAL but does NOT msync the mmaps, so recovery still has to replay.
-		store.BeginBatch()
+		// Build using a single index batch: all inserts committed as one durable txn,
+		// deferring per-op msync without weakening the test.
+		b := idx.NewBatch()
 		for i, v := range vecs {
-			if err := idx.Insert(fmt.Sprintf("doc-%d", i), v); err != nil {
-				t.Fatalf("Insert doc-%d: %v", i, err)
-			}
+			b.Put(fmt.Sprintf("doc-%d", i), v)
 		}
-		if err := store.CommitBatch(false); err != nil {
-			t.Fatalf("CommitBatch: %v", err)
+		if err := b.Commit(); err != nil {
+			t.Fatalf("batch Commit: %v", err)
 		}
 
 		preResults = mmapHNSWSearchResults(t, idx, queries, k)
@@ -1081,23 +1078,19 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 		WithEfConstruction(200),
 		WithRand(rand.New(rand.NewSource(hnswSeed))))
 
-	// Batch the post-export inserts + deletes: each HNSW op is a PutNode plus
-	// several SetNeighbors, and a per-op msync makes this ~13s on Windows.
-	// Batching defers the sync (one CommitBatch) without changing what's tested.
-	mmapStore.BeginBatch()
+	// Use an index-level batch to group post-export inserts + deletes: each HNSW op
+	// is a PutNode plus several SetNeighbors, and a per-op msync makes this ~13s on
+	// Windows. One batch Commit defers all syncing without changing what's tested.
+	b := mmapIdx.NewBatch()
 	for i := n; i < n+nExtra; i++ {
-		if err := mmapIdx.Insert(fmt.Sprintf("doc-%d", i), baseVecs[i]); err != nil {
-			t.Fatalf("Post-export insert doc-%d: %v", i, err)
-		}
+		b.Put(fmt.Sprintf("doc-%d", i), baseVecs[i])
 	}
 
 	for i := 0; i < nDelete; i++ {
-		if err := mmapIdx.Delete(fmt.Sprintf("doc-%d", i)); err != nil {
-			t.Fatalf("Post-export delete doc-%d: %v", i, err)
-		}
+		b.Delete(fmt.Sprintf("doc-%d", i))
 	}
-	if err := mmapStore.CommitBatch(true); err != nil {
-		t.Fatalf("CommitBatch: %v", err)
+	if err := b.Commit(); err != nil {
+		t.Fatalf("batch Commit: %v", err)
 	}
 
 	for i := 0; i < nDelete; i++ {

--- a/internal/core/vectorindex/mmap_store_hnsw_test.go
+++ b/internal/core/vectorindex/mmap_store_hnsw_test.go
@@ -1107,3 +1107,37 @@ func TestMmapHNSW_ExportThenInsertDelete(t *testing.T) {
 	assert.Equal(t, expectedCount, mmapStore.meta.NodeCount,
 		"node count should reflect inserts and deletes")
 }
+
+func TestIndexBatchAbortNoPhantomMapping(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenMmapStore(dir, MmapStoreOptions{Metric: Cosine, Dim: 8, M: 16, CheckpointInterval: 1_000_000})
+	requireNoError(t, err)
+	idx := NewHNSWIndex(store, WithRand(rand.New(rand.NewSource(11))))
+
+	// Commit one doc.
+	requireNoError(t, idx.Insert("doc-keep", []float32{1, 0, 0, 0, 0, 0, 0, 0}))
+
+	// A batch that will crash before commit (simulate via a fresh batch whose
+	// records we leave uncommitted): drive the store directly to model a crash.
+	requireNoError(t, store.txnBegin())
+	id, _ := store.NextNodeId()
+	requireNoError(t, store.PutNode(id, 0, []float32{0, 1, 0, 0, 0, 0, 0, 0}))
+	requireNoError(t, store.SetNodeMapping("doc-crash", id))
+	// crash WITHOUT txnCommit
+	simulateCrash(store)
+
+	store2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: Cosine, Dim: 8, M: 16})
+	requireNoError(t, err)
+	defer store2.Close()
+	idx2 := NewHNSWIndex(store2, WithRand(rand.New(rand.NewSource(11))))
+
+	if _, ok, _ := store2.GetNodeId("doc-crash"); ok {
+		t.Fatal("uncommitted mapping doc-crash must not survive (D1 closed)")
+	}
+	if _, ok, _ := store2.GetNodeId("doc-keep"); !ok {
+		t.Fatal("previously committed mapping doc-keep must survive")
+	}
+	res, err := idx2.Search([]float32{1, 0, 0, 0, 0, 0, 0, 0}, 1)
+	requireNoError(t, err)
+	requireLen(t, res, 1)
+}

--- a/internal/core/vectorindex/mmap_store_test.go
+++ b/internal/core/vectorindex/mmap_store_test.go
@@ -223,6 +223,35 @@ func TestTxnAbortFaultsAndDiscardsOnReopen(t *testing.T) {
 	}
 }
 
+func TestTxnAbortDiscardedAfterGracefulClose(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1_000_000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.txnBegin(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutNode(0, 0, []float32{9, 9, 9, 9}); err != nil {
+		t.Fatal(err)
+	}
+	_ = s.txnAbort(fmt.Errorf("boom"))
+	// Graceful Close (NOT a crash) must NOT persist the aborted txn.
+	_ = s.Close()
+
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+	if s2.meta.NodeCount != 0 {
+		t.Fatalf("NodeCount = %d, want 0 (aborted txn must not survive graceful Close)", s2.meta.NodeCount)
+	}
+	if s2.meta.NextNodeId != 0 {
+		t.Fatalf("NextNodeId = %d, want 0", s2.meta.NextNodeId)
+	}
+}
+
 func TestTxnBeginRejectsNested(t *testing.T) {
 	dir := t.TempDir()
 	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})

--- a/internal/core/vectorindex/mmap_store_test.go
+++ b/internal/core/vectorindex/mmap_store_test.go
@@ -1,6 +1,7 @@
 package vectorindex
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -124,5 +125,26 @@ func TestMmapStoreInitSmallCap(t *testing.T) {
 	// With defaultInitialCapacity=1024, upperCap = 1024/4 = 256.
 	if s.upperCapacity < 64 {
 		t.Errorf("upperCapacity = %d, want >= 64", s.upperCapacity)
+	}
+}
+
+func TestFaultedStoreRejectsWrites(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Simulate a recorded fault.
+	s.muWrite.Lock()
+	s.fault(fmt.Errorf("disk on fire"))
+	s.muWrite.Unlock()
+
+	if err := s.PutNode(0, 0, []float32{1, 2, 3, 4}); err == nil {
+		t.Fatal("PutNode on a faulted store must return an error")
+	}
+	if err := s.SetNeighbors(0, 0, []uint64{1}); err == nil {
+		t.Fatal("SetNeighbors on a faulted store must return an error")
 	}
 }

--- a/internal/core/vectorindex/mmap_store_test.go
+++ b/internal/core/vectorindex/mmap_store_test.go
@@ -148,3 +148,96 @@ func TestFaultedStoreRejectsWrites(t *testing.T) {
 		t.Fatal("SetNeighbors on a faulted store must return an error")
 	}
 }
+
+func TestTxnCommitDurableAfterCrash(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1_000_000})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.txnBegin(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutNode(0, 0, []float32{1, 2, 3, 4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetNodeMapping("doc-0", 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.txnCommit(); err != nil {
+		t.Fatal(err)
+	}
+	simulateCrash(s)
+
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+	vec, err := s2.GetVector(0)
+	if err != nil {
+		t.Fatalf("committed node must survive crash: %v", err)
+	}
+	if vec[0] != 1 || vec[3] != 4 {
+		t.Fatalf("vec = %v, want [1 2 3 4]", vec)
+	}
+	if s2.meta.NodeCount != 1 {
+		t.Fatalf("NodeCount = %d, want 1", s2.meta.NodeCount)
+	}
+}
+
+func TestTxnAbortFaultsAndDiscardsOnReopen(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1_000_000})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.txnBegin(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutNode(0, 0, []float32{9, 9, 9, 9}); err != nil {
+		t.Fatal(err)
+	}
+	// Abort: records a fault, writes NO commit marker.
+	if err := s.txnAbort(fmt.Errorf("boom")); err == nil {
+		t.Fatal("txnAbort must return the fault error")
+	}
+	// Subsequent writes are rejected.
+	if err := s.PutNode(1, 0, []float32{1, 1, 1, 1}); err == nil {
+		t.Fatal("writes after abort must be rejected")
+	}
+	simulateCrash(s)
+
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+	if s2.meta.NodeCount != 0 {
+		t.Fatalf("NodeCount = %d, want 0 (aborted txn must not persist)", s2.meta.NodeCount)
+	}
+	if s2.meta.NextNodeId != 0 {
+		t.Fatalf("NextNodeId = %d, want 0", s2.meta.NextNodeId)
+	}
+}
+
+func TestTxnBeginRejectsNested(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	if err := s.txnBegin(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.txnBegin(); err == nil {
+		t.Fatal("nested txnBegin must error (single-level transactions)")
+	}
+	if err := s.txnCommit(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -482,8 +482,8 @@ func (s *MmapStore) compactIdmap() error {
 		return err
 	}
 
-	// Reopen idmap for append.
-	nf, err := fsOpenFile(path, os.O_RDWR|os.O_APPEND, 0644)
+	// Reopen idmap handle (lifecycle/Close tracking only; writes go through compactIdmap).
+	nf, err := fsOpenFile(path, os.O_RDWR, 0644)
 	if err != nil {
 		s.muDoc.Unlock()
 		return err

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -204,40 +204,27 @@ func (s *MmapStore) SetEntryPoint(id uint64, maxLayer int) error {
 	return s.maybeCheckpoint()
 }
 
-// SetNodeMapping adds a docId ↔ nodeId mapping and persists it to idmap.dat.
+// SetNodeMapping adds a docId ↔ nodeId mapping. The mapping is journaled to the
+// WAL (committed atomically with its transaction); idmap.dat is rewritten only
+// at checkpoint (compactIdmap). Crash recovery rebuilds the maps from the WAL.
 func (s *MmapStore) SetNodeMapping(docId string, nodeId uint64) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
-
 	if s.faulted != nil {
 		return s.faulted
 	}
-
+	if _, err := s.wal.Append(WalSetMapping, EncodeSetMapping(nodeId, docId)); err != nil {
+		return s.fault(fmt.Errorf("MmapStore.SetNodeMapping: WAL: %w", err))
+	}
 	s.muDoc.Lock()
-	defer s.muDoc.Unlock()
-
 	s.docToNode[docId] = nodeId
 	s.nodeToDoc[nodeId] = docId
-
-	// Append to idmap.dat: NodeId(8) + DocIdLen(2) + DocId(var) + CRC32(4)
-	docBytes := []byte(docId)
-	entry := make([]byte, 10+len(docBytes)+4)
-	binary.LittleEndian.PutUint64(entry[0:], nodeId)
-	binary.LittleEndian.PutUint16(entry[8:], uint16(len(docBytes)))
-	copy(entry[10:], docBytes)
-
-	h := crc32.NewIEEE()
-	h.Write(entry[:10+len(docBytes)])
-	binary.LittleEndian.PutUint32(entry[10+len(docBytes):], h.Sum32())
-
-	if _, err := s.idmapFile.Write(entry); err != nil {
-		return fmt.Errorf("MmapStore.SetNodeMapping: write idmap: %w", err)
-	}
+	s.muDoc.Unlock()
 	return nil
 }
 
-// DeleteNodeMapping removes a docId mapping from memory.
-// idmap.dat is not updated (Phase 3 compact will clean it up).
+// DeleteNodeMapping removes a docId mapping. Journaled to the WAL so the removal
+// is transactional and replayable; idmap.dat is reconciled at checkpoint.
 func (s *MmapStore) DeleteNodeMapping(docId string) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
@@ -246,13 +233,15 @@ func (s *MmapStore) DeleteNodeMapping(docId string) error {
 		return s.faulted
 	}
 
+	if _, err := s.wal.Append(WalDeleteMapping, EncodeDeleteMapping(docId)); err != nil {
+		return s.fault(fmt.Errorf("MmapStore.DeleteNodeMapping: WAL: %w", err))
+	}
 	s.muDoc.Lock()
-	defer s.muDoc.Unlock()
-
 	if nodeId, ok := s.docToNode[docId]; ok {
 		delete(s.nodeToDoc, nodeId)
 	}
 	delete(s.docToNode, docId)
+	s.muDoc.Unlock()
 	return nil
 }
 

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -360,7 +360,7 @@ func (s *MmapStore) txnCommit() error {
 // txnAbort records a fault and clears the open-transaction flag WITHOUT writing
 // a commit marker. In-place mmap writes from the partial transaction are not
 // rolled back here; reopening recovers to the pre-transaction state because the
-// unterminated WAL transaction is discarded on replay (Phase 1). Returns the
+// unterminated WAL transaction is discarded on replay. Returns the
 // fault error so callers can propagate it.
 func (s *MmapStore) txnAbort(cause error) error {
 	s.muWrite.Lock()

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -258,6 +258,10 @@ func (s *MmapStore) DeleteNodeMapping(docId string) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
 
+	if s.faulted != nil {
+		return s.faulted
+	}
+
 	s.muDoc.Lock()
 	defer s.muDoc.Unlock()
 
@@ -413,6 +417,7 @@ func (s *MmapStore) txnCommit() error {
 	if !s.inTxn {
 		return fmt.Errorf("MmapStore.txnCommit: no open transaction")
 	}
+	s.inTxn = false // the transaction is ending regardless of success/failure
 	if _, err := s.wal.Append(WalTxnCommit, nil, true); err != nil {
 		return s.fault(fmt.Errorf("MmapStore.txnCommit: WAL append: %w", err))
 	}
@@ -422,7 +427,6 @@ func (s *MmapStore) txnCommit() error {
 	if err := s.syncAll(); err != nil {
 		return s.fault(fmt.Errorf("MmapStore.txnCommit: msync: %w", err))
 	}
-	s.inTxn = false
 	if s.opsSinceCheckpoint >= s.checkpointInterval {
 		return s.checkpointLocked()
 	}

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -379,6 +379,68 @@ func (s *MmapStore) BatchDepth() int {
 	return s.batchDepth
 }
 
+// --- Transaction primitive (internal; used by Batch.Commit) ---
+
+// txnBegin opens a single-level store transaction: writes a WalTxnBegin marker
+// (buffered) and defers all syncing until txnCommit. Nesting is a programming
+// error and returns an error. The caller (Batch.Commit) serializes via the
+// index write lock; muWrite guards store state.
+func (s *MmapStore) txnBegin() error {
+	s.muWrite.Lock()
+	defer s.muWrite.Unlock()
+	if s.faulted != nil {
+		return s.faulted
+	}
+	if s.inTxn {
+		return fmt.Errorf("MmapStore.txnBegin: transaction already open")
+	}
+	if _, err := s.wal.Append(WalTxnBegin, nil, true); err != nil {
+		return s.fault(fmt.Errorf("MmapStore.txnBegin: WAL: %w", err))
+	}
+	s.inTxn = true
+	return nil
+}
+
+// txnCommit closes the transaction durably: writes a WalTxnCommit marker, then
+// fsyncs the WAL (the atomic commit point), msyncs all mmap regions, and
+// maybe-checkpoints. Any failure faults the store.
+func (s *MmapStore) txnCommit() error {
+	s.muWrite.Lock()
+	defer s.muWrite.Unlock()
+	if s.faulted != nil {
+		return s.faulted
+	}
+	if !s.inTxn {
+		return fmt.Errorf("MmapStore.txnCommit: no open transaction")
+	}
+	if _, err := s.wal.Append(WalTxnCommit, nil, true); err != nil {
+		return s.fault(fmt.Errorf("MmapStore.txnCommit: WAL append: %w", err))
+	}
+	if err := s.wal.Sync(); err != nil { // flush + fsync = commit point
+		return s.fault(fmt.Errorf("MmapStore.txnCommit: WAL sync: %w", err))
+	}
+	if err := s.syncAll(); err != nil {
+		return s.fault(fmt.Errorf("MmapStore.txnCommit: msync: %w", err))
+	}
+	s.inTxn = false
+	if s.opsSinceCheckpoint >= s.checkpointInterval {
+		return s.checkpointLocked()
+	}
+	return nil
+}
+
+// txnAbort records a fault and clears the open-transaction flag WITHOUT writing
+// a commit marker. In-place mmap writes from the partial transaction are not
+// rolled back here; reopening recovers to the pre-transaction state because the
+// unterminated WAL transaction is discarded on replay (Phase 1). Returns the
+// fault error so callers can propagate it.
+func (s *MmapStore) txnAbort(cause error) error {
+	s.muWrite.Lock()
+	defer s.muWrite.Unlock()
+	s.inTxn = false
+	return s.fault(fmt.Errorf("MmapStore.txnAbort: %w", cause))
+}
+
 // syncAll syncs all mmap regions to disk.
 func (s *MmapStore) syncAll() error {
 	if err := mmapSync(s.vectors); err != nil {

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -18,6 +18,10 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
 
+	if s.faulted != nil {
+		return s.faulted
+	}
+
 	// Convert to stored form (cosine: unit vector) and keep the original norm
 	// for GetVector restore. norm never participates in distance computation.
 	stored, norm := s.metric.prepare(vector)
@@ -91,6 +95,10 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 func (s *MmapStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
+
+	if s.faulted != nil {
+		return s.faulted
+	}
 
 	if _, err := s.wal.Append(WalSetNeighbors, EncodeSetNeighbors(id, layer, neighbors), s.batchMode); err != nil {
 		return fmt.Errorf("MmapStore.SetNeighbors: WAL: %w", err)
@@ -171,6 +179,10 @@ func (s *MmapStore) SetNorm(id uint64, norm float32) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
 
+	if s.faulted != nil {
+		return s.faulted
+	}
+
 	if _, err := s.wal.Append(WalSetNorm, EncodeSetNorm(id, norm), s.batchMode); err != nil {
 		return fmt.Errorf("MmapStore.SetNorm: WAL: %w", err)
 	}
@@ -192,6 +204,10 @@ func (s *MmapStore) SetEntryPoint(id uint64, maxLayer int) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
 
+	if s.faulted != nil {
+		return s.faulted
+	}
+
 	if _, err := s.wal.Append(WalSetEntry, EncodeSetEntry(id, maxLayer), s.batchMode); err != nil {
 		return fmt.Errorf("MmapStore.SetEntryPoint: WAL: %w", err)
 	}
@@ -208,6 +224,10 @@ func (s *MmapStore) SetEntryPoint(id uint64, maxLayer int) error {
 func (s *MmapStore) SetNodeMapping(docId string, nodeId uint64) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
+
+	if s.faulted != nil {
+		return s.faulted
+	}
 
 	s.muDoc.Lock()
 	defer s.muDoc.Unlock()
@@ -253,6 +273,10 @@ func (s *MmapStore) DeleteNode(id uint64) error {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
 
+	if s.faulted != nil {
+		return s.faulted
+	}
+
 	// Look up docId for WAL record.
 	docId := s.nodeToDoc[id]
 
@@ -286,6 +310,21 @@ func (s *MmapStore) allocUpperSlot() uint32 {
 }
 
 // --- BatchableStore implementation ---
+
+// deferSync reports whether per-op syncing should be skipped because a batch
+// or a transaction is open; the open scope syncs once at commit time.
+// Caller holds muWrite.
+func (s *MmapStore) deferSync() bool { return s.batchMode || s.inTxn }
+
+// fault records the first fatal write error and returns it. Once faulted, all
+// write methods reject. Recovery is via reopen (transaction-aware replay
+// restores the last committed state). Caller holds muWrite.
+func (s *MmapStore) fault(err error) error {
+	if s.faulted == nil {
+		s.faulted = err
+	}
+	return s.faulted
+}
 
 // BeginBatch enters batch mode, deferring sync until CommitBatch.
 func (s *MmapStore) BeginBatch() {

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -30,7 +30,7 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	docId := s.nodeToDoc[id]
 
 	// WAL — record the stored form so replay writes it back verbatim.
-	if _, err := s.wal.Append(WalInsert, EncodeInsert(id, level, stored, norm, docId), s.batchMode); err != nil {
+	if _, err := s.wal.Append(WalInsert, EncodeInsert(id, level, stored, norm, docId), s.deferSync()); err != nil {
 		return fmt.Errorf("MmapStore.PutNode: WAL: %w", err)
 	}
 	if s.crashAfterWALWrite != nil {
@@ -53,7 +53,7 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	for i, v := range stored {
 		binary.LittleEndian.PutUint32(s.vectors[vecOff+int64(i*4):], math.Float32bits(v))
 	}
-	if !s.batchMode {
+	if !s.deferSync() {
 		mmapSync(s.vectors)
 	}
 
@@ -75,7 +75,7 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	binary.LittleEndian.PutUint32(s.nodes[nodeOff+4:], math.Float32bits(norm))
 	binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], upperSlotVal)
 
-	if !s.batchMode {
+	if !s.deferSync() {
 		mmapSync(s.nodes)
 	}
 
@@ -100,7 +100,7 @@ func (s *MmapStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error
 		return s.faulted
 	}
 
-	if _, err := s.wal.Append(WalSetNeighbors, EncodeSetNeighbors(id, layer, neighbors), s.batchMode); err != nil {
+	if _, err := s.wal.Append(WalSetNeighbors, EncodeSetNeighbors(id, layer, neighbors), s.deferSync()); err != nil {
 		return fmt.Errorf("MmapStore.SetNeighbors: WAL: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func (s *MmapStore) setNeighborsL0(id uint64, neighbors []uint64) error {
 		binary.LittleEndian.PutUint64(s.graphL0[offset+4+int64(i*8):], neighbors[i])
 	}
 
-	if !s.batchMode {
+	if !s.deferSync() {
 		mmapSync(s.graphL0)
 	}
 	return nil
@@ -168,7 +168,7 @@ func (s *MmapStore) setNeighborsUpper(id uint64, layer int, neighbors []uint64) 
 		binary.LittleEndian.PutUint64(s.graphUpper[layerOffset+4+int64(i*8):], neighbors[i])
 	}
 
-	if !s.batchMode {
+	if !s.deferSync() {
 		mmapSync(s.graphUpper)
 	}
 	return nil
@@ -183,7 +183,7 @@ func (s *MmapStore) SetNorm(id uint64, norm float32) error {
 		return s.faulted
 	}
 
-	if _, err := s.wal.Append(WalSetNorm, EncodeSetNorm(id, norm), s.batchMode); err != nil {
+	if _, err := s.wal.Append(WalSetNorm, EncodeSetNorm(id, norm), s.deferSync()); err != nil {
 		return fmt.Errorf("MmapStore.SetNorm: WAL: %w", err)
 	}
 
@@ -193,7 +193,7 @@ func (s *MmapStore) SetNorm(id uint64, norm float32) error {
 	offset := int64(pageSize) + int64(id)*int64(nodeSlotSize)
 	binary.LittleEndian.PutUint32(s.nodes[offset+4:], math.Float32bits(norm))
 
-	if !s.batchMode {
+	if !s.deferSync() {
 		mmapSync(s.nodes)
 	}
 	return s.maybeCheckpoint()
@@ -208,7 +208,7 @@ func (s *MmapStore) SetEntryPoint(id uint64, maxLayer int) error {
 		return s.faulted
 	}
 
-	if _, err := s.wal.Append(WalSetEntry, EncodeSetEntry(id, maxLayer), s.batchMode); err != nil {
+	if _, err := s.wal.Append(WalSetEntry, EncodeSetEntry(id, maxLayer), s.deferSync()); err != nil {
 		return fmt.Errorf("MmapStore.SetEntryPoint: WAL: %w", err)
 	}
 
@@ -280,7 +280,7 @@ func (s *MmapStore) DeleteNode(id uint64) error {
 	// Look up docId for WAL record.
 	docId := s.nodeToDoc[id]
 
-	if _, err := s.wal.Append(WalDelete, EncodeDelete(id, docId), s.batchMode); err != nil {
+	if _, err := s.wal.Append(WalDelete, EncodeDelete(id, docId), s.deferSync()); err != nil {
 		return fmt.Errorf("MmapStore.DeleteNode: WAL: %w", err)
 	}
 
@@ -422,7 +422,7 @@ func (s *MmapStore) Sync() error {
 // if the threshold is reached. Caller must hold muWrite.
 func (s *MmapStore) maybeCheckpoint() error {
 	s.opsSinceCheckpoint++
-	if !s.batchMode && s.opsSinceCheckpoint >= s.checkpointInterval {
+	if !s.deferSync() && s.opsSinceCheckpoint >= s.checkpointInterval {
 		return s.checkpointLocked()
 	}
 	return nil

--- a/internal/core/vectorindex/mmap_store_write.go
+++ b/internal/core/vectorindex/mmap_store_write.go
@@ -30,7 +30,7 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	docId := s.nodeToDoc[id]
 
 	// WAL — record the stored form so replay writes it back verbatim.
-	if _, err := s.wal.Append(WalInsert, EncodeInsert(id, level, stored, norm, docId), s.deferSync()); err != nil {
+	if _, err := s.wal.Append(WalInsert, EncodeInsert(id, level, stored, norm, docId)); err != nil {
 		return fmt.Errorf("MmapStore.PutNode: WAL: %w", err)
 	}
 	if s.crashAfterWALWrite != nil {
@@ -53,9 +53,6 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	for i, v := range stored {
 		binary.LittleEndian.PutUint32(s.vectors[vecOff+int64(i*4):], math.Float32bits(v))
 	}
-	if !s.deferSync() {
-		mmapSync(s.vectors)
-	}
 
 	// If level > 0, allocate an upper slot.
 	var upperSlotVal uint32
@@ -74,10 +71,6 @@ func (s *MmapStore) PutNode(id uint64, level int, vector []float32) error {
 	s.nodes[nodeOff+3] = 0                // padding
 	binary.LittleEndian.PutUint32(s.nodes[nodeOff+4:], math.Float32bits(norm))
 	binary.LittleEndian.PutUint32(s.nodes[nodeOff+8:], upperSlotVal)
-
-	if !s.deferSync() {
-		mmapSync(s.nodes)
-	}
 
 	// Update meta.
 	if id >= s.meta.TotalSlots {
@@ -100,7 +93,7 @@ func (s *MmapStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error
 		return s.faulted
 	}
 
-	if _, err := s.wal.Append(WalSetNeighbors, EncodeSetNeighbors(id, layer, neighbors), s.deferSync()); err != nil {
+	if _, err := s.wal.Append(WalSetNeighbors, EncodeSetNeighbors(id, layer, neighbors)); err != nil {
 		return fmt.Errorf("MmapStore.SetNeighbors: WAL: %w", err)
 	}
 
@@ -131,9 +124,6 @@ func (s *MmapStore) setNeighborsL0(id uint64, neighbors []uint64) error {
 		binary.LittleEndian.PutUint64(s.graphL0[offset+4+int64(i*8):], neighbors[i])
 	}
 
-	if !s.deferSync() {
-		mmapSync(s.graphL0)
-	}
 	return nil
 }
 
@@ -168,9 +158,6 @@ func (s *MmapStore) setNeighborsUpper(id uint64, layer int, neighbors []uint64) 
 		binary.LittleEndian.PutUint64(s.graphUpper[layerOffset+4+int64(i*8):], neighbors[i])
 	}
 
-	if !s.deferSync() {
-		mmapSync(s.graphUpper)
-	}
 	return nil
 }
 
@@ -183,7 +170,7 @@ func (s *MmapStore) SetNorm(id uint64, norm float32) error {
 		return s.faulted
 	}
 
-	if _, err := s.wal.Append(WalSetNorm, EncodeSetNorm(id, norm), s.deferSync()); err != nil {
+	if _, err := s.wal.Append(WalSetNorm, EncodeSetNorm(id, norm)); err != nil {
 		return fmt.Errorf("MmapStore.SetNorm: WAL: %w", err)
 	}
 
@@ -193,9 +180,6 @@ func (s *MmapStore) SetNorm(id uint64, norm float32) error {
 	offset := int64(pageSize) + int64(id)*int64(nodeSlotSize)
 	binary.LittleEndian.PutUint32(s.nodes[offset+4:], math.Float32bits(norm))
 
-	if !s.deferSync() {
-		mmapSync(s.nodes)
-	}
 	return s.maybeCheckpoint()
 }
 
@@ -208,7 +192,7 @@ func (s *MmapStore) SetEntryPoint(id uint64, maxLayer int) error {
 		return s.faulted
 	}
 
-	if _, err := s.wal.Append(WalSetEntry, EncodeSetEntry(id, maxLayer), s.deferSync()); err != nil {
+	if _, err := s.wal.Append(WalSetEntry, EncodeSetEntry(id, maxLayer)); err != nil {
 		return fmt.Errorf("MmapStore.SetEntryPoint: WAL: %w", err)
 	}
 
@@ -284,7 +268,7 @@ func (s *MmapStore) DeleteNode(id uint64) error {
 	// Look up docId for WAL record.
 	docId := s.nodeToDoc[id]
 
-	if _, err := s.wal.Append(WalDelete, EncodeDelete(id, docId), s.deferSync()); err != nil {
+	if _, err := s.wal.Append(WalDelete, EncodeDelete(id, docId)); err != nil {
 		return fmt.Errorf("MmapStore.DeleteNode: WAL: %w", err)
 	}
 
@@ -313,12 +297,7 @@ func (s *MmapStore) allocUpperSlot() uint32 {
 	return uint32(slot)
 }
 
-// --- BatchableStore implementation ---
-
-// deferSync reports whether per-op syncing should be skipped because a batch
-// or a transaction is open; the open scope syncs once at commit time.
-// Caller holds muWrite.
-func (s *MmapStore) deferSync() bool { return s.batchMode || s.inTxn }
+// --- Transaction primitive (internal; used by Batch.Commit) ---
 
 // fault records the first fatal write error and returns it. Once faulted, all
 // write methods reject. Recovery is via reopen (transaction-aware replay
@@ -329,61 +308,6 @@ func (s *MmapStore) fault(err error) error {
 	}
 	return s.faulted
 }
-
-// BeginBatch enters batch mode, deferring sync until CommitBatch.
-func (s *MmapStore) BeginBatch() {
-	s.muWrite.Lock()
-	defer s.muWrite.Unlock()
-
-	s.batchDepth++
-	s.batchMode = true
-}
-
-// CommitBatch exits one level of batch nesting. When depth reaches 0,
-// flushes WAL. In SyncImmediate mode (default), also syncs WAL and msync's
-// all mmap regions. In SyncDeferred mode, only flushes the WAL buffer.
-func (s *MmapStore) CommitBatch(sync bool) error {
-	s.muWrite.Lock()
-	defer s.muWrite.Unlock()
-
-	s.batchDepth--
-	if s.batchDepth > 0 {
-		return nil
-	}
-	s.batchMode = false
-
-	if err := s.wal.Flush(); err != nil {
-		return fmt.Errorf("MmapStore.CommitBatch: WAL flush: %w", err)
-	}
-	if sync && s.syncMode == SyncImmediate {
-		if err := s.wal.Sync(); err != nil {
-			return fmt.Errorf("MmapStore.CommitBatch: WAL sync: %w", err)
-		}
-		if err := s.syncAll(); err != nil {
-			return fmt.Errorf("MmapStore.CommitBatch: mmap sync: %w", err)
-		}
-	}
-	if s.opsSinceCheckpoint >= s.checkpointInterval {
-		return s.checkpointLocked()
-	}
-	return nil
-}
-
-// DiscardBatch resets batch state. Note: mmap writes cannot be rolled back.
-func (s *MmapStore) DiscardBatch() {
-	s.muWrite.Lock()
-	defer s.muWrite.Unlock()
-
-	s.batchDepth = 0
-	s.batchMode = false
-}
-
-// BatchDepth returns the current batch nesting depth.
-func (s *MmapStore) BatchDepth() int {
-	return s.batchDepth
-}
-
-// --- Transaction primitive (internal; used by Batch.Commit) ---
 
 // txnBegin opens a single-level store transaction: writes a WalTxnBegin marker
 // (buffered) and defers all syncing until txnCommit. Nesting is a programming
@@ -398,7 +322,7 @@ func (s *MmapStore) txnBegin() error {
 	if s.inTxn {
 		return fmt.Errorf("MmapStore.txnBegin: transaction already open")
 	}
-	if _, err := s.wal.Append(WalTxnBegin, nil, true); err != nil {
+	if _, err := s.wal.Append(WalTxnBegin, nil); err != nil {
 		return s.fault(fmt.Errorf("MmapStore.txnBegin: WAL: %w", err))
 	}
 	s.inTxn = true
@@ -418,7 +342,7 @@ func (s *MmapStore) txnCommit() error {
 		return fmt.Errorf("MmapStore.txnCommit: no open transaction")
 	}
 	s.inTxn = false // the transaction is ending regardless of success/failure
-	if _, err := s.wal.Append(WalTxnCommit, nil, true); err != nil {
+	if _, err := s.wal.Append(WalTxnCommit, nil); err != nil {
 		return s.fault(fmt.Errorf("MmapStore.txnCommit: WAL append: %w", err))
 	}
 	if err := s.wal.Sync(); err != nil { // flush + fsync = commit point
@@ -459,36 +383,11 @@ func (s *MmapStore) syncAll() error {
 	return mmapSync(s.graphUpper)
 }
 
-// SetSyncMode sets the sync strategy for CommitBatch.
-// Returns an error if a batch is currently active.
-func (s *MmapStore) SetSyncMode(mode SyncMode) error {
-	s.muWrite.Lock()
-	defer s.muWrite.Unlock()
-	if s.batchDepth > 0 {
-		return fmt.Errorf("MmapStore.SetSyncMode: cannot change sync mode while batch is active (depth=%d)", s.batchDepth)
-	}
-	s.syncMode = mode
-	return nil
-}
-
-// Sync forces WAL sync + msync + checkpoint. Use after bulk inserts with SyncDeferred.
-func (s *MmapStore) Sync() error {
-	s.muWrite.Lock()
-	defer s.muWrite.Unlock()
-	if err := s.wal.Flush(); err != nil {
-		return fmt.Errorf("MmapStore.Sync: WAL flush: %w", err)
-	}
-	if err := s.wal.Sync(); err != nil {
-		return fmt.Errorf("MmapStore.Sync: WAL sync: %w", err)
-	}
-	return s.checkpointLocked()
-}
-
 // maybeCheckpoint increments the ops counter and triggers a checkpoint
 // if the threshold is reached. Caller must hold muWrite.
 func (s *MmapStore) maybeCheckpoint() error {
 	s.opsSinceCheckpoint++
-	if !s.deferSync() && s.opsSinceCheckpoint >= s.checkpointInterval {
+	if !s.inTxn && s.opsSinceCheckpoint >= s.checkpointInterval {
 		return s.checkpointLocked()
 	}
 	return nil

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -199,37 +199,6 @@ func TestMmapStoreBatchWriteAndRead(t *testing.T) {
 	}
 }
 
-func TestMmapStoreBatchNesting(t *testing.T) {
-	s := openTestMmapStore(t)
-	defer s.Close()
-
-	s.BeginBatch()
-	assert.Equal(t, 1, s.BatchDepth())
-
-	s.BeginBatch()
-	assert.Equal(t, 2, s.BatchDepth())
-
-	requireNoError(t, s.CommitBatch(false))
-	assert.Equal(t, 1, s.BatchDepth())
-	assert.True(t, s.batchMode) // still in batch
-
-	requireNoError(t, s.CommitBatch(true))
-	assert.Equal(t, 0, s.BatchDepth())
-	assert.False(t, s.batchMode)
-}
-
-func TestMmapStoreDiscardBatch(t *testing.T) {
-	s := openTestMmapStore(t)
-	defer s.Close()
-
-	s.BeginBatch()
-	s.BeginBatch()
-	assert.Equal(t, 2, s.BatchDepth())
-
-	s.DiscardBatch()
-	assert.Equal(t, 0, s.BatchDepth())
-	assert.False(t, s.batchMode)
-}
 
 func TestMmapStoreNextNodeId(t *testing.T) {
 	s := openTestMmapStore(t)
@@ -307,18 +276,3 @@ func TestDeferredSync_InsertSyncReopen(t *testing.T) {
 	assert.Equal(t, uint64(50), nodeId)
 }
 
-func TestSetSyncMode_ErrorDuringActiveBatch(t *testing.T) {
-	s := openTestMmapStore(t)
-	defer s.Close()
-
-	requireNoError(t, s.SetSyncMode(SyncDeferred))
-
-	s.BeginBatch()
-	err := s.SetSyncMode(SyncImmediate)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "batch is active")
-
-	requireNoError(t, s.CommitBatch(false))
-
-	requireNoError(t, s.SetSyncMode(SyncImmediate))
-}

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -195,7 +195,6 @@ func TestMmapStoreBatchWriteAndRead(t *testing.T) {
 	}
 }
 
-
 func TestMmapStoreNextNodeId(t *testing.T) {
 	s := openTestMmapStore(t)
 	defer s.Close()
@@ -268,4 +267,3 @@ func TestTxnInsertSurvivesReopen(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, uint64(50), nodeId)
 }
-

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -304,3 +304,22 @@ func TestMappingCommittedSurvivesCrash(t *testing.T) {
 		t.Fatalf("committed mapping must survive crash: got (%d,%v)", id, ok)
 	}
 }
+
+func TestMappingSetThenDeleteInTxnSurvivesAsDeleted(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1_000_000})
+	requireNoError(t, err)
+	requireNoError(t, s.txnBegin())
+	requireNoError(t, s.PutNode(0, 0, []float32{1, 2, 3, 4}))
+	requireNoError(t, s.SetNodeMapping("doc-0", 0))
+	requireNoError(t, s.DeleteNodeMapping("doc-0"))
+	requireNoError(t, s.txnCommit())
+	simulateCrash(s)
+
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	requireNoError(t, err)
+	defer s2.Close()
+	if _, ok, _ := s2.GetNodeId("doc-0"); ok {
+		t.Fatal("set-then-delete in same committed txn must not survive as a mapping")
+	}
+}

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -267,3 +267,40 @@ func TestTxnInsertSurvivesReopen(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, uint64(50), nodeId)
 }
+
+func TestMappingDiscardedOnAbortReopen(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1_000_000})
+	requireNoError(t, err)
+	requireNoError(t, s.txnBegin())
+	requireNoError(t, s.PutNode(0, 0, []float32{1, 2, 3, 4}))
+	requireNoError(t, s.SetNodeMapping("doc-0", 0))
+	_ = s.txnAbort(fmt.Errorf("boom"))
+	_ = s.Close() // graceful close of a faulted store must not persist
+
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	requireNoError(t, err)
+	defer s2.Close()
+	if _, ok, _ := s2.GetNodeId("doc-0"); ok {
+		t.Fatal("aborted batch's docId mapping must NOT survive reopen (D1 closed)")
+	}
+}
+
+func TestMappingCommittedSurvivesCrash(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4, CheckpointInterval: 1_000_000})
+	requireNoError(t, err)
+	requireNoError(t, s.txnBegin())
+	requireNoError(t, s.PutNode(0, 0, []float32{1, 2, 3, 4}))
+	requireNoError(t, s.SetNodeMapping("doc-0", 0))
+	requireNoError(t, s.txnCommit())
+	simulateCrash(s)
+
+	s2, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4})
+	requireNoError(t, err)
+	defer s2.Close()
+	id, ok, _ := s2.GetNodeId("doc-0")
+	if !ok || id != 0 {
+		t.Fatalf("committed mapping must survive crash: got (%d,%v)", id, ok)
+	}
+}

--- a/internal/core/vectorindex/mmap_store_write_test.go
+++ b/internal/core/vectorindex/mmap_store_write_test.go
@@ -175,17 +175,13 @@ func TestMmapStoreBatchWriteAndRead(t *testing.T) {
 	s := openTestMmapStore(t)
 	defer s.Close()
 
-	s.BeginBatch()
-	assert.Equal(t, 1, s.BatchDepth())
-
+	requireNoError(t, s.txnBegin())
 	for i := uint64(0); i < 10; i++ {
 		vec := []float32{float32(i), 0, 0, 0}
 		requireNoError(t, s.PutNode(i, 0, vec))
 		requireNoError(t, s.SetNeighbors(i, 0, []uint64{(i + 1) % 10}))
 	}
-
-	requireNoError(t, s.CommitBatch(true))
-	assert.Equal(t, 0, s.BatchDepth())
+	requireNoError(t, s.txnCommit())
 
 	// Verify all data is readable.
 	for i := uint64(0); i < 10; i++ {
@@ -240,23 +236,21 @@ func TestMmapStoreNextNodeIdPersistence(t *testing.T) {
 	assert.Equal(t, uint64(5), id)
 }
 
-func TestDeferredSync_InsertSyncReopen(t *testing.T) {
+func TestTxnInsertSurvivesReopen(t *testing.T) {
 	dir := t.TempDir()
 	opts := MmapStoreOptions{Metric: DotProduct, Dim: 4, M: 4}
 
 	s, err := OpenMmapStore(dir, opts)
 	requireNoError(t, err)
 
-	requireNoError(t, s.SetSyncMode(SyncDeferred))
-
 	const n = 100
+	requireNoError(t, s.txnBegin())
 	for i := 0; i < n; i++ {
 		v := []float32{float32(i), float32(i + 1), float32(i + 2), float32(i + 3)}
 		requireNoError(t, s.SetNodeMapping(fmt.Sprintf("doc-%d", i), uint64(i)))
 		requireNoError(t, s.PutNode(uint64(i), 0, v))
 	}
-
-	requireNoError(t, s.Sync())
+	requireNoError(t, s.txnCommit())
 	requireNoError(t, s.Close())
 
 	s2, err := OpenMmapStore(dir, opts)
@@ -269,7 +263,6 @@ func TestDeferredSync_InsertSyncReopen(t *testing.T) {
 		requireNoError(t, err)
 		assert.Equal(t, v, got, "vector %d mismatch after reopen", i)
 	}
-
 	nodeId, ok, err := s2.GetNodeId("doc-50")
 	requireNoError(t, err)
 	assert.True(t, ok)

--- a/internal/core/vectorindex/mmap_wal.go
+++ b/internal/core/vectorindex/mmap_wal.go
@@ -121,9 +121,10 @@ func (w *WAL) scanLSN() error {
 	return nil
 }
 
-// Append writes a WAL record and returns the assigned LSN.
-// In non-batch mode, it fsyncs immediately.
-func (w *WAL) Append(typ WalRecordType, payload []byte, batchMode bool) (uint64, error) {
+// Append writes a WAL record and returns the assigned LSN. The record is
+// buffered; the caller is responsible for flushing and fsyncing at the
+// appropriate commit boundary (txnCommit calls wal.Sync).
+func (w *WAL) Append(typ WalRecordType, payload []byte) (uint64, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -150,15 +151,6 @@ func (w *WAL) Append(typ WalRecordType, payload []byte, batchMode bool) (uint64,
 	}
 	if _, err := w.buf.Write(crcBuf); err != nil {
 		return 0, fmt.Errorf("WAL: write crc: %w", err)
-	}
-
-	if !batchMode {
-		if err := w.buf.Flush(); err != nil {
-			return 0, fmt.Errorf("WAL: flush: %w", err)
-		}
-		if err := w.file.Sync(); err != nil {
-			return 0, fmt.Errorf("WAL: sync: %w", err)
-		}
 	}
 
 	return lsn, nil

--- a/internal/core/vectorindex/mmap_wal.go
+++ b/internal/core/vectorindex/mmap_wal.go
@@ -21,8 +21,10 @@ const (
 	WalSetNeighbors WalRecordType = 3
 	WalSetEntry     WalRecordType = 4
 	WalSetNorm      WalRecordType = 5
-	WalTxnBegin     WalRecordType = 6 // transaction start marker (empty payload)
-	WalTxnCommit    WalRecordType = 7 // transaction commit marker (empty payload)
+	WalTxnBegin      WalRecordType = 6 // transaction start marker (empty payload)
+	WalTxnCommit     WalRecordType = 7 // transaction commit marker (empty payload)
+	WalSetMapping    WalRecordType = 8 // docId↔nodeId mapping add (payload: nodeId(8) + docId)
+	WalDeleteMapping WalRecordType = 9 // docId↔nodeId mapping remove (payload: docId)
 )
 
 // WAL record disk layout: LSN(8) + Length(4) + Type(1) + Payload(var) + CRC32(4)
@@ -398,3 +400,22 @@ func DecodeSetNorm(payload []byte) (nodeId uint64, norm float32) {
 	norm = math.Float32frombits(binary.LittleEndian.Uint32(payload[8:]))
 	return
 }
+
+// EncodeSetMapping encodes a SETMAPPING WAL payload: nodeId(8) + docId(var).
+func EncodeSetMapping(nodeId uint64, docId string) []byte {
+	b := make([]byte, 8+len(docId))
+	binary.LittleEndian.PutUint64(b[0:8], nodeId)
+	copy(b[8:], docId)
+	return b
+}
+
+// DecodeSetMapping decodes a SETMAPPING payload.
+func DecodeSetMapping(payload []byte) (uint64, string) {
+	return binary.LittleEndian.Uint64(payload[0:8]), string(payload[8:])
+}
+
+// EncodeDeleteMapping encodes a DELETEMAPPING WAL payload: docId(var).
+func EncodeDeleteMapping(docId string) []byte { return []byte(docId) }
+
+// DecodeDeleteMapping decodes a DELETEMAPPING payload.
+func DecodeDeleteMapping(payload []byte) string { return string(payload) }

--- a/internal/core/vectorindex/mmap_wal.go
+++ b/internal/core/vectorindex/mmap_wal.go
@@ -21,6 +21,8 @@ const (
 	WalSetNeighbors WalRecordType = 3
 	WalSetEntry     WalRecordType = 4
 	WalSetNorm      WalRecordType = 5
+	WalTxnBegin     WalRecordType = 6 // transaction start marker (empty payload)
+	WalTxnCommit    WalRecordType = 7 // transaction commit marker (empty payload)
 )
 
 // WAL record disk layout: LSN(8) + Length(4) + Type(1) + Payload(var) + CRC32(4)

--- a/internal/core/vectorindex/mmap_wal.go
+++ b/internal/core/vectorindex/mmap_wal.go
@@ -16,11 +16,11 @@ import (
 type WalRecordType uint8
 
 const (
-	WalInsert       WalRecordType = 1
-	WalDelete       WalRecordType = 2
-	WalSetNeighbors WalRecordType = 3
-	WalSetEntry     WalRecordType = 4
-	WalSetNorm      WalRecordType = 5
+	WalInsert        WalRecordType = 1
+	WalDelete        WalRecordType = 2
+	WalSetNeighbors  WalRecordType = 3
+	WalSetEntry      WalRecordType = 4
+	WalSetNorm       WalRecordType = 5
 	WalTxnBegin      WalRecordType = 6 // transaction start marker (empty payload)
 	WalTxnCommit     WalRecordType = 7 // transaction commit marker (empty payload)
 	WalSetMapping    WalRecordType = 8 // docId↔nodeId mapping add (payload: nodeId(8) + docId)

--- a/internal/core/vectorindex/mmap_wal_test.go
+++ b/internal/core/vectorindex/mmap_wal_test.go
@@ -312,6 +312,102 @@ func TestWalTxnMarkerConstants(t *testing.T) {
 	}
 }
 
+// openStoreForReplay opens a fresh DotProduct store with the given dim/M.
+func openStoreForReplay(t *testing.T, dir string, dim, m int) *MmapStore {
+	t.Helper()
+	s, err := OpenMmapStore(dir, MmapStoreOptions{Metric: DotProduct, Dim: dim, M: m, CheckpointInterval: 1_000_000})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	return s
+}
+
+// appendRaw appends one WAL record in buffered mode (no fsync), so tests can
+// hand-build txn-framed WAL streams.
+func appendRaw(t *testing.T, s *MmapStore, typ WalRecordType, payload []byte) {
+	t.Helper()
+	if _, err := s.wal.Append(typ, payload, true); err != nil {
+		t.Fatalf("append %d: %v", typ, err)
+	}
+}
+
+func TestReplayCommittedTxnApplies(t *testing.T) {
+	dir := t.TempDir()
+	s := openStoreForReplay(t, dir, 4, 8)
+
+	appendRaw(t, s, WalTxnBegin, nil)
+	appendRaw(t, s, WalInsert, EncodeInsert(0, 0, []float32{1, 2, 3, 4}, 0, "doc-0"))
+	appendRaw(t, s, WalTxnCommit, nil)
+	if err := s.wal.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	simulateCrash(s) // skip Close, keep WAL on disk
+
+	s2 := openStoreForReplay(t, dir, 4, 8)
+	defer s2.Close()
+
+	vec, err := s2.GetVector(0)
+	if err != nil {
+		t.Fatalf("committed insert must be visible: %v", err)
+	}
+	if vec[0] != 1 || vec[3] != 4 {
+		t.Fatalf("vec = %v, want [1 2 3 4]", vec)
+	}
+	if s2.meta.NodeCount != 1 {
+		t.Fatalf("NodeCount = %d, want 1", s2.meta.NodeCount)
+	}
+}
+
+func TestReplayUnterminatedTxnDiscarded(t *testing.T) {
+	dir := t.TempDir()
+	s := openStoreForReplay(t, dir, 4, 8)
+
+	appendRaw(t, s, WalTxnBegin, nil)
+	appendRaw(t, s, WalInsert, EncodeInsert(0, 0, []float32{9, 9, 9, 9}, 0, "doc-0"))
+	// NO WalTxnCommit — simulates a crash mid-commit.
+	if err := s.wal.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	simulateCrash(s)
+
+	s2 := openStoreForReplay(t, dir, 4, 8)
+	defer s2.Close()
+
+	// NOTE: GetVector does NOT check the occupied flag (it returns raw mmap
+	// bytes), so "not visible" is asserted via committed meta state, which is
+	// what the index actually relies on: NextNodeId/NodeCount only ever account
+	// for committed nodes, and Search reaches nodes only via those.
+	if s2.meta.NodeCount != 0 {
+		t.Fatalf("NodeCount = %d, want 0 (uncommitted insert must not apply)", s2.meta.NodeCount)
+	}
+	if s2.meta.NextNodeId != 0 {
+		t.Fatalf("NextNodeId = %d, want 0 (uncommitted insert must not advance allocator)", s2.meta.NextNodeId)
+	}
+}
+
+func TestReplayLegacyUnframedRecordsApply(t *testing.T) {
+	// Records with no surrounding BEGIN/COMMIT (pre-redesign WAL) still apply.
+	dir := t.TempDir()
+	s := openStoreForReplay(t, dir, 4, 8)
+
+	appendRaw(t, s, WalInsert, EncodeInsert(0, 0, []float32{5, 6, 7, 8}, 0, "doc-0"))
+	if err := s.wal.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	simulateCrash(s)
+
+	s2 := openStoreForReplay(t, dir, 4, 8)
+	defer s2.Close()
+
+	vec, err := s2.GetVector(0)
+	if err != nil {
+		t.Fatalf("legacy unframed insert must apply: %v", err)
+	}
+	if vec[0] != 5 {
+		t.Fatalf("vec = %v, want [5 6 7 8]", vec)
+	}
+}
+
 func TestWALContinueLSNAfterReopen(t *testing.T) {
 	dir := t.TempDir()
 	w, err := OpenWAL(dir)

--- a/internal/core/vectorindex/mmap_wal_test.go
+++ b/internal/core/vectorindex/mmap_wal_test.go
@@ -296,6 +296,22 @@ func TestWALReplayGrowsDuringReplay(t *testing.T) {
 	assert.Greater(t, s2.vecCapacity, uint64(1500))
 }
 
+func TestWalTxnMarkerConstants(t *testing.T) {
+	// Markers must be distinct from the five data record types and from
+	// each other; replay switches on these exact values.
+	got := map[WalRecordType]string{
+		WalInsert: "insert", WalDelete: "delete", WalSetNeighbors: "neighbors",
+		WalSetEntry: "entry", WalSetNorm: "norm",
+		WalTxnBegin: "begin", WalTxnCommit: "commit",
+	}
+	if len(got) != 7 {
+		t.Fatalf("record type values collide: %v", got)
+	}
+	if WalTxnBegin != 6 || WalTxnCommit != 7 {
+		t.Fatalf("marker values: begin=%d commit=%d, want 6 and 7", WalTxnBegin, WalTxnCommit)
+	}
+}
+
 func TestWALContinueLSNAfterReopen(t *testing.T) {
 	dir := t.TempDir()
 	w, err := OpenWAL(dir)

--- a/internal/core/vectorindex/mmap_wal_test.go
+++ b/internal/core/vectorindex/mmap_wal_test.go
@@ -493,3 +493,22 @@ func TestWALContinueLSNAfterReopen(t *testing.T) {
 	assert.Equal(t, uint64(3), lsn)
 	requireNoError(t, w2.Close())
 }
+
+func TestEncodeDecodeMappingRecords(t *testing.T) {
+	nid, doc := uint64(123), "doc-abc"
+	gotID, gotDoc := DecodeSetMapping(EncodeSetMapping(nid, doc))
+	if gotID != nid || gotDoc != doc {
+		t.Fatalf("SetMapping roundtrip: got (%d,%q) want (%d,%q)", gotID, gotDoc, nid, doc)
+	}
+	if got := DecodeDeleteMapping(EncodeDeleteMapping(doc)); got != doc {
+		t.Fatalf("DeleteMapping roundtrip: got %q want %q", got, doc)
+	}
+	// empty docId edge case
+	id2, d2 := DecodeSetMapping(EncodeSetMapping(7, ""))
+	if id2 != 7 || d2 != "" {
+		t.Fatalf("empty-doc roundtrip: got (%d,%q)", id2, d2)
+	}
+	if WalSetMapping != 8 || WalDeleteMapping != 9 {
+		t.Fatalf("marker values: set=%d del=%d want 8,9", WalSetMapping, WalDeleteMapping)
+	}
+}

--- a/internal/core/vectorindex/mmap_wal_test.go
+++ b/internal/core/vectorindex/mmap_wal_test.go
@@ -408,6 +408,73 @@ func TestReplayLegacyUnframedRecordsApply(t *testing.T) {
 	}
 }
 
+func TestReplayTwoConsecutiveCommittedTxns(t *testing.T) {
+	// Primary production sequence: back-to-back framed transactions. The replay
+	// state machine must reset between them so BOTH commits apply.
+	dir := t.TempDir()
+	s := openStoreForReplay(t, dir, 4, 8)
+
+	appendRaw(t, s, WalTxnBegin, nil)
+	appendRaw(t, s, WalInsert, EncodeInsert(0, 0, []float32{1, 1, 1, 1}, 0, "doc-0"))
+	appendRaw(t, s, WalTxnCommit, nil)
+	appendRaw(t, s, WalTxnBegin, nil)
+	appendRaw(t, s, WalInsert, EncodeInsert(1, 0, []float32{2, 2, 2, 2}, 0, "doc-1"))
+	appendRaw(t, s, WalTxnCommit, nil)
+	if err := s.wal.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	simulateCrash(s)
+
+	s2 := openStoreForReplay(t, dir, 4, 8)
+	defer s2.Close()
+
+	v0, err := s2.GetVector(0)
+	if err != nil {
+		t.Fatalf("first committed insert must be visible: %v", err)
+	}
+	if v0[0] != 1 {
+		t.Fatalf("vec0 = %v, want [1 1 1 1]", v0)
+	}
+	v1, err := s2.GetVector(1)
+	if err != nil {
+		t.Fatalf("second committed insert must be visible: %v", err)
+	}
+	if v1[0] != 2 {
+		t.Fatalf("vec1 = %v, want [2 2 2 2]", v1)
+	}
+	if s2.meta.NodeCount != 2 {
+		t.Fatalf("NodeCount = %d, want 2", s2.meta.NodeCount)
+	}
+}
+
+func TestReplayStrayCommitIgnored(t *testing.T) {
+	// A lone WalTxnCommit with no preceding BEGIN must not panic or corrupt
+	// state. A following legacy unframed insert still applies normally.
+	dir := t.TempDir()
+	s := openStoreForReplay(t, dir, 4, 8)
+
+	appendRaw(t, s, WalTxnCommit, nil) // stray commit, no open txn
+	appendRaw(t, s, WalInsert, EncodeInsert(0, 0, []float32{7, 7, 7, 7}, 0, "doc-0"))
+	if err := s.wal.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	simulateCrash(s)
+
+	s2 := openStoreForReplay(t, dir, 4, 8)
+	defer s2.Close()
+
+	vec, err := s2.GetVector(0)
+	if err != nil {
+		t.Fatalf("legacy insert after stray commit must apply: %v", err)
+	}
+	if vec[0] != 7 {
+		t.Fatalf("vec = %v, want [7 7 7 7]", vec)
+	}
+	if s2.meta.NodeCount != 1 {
+		t.Fatalf("NodeCount = %d, want 1 (stray commit must not add a node)", s2.meta.NodeCount)
+	}
+}
+
 func TestWALContinueLSNAfterReopen(t *testing.T) {
 	dir := t.TempDir()
 	w, err := OpenWAL(dir)

--- a/internal/core/vectorindex/mmap_wal_test.go
+++ b/internal/core/vectorindex/mmap_wal_test.go
@@ -14,23 +14,23 @@ func TestWALAppendAndReplay(t *testing.T) {
 	requireNoError(t, err)
 
 	vec := []float32{1.0, 2.0, 3.0}
-	lsn1, err := w.Append(WalInsert, EncodeInsert(0, 1, vec, 3.74, "doc-0"), false)
+	lsn1, err := w.Append(WalInsert, EncodeInsert(0, 1, vec, 3.74, "doc-0"))
 	requireNoError(t, err)
 	assert.Equal(t, uint64(1), lsn1)
 
-	lsn2, err := w.Append(WalSetNeighbors, EncodeSetNeighbors(0, 0, []uint64{1, 2, 3}), false)
+	lsn2, err := w.Append(WalSetNeighbors, EncodeSetNeighbors(0, 0, []uint64{1, 2, 3}))
 	requireNoError(t, err)
 	assert.Equal(t, uint64(2), lsn2)
 
-	lsn3, err := w.Append(WalSetEntry, EncodeSetEntry(0, 1), false)
+	lsn3, err := w.Append(WalSetEntry, EncodeSetEntry(0, 1))
 	requireNoError(t, err)
 	assert.Equal(t, uint64(3), lsn3)
 
-	lsn4, err := w.Append(WalSetNorm, EncodeSetNorm(0, 5.5), false)
+	lsn4, err := w.Append(WalSetNorm, EncodeSetNorm(0, 5.5))
 	requireNoError(t, err)
 	assert.Equal(t, uint64(4), lsn4)
 
-	lsn5, err := w.Append(WalDelete, EncodeDelete(0, "doc-0"), false)
+	lsn5, err := w.Append(WalDelete, EncodeDelete(0, "doc-0"))
 	requireNoError(t, err)
 	assert.Equal(t, uint64(5), lsn5)
 
@@ -89,7 +89,7 @@ func TestWALReplayAfterLSN(t *testing.T) {
 	requireNoError(t, err)
 
 	for i := 0; i < 10; i++ {
-		_, err := w.Append(WalSetNorm, EncodeSetNorm(uint64(i), float32(i)), false)
+		_, err := w.Append(WalSetNorm, EncodeSetNorm(uint64(i), float32(i)))
 		requireNoError(t, err)
 	}
 	requireNoError(t, w.Close())
@@ -114,7 +114,7 @@ func TestWALTruncatedRecord(t *testing.T) {
 	requireNoError(t, err)
 
 	for i := 0; i < 5; i++ {
-		_, err := w.Append(WalSetNorm, EncodeSetNorm(uint64(i), float32(i)), false)
+		_, err := w.Append(WalSetNorm, EncodeSetNorm(uint64(i), float32(i)))
 		requireNoError(t, err)
 	}
 	requireNoError(t, w.Close())
@@ -143,7 +143,7 @@ func TestWALCorruptedCRC(t *testing.T) {
 	requireNoError(t, err)
 
 	for i := 0; i < 5; i++ {
-		_, err := w.Append(WalSetNorm, EncodeSetNorm(uint64(i), float32(i)), false)
+		_, err := w.Append(WalSetNorm, EncodeSetNorm(uint64(i), float32(i)))
 		requireNoError(t, err)
 	}
 	requireNoError(t, w.Close())
@@ -326,7 +326,7 @@ func openStoreForReplay(t *testing.T, dir string, dim, m int) *MmapStore {
 // hand-build txn-framed WAL streams.
 func appendRaw(t *testing.T, s *MmapStore, typ WalRecordType, payload []byte) {
 	t.Helper()
-	if _, err := s.wal.Append(typ, payload, true); err != nil {
+	if _, err := s.wal.Append(typ, payload); err != nil {
 		t.Fatalf("append %d: %v", typ, err)
 	}
 }
@@ -480,15 +480,15 @@ func TestWALContinueLSNAfterReopen(t *testing.T) {
 	w, err := OpenWAL(dir)
 	requireNoError(t, err)
 
-	_, err = w.Append(WalSetNorm, EncodeSetNorm(0, 1.0), false)
+	_, err = w.Append(WalSetNorm, EncodeSetNorm(0, 1.0))
 	requireNoError(t, err)
-	_, err = w.Append(WalSetNorm, EncodeSetNorm(1, 2.0), false)
+	_, err = w.Append(WalSetNorm, EncodeSetNorm(1, 2.0))
 	requireNoError(t, err)
 	requireNoError(t, w.Close())
 
 	w2, err := OpenWAL(dir)
 	requireNoError(t, err)
-	lsn, err := w2.Append(WalSetNorm, EncodeSetNorm(2, 3.0), false)
+	lsn, err := w2.Append(WalSetNorm, EncodeSetNorm(2, 3.0))
 	requireNoError(t, err)
 	assert.Equal(t, uint64(3), lsn)
 	requireNoError(t, w2.Close())

--- a/internal/core/vectorindex/store.go
+++ b/internal/core/vectorindex/store.go
@@ -43,6 +43,7 @@ type NodeStore interface {
 }
 
 // BatchableStore defines optional batching support for NodeStore implementations.
+// TODO(Phase 4): remove — superseded by the txnBegin/txnCommit/txnAbort primitive.
 type BatchableStore interface {
 	BeginBatch()
 	CommitBatch(sync bool) error

--- a/internal/core/vectorindex/store.go
+++ b/internal/core/vectorindex/store.go
@@ -42,15 +42,6 @@ type NodeStore interface {
 	Close() error
 }
 
-// BatchableStore defines optional batching support for NodeStore implementations.
-// TODO(Phase 4): remove — superseded by the txnBegin/txnCommit/txnAbort primitive.
-type BatchableStore interface {
-	BeginBatch()
-	CommitBatch(sync bool) error
-	DiscardBatch()
-	BatchDepth() int
-}
-
 // --- encoding helpers ---
 
 func encodeFloat32s(v []float32) []byte {

--- a/internal/core/vectorindex/store.go
+++ b/internal/core/vectorindex/store.go
@@ -33,6 +33,12 @@ type NodeStore interface {
 	GetNorm(id uint64) (float32, error)
 	// SetNorm stores a precomputed L2 norm for a node's vector.
 	SetNorm(id uint64, norm float32) error
+	// Transaction primitive (internal). Batch.Commit brackets a group of
+	// mutations as one durable, crash-atomic unit. MemNodeStore implements
+	// these as no-ops (no durability target); MmapStore frames them in the WAL.
+	txnBegin() error
+	txnCommit() error
+	txnAbort(cause error) error
 	Close() error
 }
 

--- a/internal/core/vectorindex/upsert_test.go
+++ b/internal/core/vectorindex/upsert_test.go
@@ -36,7 +36,7 @@ func TestHNSWUpsertEntryPoint(t *testing.T) {
 	assert.Len(t, results, 2, "should have 2 nodes total")
 }
 
-func TestHNSWInsertBatchDuplicateDocId(t *testing.T) {
+func TestBatchDuplicateDocIdUpsert(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store)
 
@@ -59,7 +59,7 @@ func TestHNSWInsertBatchDuplicateDocId(t *testing.T) {
 	assert.InDelta(t, 0.0, results[0].Distance, 0.01)
 }
 
-func TestHNSWInsertBatchPartialFailure(t *testing.T) {
+func TestBatchPartialFailure(t *testing.T) {
 	es := newErrorStore()
 	idx := NewHNSWIndex(es)
 

--- a/internal/core/vectorindex/upsert_test.go
+++ b/internal/core/vectorindex/upsert_test.go
@@ -40,12 +40,11 @@ func TestHNSWInsertBatchDuplicateDocId(t *testing.T) {
 	store := NewMemNodeStore()
 	idx := NewHNSWIndex(store)
 
-	items := []InsertItem{
-		{DocId: "doc1", Vector: []float32{1, 0, 0}},
-		{DocId: "doc2", Vector: []float32{0, 1, 0}},
-		{DocId: "doc1", Vector: []float32{0, 0, 1}}, // duplicate
-	}
-	err := idx.InsertBatch(items)
+	b := idx.NewBatch()
+	b.Put("doc1", []float32{1, 0, 0})
+	b.Put("doc2", []float32{0, 1, 0})
+	b.Put("doc1", []float32{0, 0, 1}) // duplicate — last-op-wins coalescing
+	err := b.Commit()
 	assert.NoError(t, err)
 
 	// Should have exactly 2 nodes


### PR DESCRIPTION
## Summary

Replaces the vectorindex batch subsystem — whose interface and implementation were both poor — with a real, crash-atomic `Batch` type. `Put`/`Delete` buffer (coalesced); the graph is touched **only at `Commit`**, inside one all-or-nothing WAL transaction. Single `Insert`/`Delete` become thin 1-op-batch wrappers. All the old machinery is deleted.

### Before → After
| | Before | After |
|---|---|---|
| Mutation unit | implicit `batchMode`/`batchDepth` global state + `BatchableStore` runtime type-assertions in HNSW | a real `Batch`: `NewBatch / Put / Delete / Commit / Discard / Len` |
| Semantics | "batch" = deferred fsync only (no atomicity/isolation); `DiscardBatch` couldn't roll back | buffer-then-commit; **crash-atomic** all-or-nothing; clean discard |
| `CommitBatch(sync bool)` | dead bool param (always `true`); duplicated `syncMode` | removed; durability is intrinsic to `Commit` |

### Bugs fixed (all latent in the old design)
- **Corruptible depth counter** — `InsertBatch` + a concurrent `Insert` could drive `batchDepth` negative and permanently desync (the old `DiscardBatch` set it to `0` instead of decrementing).
- **Data race** — `BatchDepth()` read shared state without the lock.
- **Non-atomic upsert** — old `Insert` deleted the existing node *before* the batch began (durable immediately); an insert failure left "old gone, new missing". Now delete-old + insert-new run in the **same** transaction.
- **"Discard can't roll back"** — uncommitted transactions are now discarded on WAL replay.

## How it works

- **WAL framing:** new `WalTxnBegin`/`WalTxnCommit` markers. The fsync of the COMMIT marker is the single commit point. Replay buffers a framed transaction and applies it only on COMMIT; an unterminated trailing transaction is discarded.
- **Store transaction primitive** (`txnBegin`/`txnCommit`/`txnAbort` on `NodeStore`, no runtime type-assertion). `MemNodeStore` implements them as no-ops.
- **Faulted state:** a mid-commit I/O error faults the store, no COMMIT is written, and a graceful `Close()` skips checkpoint so reopen recovers to the pre-batch state.
- **Transactional idmap:** `docId↔nodeId` mappings are journaled (`WalSetMapping`/`WalDeleteMapping`) and reconstructed on replay; `idmap.dat` is now purely a checkpoint cache. An aborted/crashed batch leaves no stale mapping.

Built and reviewed across 6 phases (WAL framing → store primitive → `Batch` + index migration → legacy deletion → benchmarks → transactional idmap). Each phase passed independent spec-compliance + code-quality review.

## Test plan / verification
- [x] `go test ./internal/core/vectorindex/ -count=1` — green
- [x] `go test ./internal/core/vectorindex/ -race -count=1` — green (concurrent batch commits + searchers; snapshot-isolation test asserts Search only ever sees the pre- or post-commit state)
- [x] `gofmt -l` empty, `go vet` clean
- [x] Crash-atomicity: committed batch survives crash; unterminated/aborted batch discarded on reopen; mid-commit fault → faulted + reopen-clean; transactional-idmap leaves no phantom mapping
- [x] Coalescing (Put×2 / Put→Delete / Delete→Put / Delete-absent) and cross-commit atomic upsert
- [x] Grep gates: `BatchableStore`/`BeginBatch`/`CommitBatch`/`DiscardBatch`/`BatchDepth`/`batchMode`/`SyncMode`/`InsertBatch`/`InsertItem` → 0 hits

## Performance & recall (benchstat vs `main`, MemNodeStore)
- Insert **−0.8%**, Search **−1.2%** (both statistically-significant improvements) — no regression.
- Recall@10 = **1.0000**, unchanged (graph construction is byte-faithful to the old algorithm).
- New `BenchmarkHNSWBatchInsert` / `BenchmarkHNSWDelete` added as baselines.

## Notes
- No production consumers outside this package (only `cmd/insert-analysis` + `cmd/gen-testdata` tools), so the public API was redesigned without a compat shim.
- Independent of #72 (NEON dot kernel) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)