### PR TITLE
perf(invertedindex): hand-roll codec hot paths (byte-identical) + add benchmarks

### DIFF
--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -2,7 +2,6 @@ package invertedindex
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -34,17 +33,41 @@ func parseId(key string) int {
 	return v
 }
 
+// appendInvertedKeyPrefix appends "<keyTypeRow><tableId>|<keyword>|" to b. Shared
+// by the prefix and full-key encoders; hand-rolled (vs fmt.Sprintf) because it is
+// on every Search/GetDocs/write/merge path.
+func (idx *Index) appendInvertedKeyPrefix(b []byte, tableId int, keyword string) []byte {
+	b = append(b, idx.keyTypeRow)
+	b = strconv.AppendInt(b, int64(tableId), 10)
+	b = append(b, '|')
+	b = append(b, keyword...)
+	b = append(b, '|')
+	return b
+}
+
 func (idx *Index) encodeInvertedSearchKey(tableId int, query string) []byte {
-	return []byte(fmt.Sprintf("%c%d|%s", idx.keyTypeRow, tableId, query))
+	// "<keyTypeRow><tableId>|<query>" (no trailing '|').
+	b := make([]byte, 0, 1+11+1+len(query))
+	b = append(b, idx.keyTypeRow)
+	b = strconv.AppendInt(b, int64(tableId), 10)
+	b = append(b, '|')
+	b = append(b, query...)
+	return b
 }
 
 func (idx *Index) encodeInvertedKeyPrefix(tableId int, keyword string) []byte {
-	return []byte(fmt.Sprintf("%c%d|%s|", idx.keyTypeRow, tableId, keyword))
+	b := make([]byte, 0, 1+11+1+len(keyword)+1)
+	return idx.appendInvertedKeyPrefix(b, tableId, keyword)
 }
 
 func (idx *Index) encodeInvertedKey(tableId int, keyword string, doccount int) []byte {
-	return []byte(fmt.Sprintf("%s%d|%d",
-		string(idx.encodeInvertedKeyPrefix(tableId, keyword)), doccount, time.Now().UnixMicro()))
+	// "<prefix><doccount>|<tick>" where tick is the current micros.
+	b := make([]byte, 0, 1+11+1+len(keyword)+1+11+1+19)
+	b = idx.appendInvertedKeyPrefix(b, tableId, keyword)
+	b = strconv.AppendInt(b, int64(doccount), 10)
+	b = append(b, '|')
+	b = strconv.AppendInt(b, time.Now().UnixMicro(), 10)
+	return b
 }
 
 func (idx *Index) decodeInvertedKey(key string) (int, string, int, string) {
@@ -54,28 +77,47 @@ func (idx *Index) decodeInvertedKey(key string) (int, string, int, string) {
 
 	key = key[1:]
 
-	parts := strings.Split(key, "|")
-	if len(parts) != 4 {
+	// Expect exactly "<tableId>|<keyword>|<doccount>|<tick>" (3 separators, no more).
+	// Parse by locating the separators instead of strings.Split, which allocates a
+	// []string on every row scanned by the merger.
+	i1 := strings.IndexByte(key, '|')
+	if i1 < 0 {
 		return InvalidId, "", 0, ""
 	}
+	i2 := strings.IndexByte(key[i1+1:], '|')
+	if i2 < 0 {
+		return InvalidId, "", 0, ""
+	}
+	i2 += i1 + 1
+	i3 := strings.IndexByte(key[i2+1:], '|')
+	if i3 < 0 {
+		return InvalidId, "", 0, ""
+	}
+	i3 += i2 + 1
+	if strings.IndexByte(key[i3+1:], '|') >= 0 {
+		return InvalidId, "", 0, "" // a 5th part — same rejection as the old len(parts)!=4
+	}
 
-	tableId := parseId(parts[0])
-	keyword := parts[1]
-	doccount, err := strconv.Atoi(parts[2])
+	tableId := parseId(key[:i1])
+	keyword := key[i1+1 : i2]
+	doccount, err := strconv.Atoi(key[i2+1 : i3])
 	if err != nil {
 		return InvalidId, "", 0, ""
 	}
-	tick := parts[3]
+	tick := key[i3+1:]
 
 	return tableId, keyword, doccount, tick
 }
 
 func (idx *Index) encodeNextTableIdKey() []byte {
-	return []byte(fmt.Sprintf("%c", idx.keyTypeNextId))
+	return []byte{idx.keyTypeNextId}
 }
 
 func (idx *Index) encodeTableKey(tableId int) []byte {
-	return []byte(fmt.Sprintf("%c%d", idx.keyTypeTable, tableId))
+	b := make([]byte, 0, 1+11)
+	b = append(b, idx.keyTypeTable)
+	b = strconv.AppendInt(b, int64(tableId), 10)
+	return b
 }
 
 func encodeTableValue(info TableInfo) []byte {
@@ -89,38 +131,29 @@ func encodeInvertedValue(docids []string) []byte {
 }
 
 func decodeInvertedValue(data []byte) []string {
-	// Each docid is a 8-byte string
-	if len(data)%8 != 0 || len(data) == 0 {
+	// Each docid is an 8-byte string.
+	if len(data) == 0 || len(data)%8 != 0 {
 		return []string{}
 	}
 
 	const size = 8
-	var chunks []string
-	for i := 0; i < len(data); i += size {
-		end := i + size
-		if end > len(data) {
-			end = len(data)
-		}
-		chunks = append(chunks, string(data[i:end]))
+	chunks := make([]string, 0, len(data)/size)
+	for i := 0; i+size <= len(data); i += size {
+		chunks = append(chunks, string(data[i:i+size]))
 	}
 	return chunks
 }
 
 func decodeInvertedValueStr(data string) []string {
-	// Each docid is a 8-byte string
-	if len(data)%8 != 0 || len(data) == 0 {
+	// Each docid is an 8-byte string.
+	if len(data) == 0 || len(data)%8 != 0 {
 		return []string{}
 	}
 
 	const size = 8
-	var chunks []string
-	for i := 0; i < len(data); i += size {
-		end := i + size
-		if end > len(data) {
-			end = len(data)
-		}
-		chunks = append(chunks, data[i:end])
+	chunks := make([]string, 0, len(data)/size)
+	for i := 0; i+size <= len(data); i += size {
+		chunks = append(chunks, data[i:i+size])
 	}
-
 	return chunks
 }

--- a/core/invertedindex/codec_bench_test.go
+++ b/core/invertedindex/codec_bench_test.go
@@ -1,0 +1,69 @@
+package invertedindex
+
+import (
+	"fmt"
+	"testing"
+)
+
+func benchIdx() *Index {
+	return &Index{
+		keyTypeRow:    DefaultKeyTypeRow,
+		keyTypeTable:  DefaultKeyTypeTable,
+		keyTypeNextId: DefaultKeyTypeNextId,
+	}
+}
+
+func benchValue(n int) []byte {
+	buf := make([]byte, 0, n*8)
+	for i := 0; i < n; i++ {
+		buf = append(buf, []byte(fmt.Sprintf("%08d", i))...)
+	}
+	return buf
+}
+
+// BenchmarkEncodeInvertedKey covers the per-row write/merge key encoder (the
+// double-fmt.Sprintf path).
+func BenchmarkEncodeInvertedKey(b *testing.B) {
+	idx := benchIdx()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = idx.encodeInvertedKey(7, "handleRequest", 42)
+	}
+}
+
+// BenchmarkEncodeInvertedSearchKey covers the per-Search key encoder.
+func BenchmarkEncodeInvertedSearchKey(b *testing.B) {
+	idx := benchIdx()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = idx.encodeInvertedSearchKey(7, "handlerequest")
+	}
+}
+
+// BenchmarkEncodeInvertedKeyPrefix covers the per-Search/GetDocs/remove prefix encoder.
+func BenchmarkEncodeInvertedKeyPrefix(b *testing.B) {
+	idx := benchIdx()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = idx.encodeInvertedKeyPrefix(7, "handleRequest")
+	}
+}
+
+// BenchmarkDecodeInvertedKey covers the per-row merge-scan key decoder (strings.Split).
+func BenchmarkDecodeInvertedKey(b *testing.B) {
+	idx := benchIdx()
+	key := string(idx.encodeInvertedKey(7, "handleRequest", 42))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _ = idx.decodeInvertedKey(key)
+	}
+}
+
+// BenchmarkDecodeInvertedValue covers the value decoder (50 docids).
+func BenchmarkDecodeInvertedValue(b *testing.B) {
+	v := benchValue(50)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = decodeInvertedValue(v)
+	}
+}

--- a/core/invertedindex/invertedindex.go
+++ b/core/invertedindex/invertedindex.go
@@ -34,10 +34,11 @@ func (idx *Index) Search(tableId int, query string, limit int, filterKeyword fun
 			return true
 		}
 
-		docids := decodeInvertedValue(value)
-		if len(docids) > 0 {
-			for _, docid := range docids {
-				results.DocIds[docid] = struct{}{}
+		// Iterate the packed 8-byte docids straight into the result set, avoiding
+		// the intermediate []string that decodeInvertedValue would allocate.
+		if len(value)%8 == 0 {
+			for i := 0; i < len(value); i += 8 {
+				results.DocIds[string(value[i:i+8])] = struct{}{}
 			}
 		}
 
@@ -63,8 +64,10 @@ func (idx *Index) GetDocs(tableId int, key string) SearchResult {
 	}
 
 	err := idx.db.Scan(idx.encodeInvertedKeyPrefix(tableId, key), func(key, value []byte) bool {
-		for _, docid := range decodeInvertedValue(value) {
-			results.DocIds[docid] = struct{}{}
+		if len(value)%8 == 0 {
+			for i := 0; i < len(value); i += 8 {
+				results.DocIds[string(value[i:i+8])] = struct{}{}
+			}
 		}
 		return true
 	})

--- a/core/invertedindex/invertedindex_internal.go
+++ b/core/invertedindex/invertedindex_internal.go
@@ -12,24 +12,26 @@ import (
 // documents and flush later.
 func (idx *Index) updateIndex(tableId int, docid string, keywords []string) {
 	cache := idx.getPendingWrite(tableId)
+	now := time.Now() // one timestamp for the whole update (per-keyword time.Now is hot)
 	for _, kw := range keywords {
 		// Add to write cache to merge with other documents and flush later. docid may be
 		// duplicated; however for performance we don't check for duplicates here — all
 		// duplicates will be merged later in the background.
 		cache.InvertedIndex[kw] = relatedDocs{
 			DocIds:    append(cache.InvertedIndex[kw].DocIds, docid),
-			UpdatedAt: time.Now(),
+			UpdatedAt: now,
 		}
 	}
 }
 
 func (idx *Index) removeIndex(tableId int, docid string, keywords []string) {
 	w := idx.getPendingDelete(tableId)
+	now := time.Now()
 	for _, kw := range keywords {
 		// Add to delete cache to merge with other documents and flush later.
 		w.InvertedIndex[kw] = relatedDocs{
 			DocIds:    append(w.InvertedIndex[kw].DocIds, docid),
-			UpdatedAt: time.Now(),
+			UpdatedAt: now,
 		}
 	}
 }


### PR DESCRIPTION
Benchmark-driven optimization of the `invertedindex` codec / write-cache hot paths. **Output is byte-identical** (on-disk keys and values unchanged), so the existing codec/index tests pass unchanged — verified ×2.

These are the index's hottest paths: every `Search` encodes a key + decodes values; every indexed document hits `updateIndex`; every flush/merge row encodes a key and the merge scan decodes one.

## Codec micro-benchmark deltas (added in this PR — the package had none)

| Benchmark | Before | After |
|-----------|-------:|------:|
| `EncodeInvertedKey` (per write/merge row — was **double** `fmt.Sprintf`) | 190 ns, **7 allocs** | **37 ns, 1 alloc** (~5×) |
| `EncodeInvertedKeyPrefix` | 54 ns | **5.6 ns** (~10×) |
| `EncodeInvertedSearchKey` | 50 ns | **17 ns** (~3×) |
| `DecodeInvertedKey` (per merge-scan row — `strings.Split`) | 45 ns, 1 alloc | **17 ns, 0 allocs** (~2.7×) |
| `DecodeInvertedValue` (50 ids — no preallocation) | 940 ns, **57 allocs** | **563 ns, 51 allocs** (~1.7×) |

## Changes
- **Key encoders**: `fmt.Sprintf` → `strconv.AppendInt` + byte appends (shared `appendInvertedKeyPrefix` helper). `encodeInvertedKey` was doing two `fmt.Sprintf`s + intermediate `string()` conversions.
- **`decodeInvertedKey`**: `strings.Split` → manual separator scan returning substrings (no copy, no `[]string` alloc); preserves the exact "must be 4 parts" rejection.
- **`decodeInvertedValue`/`Str`**: preallocate the result slice (`make([]string, 0, len/8)`); drop dead bounds check.
- **`Search`/`GetDocs`**: iterate the packed 8-byte docids straight into the result map, dropping the intermediate `[]string` (one slice alloc per scanned value).
- **`updateIndex`/`removeIndex`**: hoist `time.Now()` out of the per-keyword loop (a doc with N keywords made N calls; now 1).
- Add `codec_bench_test.go` — the package's first benchmarks, as a regression guard.

`go test ./core/invertedindex/ -count=2` green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)