### PR TITLE
fix(server): make internal/server tests pass on Windows (hang + handle leaks)

### DIFF
--- a/internal/server/coverage_test.go
+++ b/internal/server/coverage_test.go
@@ -67,8 +67,21 @@ func TestInitLog_File(t *testing.T) {
 
 // TestRun_DataStorageError tests the run() error path when data storage fails to open.
 func TestRun_DataStorageError(t *testing.T) {
-	conf.Get().Global.DataPath = "/dev/null/impossible"
+	// Block data-storage init portably by putting a FILE where the "data" DB dir is
+	// expected (same pattern as TestRun_IndexStorageError below).
+	//
+	// This previously set DataPath = "/dev/null/impossible": on POSIX that is
+	// uncreatable (/dev/null is a file, so a subdir under it fails with ENOTDIR), so
+	// run() failed fast at data init. On Windows there is no /dev/null device, so the
+	// path resolves to C:\dev\null\impossible — which IS creatable, so data init
+	// SUCCEEDED, run() fell through to starting the HTTP server and blocked forever
+	// (hanging `go test ./...` and littering C:\dev\null\impossible).
+	tempDir := t.TempDir()
+	conf.Get().Global.DataPath = tempDir
 	conf.Get().Server.CacheSize = 8 * 1024 * 1024
+
+	dataPath := filepath.Join(tempDir, "data")
+	assert.NoError(t, os.WriteFile(dataPath, []byte("blocker"), 0644))
 
 	err := run()
 	assert.Error(t, err)

--- a/internal/server/coverage_test.go
+++ b/internal/server/coverage_test.go
@@ -49,6 +49,7 @@ func TestInitLog_File(t *testing.T) {
 	conf.Get().Global.DataPath = tempDir
 
 	initLog()
+	defer closeLog() // release the lumberjack file handle before t.TempDir cleanup
 
 	assert.Equal(t, log.LstdFlags, log.Flags())
 

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -10,21 +10,45 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
+// activeLog is the file logger currently installed by initLog (nil when logging to
+// stdout). Tracked so closeLog can release its OS file handle. This matters on
+// Windows, where an open log file blocks its directory from being removed — e.g.
+// t.TempDir cleanup after Run()/initLog configured file logging under a temp dir.
+var activeLog *lumberjack.Logger
+
 func initLog() {
 	log.SetFlags(log.LstdFlags)
 
+	// Release any previously-installed file logger before replacing the output.
+	closeLog()
+
 	if conf.Get().Server.LoggingStdout {
 		log.SetOutput(os.Stdout)
-	} else {
-		dir := filepath.Join(conf.Get().Global.DataPath, "logs")
-		logFile := filepath.Join(dir, "server.log")
-
-		log.SetOutput(&lumberjack.Logger{
-			Filename:   logFile,
-			MaxSize:    50, // megabytes
-			MaxBackups: 3,
-			MaxAge:     28,   //days
-			Compress:   true, // disabled by default
-		})
+		return
 	}
+
+	dir := filepath.Join(conf.Get().Global.DataPath, "logs")
+	logFile := filepath.Join(dir, "server.log")
+
+	lj := &lumberjack.Logger{
+		Filename:   logFile,
+		MaxSize:    50, // megabytes
+		MaxBackups: 3,
+		MaxAge:     28,   //days
+		Compress:   true, // disabled by default
+	}
+	log.SetOutput(lj)
+	activeLog = lj
+}
+
+// closeLog releases the active file logger's OS handle (if any) and reverts log
+// output to stderr. Safe to call when no file logger is active. Run() defers this
+// so a stopped server (or a failed startup) does not leave the log file open.
+func closeLog() {
+	if activeLog == nil {
+		return
+	}
+	log.SetOutput(os.Stderr)
+	_ = activeLog.Close()
+	activeLog = nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,6 +49,7 @@ func Run() {
 	defer cleanup()
 
 	initLog()
+	defer closeLog() // release the log file handle when the server stops
 
 	log.Println(strings.Repeat("=", 64))
 	log.Println("[Server] Starting haystack server...")
@@ -67,12 +68,19 @@ func run() error {
 		running.Shutdown()
 		return fmt.Errorf("error initializing data storage: %w", err)
 	}
+	// Close on EVERY return path (incl. the early-return startup-error paths below),
+	// not just the happy path: a failed startup otherwise leaks the open pebble
+	// handle, and on Windows an open handle blocks the data dir from being removed
+	// (e.g. t.TempDir cleanup in the run() error-path tests). Runs after the stores
+	// that use db are torn down (deferred LIFO, after the manual teardown below).
+	defer db.Close()
 
 	indexdb, err := storage.Open(filepath.Join(conf.Get().Global.DataPath, "index"), conf.Get().Server.CacheSize)
 	if err != nil {
 		running.Shutdown()
 		return fmt.Errorf("error initializing index storage: %w", err)
 	}
+	defer indexdb.Close()
 
 	mpsc := queue.NewMpsc("DBQueue")
 	mpsc.Start()
@@ -150,12 +158,8 @@ func run() error {
 
 	idAlloc.Close()
 
-	// DB could be closed safely now!
-	log.Println("[Server] Closing storage...")
-	db.Close()
-	indexdb.Close()
-	log.Println("[Server] Storage closed")
-
+	// db and indexdb are closed by the deferred Close() calls registered right after
+	// each storage.Open above (they also cover the early-return error paths).
 	log.Println("[Server] Haystack server stopped")
 	return nil
 }


### PR DESCRIPTION
Fixes the local-Windows `go test ./...` problems in `internal/server`. (This package is in the **root module**, which CI only tests on **Linux** — where none of this reproduces — so CI was green throughout; these are local-Windows DX + genuine resource-leak fixes.)

## 1. The hang (the reported symptom)

`TestRun_DataStorageError` set `DataPath = "/dev/null/impossible"` to make `run()` fail fast at data-storage init. On POSIX that's uncreatable (`/dev/null` is a file → `ENOTDIR`). **Windows has no `/dev/null` device**, so it resolves to `C:\dev\null\impossible`, which **is creatable** → data init succeeded, `run()` fell through to starting the HTTP server and blocked on `wg.Wait()` **forever** → `go test ./...` hangs, and `C:\dev\null\impossible` gets created.

Fixed by blocking data init **portably** (a file at `<tempDir>/data`, the pattern `TestRun_IndexStorageError` already uses).

## 2. Handle leaks (unmasked once the hang was gone)

With the hang gone, ~7 `TestRun_*` tests ran for the first time and failed at `t.TempDir()` cleanup on Windows (`"file is being used by another process"` — Windows won't delete a dir containing an open handle). Two sources:

- **pebble DB**: `run()` closed `db`/`indexdb` only on the happy path; every startup-error path returned after `running.Shutdown()` without closing the already-opened DB(s), leaking the WAL `.log` handle. → `defer db.Close()` / `defer indexdb.Close()` right after each successful `storage.Open` (covers every return path; replaces the manual happy-path closes).
- **lumberjack log**: `initLog()` installed a `lumberjack.Logger` and never closed it, leaking `<DataPath>/logs/server.log`. → track it in a package var + `closeLog()`; `Run()` defers it; `TestInitLog_File` closes it in cleanup.

## Result

`internal/server` now passes `-count=1` with **no hang and no cleanup failures** (verified 3× fresh + vet/gofmt clean; ~1.1s, was hanging forever). Same class of Windows-handle issue as #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)