### PR TITLE
perf(vectorstore): trim per-iteration data in the two heaviest race/equivalence tests

### DIFF
--- a/core/vectorstore/batch_test.go
+++ b/core/vectorstore/batch_test.go
@@ -57,24 +57,25 @@ func TestBatch_DurableSearchableReopen(t *testing.T) {
 // TestBatch_EquivalentToSinglePut: a batch of N Puts yields the same per-id state
 // as N single Puts over identical data.
 func TestBatch_EquivalentToSinglePut(t *testing.T) {
+	const n = 60 // enough to prove batch ≡ single-Put; the single-Put control pays n fsyncs
 	build := func(useBatch bool) *Store {
 		s := openTestStore(t, Cosine)
 		rng := rand.New(rand.NewSource(7))
 		if useBatch {
 			b := s.NewBatch()
-			for i := 0; i < 150; i++ {
+			for i := 0; i < n; i++ {
 				b.Put("d-"+itoa(i), batchRandVec(rng, 16), Payload{"k": StringValue(itoa(i))})
 			}
 			requireNoError(t, b.Commit())
 		} else {
-			for i := 0; i < 150; i++ {
+			for i := 0; i < n; i++ {
 				requireNoError(t, s.Put("d-"+itoa(i), batchRandVec(rng, 16), Payload{"k": StringValue(itoa(i))}))
 			}
 		}
 		return s
 	}
 	sb, ss := build(true), build(false)
-	for i := 0; i < 150; i++ {
+	for i := 0; i < n; i++ {
 		id := "d-" + itoa(i)
 		vb, _, fb, _ := sb.Get(id)
 		vs, _, fs, _ := ss.Get(id)

--- a/core/vectorstore/merge_trigger_test.go
+++ b/core/vectorstore/merge_trigger_test.go
@@ -173,8 +173,13 @@ func TestAutoMerge_CloseRaceNoPanic(t *testing.T) {
 		s.mcfg.Fanout = 2
 		s.mcfg.MergeFloor = 0.99 // almost everything is delete-driven bait
 
-		// Build a few indexed sealed segments so Compact has real merge candidates.
-		for i := 0; i < 12; i++ {
+		// Build a couple of indexed sealed segments so Compact has real merge
+		// candidates: 6 docs / maxSegSize=3 → 2 segments, which is exactly Fanout=2,
+		// and MergeFloor=0.99 makes them delete-driven bait — enough for Compact to
+		// launch a merge (and Add to the WaitGroup) so the Close race is exercised.
+		// Kept minimal per iteration: the race coverage is the iteration COUNT, not the
+		// per-iteration data volume (each store lifecycle pays a heavy FS tax on CI).
+		for i := 0; i < 6; i++ {
 			requireNoError(t, s.Put("d-"+itoa(i), []float32{float32(i), 1, 0, 0, 0, 0, 0, 0}, nil))
 		}
 		requireNoError(t, s.WaitForIndex())


### PR DESCRIPTION
Follow-up to #81. On main, the Windows vectorstore CI job is now ~4–5× faster (runner-normalized), but two tests still dominate the per-test profile. Both are trimmed by reducing **per-iteration data volume only** — iteration counts / race coverage unchanged.

## `TestAutoMerge_CloseRaceNoPanic` — 12 → 6 docs
Single largest vectorstore test on Windows CI (~28s on a slow runner, ~23% of the package) even at `-short`'s 20 iterations: each iteration opened a store+KV and built **12 docs / maxSegSize=3 = 4 sealed segments + graphs**.

The Close-vs-Compact `WaitGroup` race coverage is the **iteration count**, not the per-iteration data. 6 docs → **2 segments = exactly Fanout=2** (MergeFloor=0.99 bait), so `Compact()` still launches a merge and `Add`s to the WaitGroup — the race is still exercised. The original test relied on the same growth-trigger, just with 4 segments. Iterations unchanged (80 full / 20 short).

## `TestBatch_EquivalentToSinglePut` — 150 → 60
The single-Put control branch pays N fsyncs; 150 is more than needed to prove `batch ≡ single-Put`. Dropped to 60 via a named `const n`.

## Verification
- `TestAutoMerge_CloseRaceNoPanic`: full-mode 2.41s → **1.60s**; `-count=5 -short` stress clean (no panic, no flake).
- `TestBatch_EquivalentToSinglePut`: passes.
- Full `go test ./core/vectorstore/` green (7.96s); `gofmt` + `go vet` clean.
- Local delta is small (cheap SSD fsync); the AutoMerge halving is worth ~12–14s on the slow Windows runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)