### PR TITLE
perf: cross-validated hot-path allocation cuts (tokenizer, documents, vectorstore)

### DIFF
--- a/core/documents/codec.go
+++ b/core/documents/codec.go
@@ -2,7 +2,6 @@ package documents
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -40,9 +39,24 @@ func parseCollectionID(key string) int {
 	return v
 }
 
+// appendDocKey builds "<prefix><collectionID>|<docid>" — the shape shared by the
+// document path/meta/words key encoders. Hand-rolled (vs fmt.Sprintf) since these
+// are on the per-document-save and per-search-result paths. The prefix byte is
+// appended raw (1 byte): the default prefixes are <128 so this is byte-identical
+// to the old "%c%d|%s" form, and a >=128 prefix never round-tripped anyway (decode
+// compares a single byte, while "%c" would UTF-8-encode it to two).
+func appendDocKey(prefix byte, collectionID int, docid string) []byte {
+	b := make([]byte, 0, 1+11+1+len(docid))
+	b = append(b, prefix)
+	b = strconv.AppendInt(b, int64(collectionID), 10)
+	b = append(b, '|')
+	b = append(b, docid...)
+	return b
+}
+
 // encodeDocumentPathKey encodes the key for a document path entry.
 func (s *Store) encodeDocumentPathKey(collectionID int, docid string) []byte {
-	return []byte(fmt.Sprintf("%c%d|%s", s.keyTypeDocPath, collectionID, docid))
+	return appendDocKey(s.keyTypeDocPath, collectionID, docid)
 }
 
 // decodeDocumentPathKey decodes a document path key, returning (collectionID, docid).
@@ -61,7 +75,7 @@ func (s *Store) decodeDocumentPathKey(key string) (int, string) {
 
 // encodeDocumentMetaKey encodes the key for a document metadata entry.
 func (s *Store) encodeDocumentMetaKey(collectionID int, docid string) []byte {
-	return []byte(fmt.Sprintf("%c%d|%s", s.keyTypeDocMeta, collectionID, docid))
+	return appendDocKey(s.keyTypeDocMeta, collectionID, docid)
 }
 
 // decodeDocumentMetaKey decodes a document metadata key, returning (collectionID, docid).
@@ -94,7 +108,7 @@ func decodeDocumentMetaValue(data []byte) (*Document, error) {
 
 // encodeDocumentWordsKey encodes the key for a document words entry.
 func (s *Store) encodeDocumentWordsKey(collectionID int, docid string) []byte {
-	return []byte(fmt.Sprintf("%c%d|%s", s.keyTypeDocWords, collectionID, docid))
+	return appendDocKey(s.keyTypeDocWords, collectionID, docid)
 }
 
 // decodeDocumentWordsKey decodes a document words key, returning (collectionID, docid).
@@ -126,7 +140,10 @@ func decodeDocumentWordsValue(data string) []string {
 
 // encodeMetaKey encodes the key for a collection metadata entry.
 func (s *Store) encodeMetaKey(collectionID int) []byte {
-	return []byte(fmt.Sprintf("%c%d", s.keyTypeDocCollection, collectionID))
+	b := make([]byte, 0, 1+11)
+	b = append(b, s.keyTypeDocCollection)
+	b = strconv.AppendInt(b, int64(collectionID), 10)
+	return b
 }
 
 // encodeFTMetaValue serialises a collection record as JSON.

--- a/core/documents/codec_bench_test.go
+++ b/core/documents/codec_bench_test.go
@@ -1,0 +1,51 @@
+package documents
+
+import "testing"
+
+// TestEncodeDocKeyGolden locks the exact on-disk key bytes, proving the hand-rolled
+// builders are byte-identical to the previous fmt.Sprintf("%c%d|%s", ...) form
+// (default prefixes 10/13 are <128, so "%c" emitted the raw byte).
+func TestEncodeDocKeyGolden(t *testing.T) {
+	s := benchStore()
+	if got, want := string(s.encodeDocumentPathKey(42, "src/a.go")), "\x0d42|src/a.go"; got != want {
+		t.Errorf("path key = %q, want %q", got, want)
+	}
+	if got, want := string(s.encodeDocumentMetaKey(-3, "x")), "\x0c-3|x"; got != want {
+		t.Errorf("meta key = %q, want %q", got, want)
+	}
+	if got, want := string(s.encodeDocumentWordsKey(0, "")), "\x0b0|"; got != want {
+		t.Errorf("words key = %q, want %q", got, want)
+	}
+	if got, want := string(s.encodeMetaKey(7)), "\x0a7"; got != want {
+		t.Errorf("meta key = %q, want %q", got, want)
+	}
+}
+
+func benchStore() *Store {
+	return &Store{
+		keyTypeDocCollection: DefaultKeyTypeDocCollection,
+		keyTypeDocWords:      DefaultKeyTypeDocWords,
+		keyTypeDocMeta:       DefaultKeyTypeDocMeta,
+		keyTypeDocPath:       DefaultKeyTypeDocPath,
+	}
+}
+
+func BenchmarkEncodeDocumentPathKey(b *testing.B) {
+	s := benchStore()
+	b.ReportAllocs()
+	var sink []byte
+	for i := 0; i < b.N; i++ {
+		sink = s.encodeDocumentPathKey(42, "src/server/handler.go")
+	}
+	_ = sink
+}
+
+func BenchmarkEncodeMetaKey(b *testing.B) {
+	s := benchStore()
+	b.ReportAllocs()
+	var sink []byte
+	for i := 0; i < b.N; i++ {
+		sink = s.encodeMetaKey(42)
+	}
+	_ = sink
+}

--- a/core/tokenizer/ascii_tokenizer.go
+++ b/core/tokenizer/ascii_tokenizer.go
@@ -27,10 +27,13 @@ func (t *ASCIITokenizer) TokenizeForIndex(str string) []string {
 		uniqueWords[strings.ToLower(word)] = struct{}{}
 	}
 
+	var splitBuf []string
 	for _, word := range words {
-		camelSplited := CamelSnakeSplit(word)
+		// Reuse splitBuf across words: the sub-tokens are slices of word and are
+		// copied into uniqueWords by pushWord, so they need not outlive this loop.
+		splitBuf = camelSnakeSplitInto(splitBuf[:0], word)
 
-		for _, word := range camelSplited {
+		for _, word := range splitBuf {
 			pushWord(word)
 		}
 	}

--- a/core/tokenizer/camel_snake_split.go
+++ b/core/tokenizer/camel_snake_split.go
@@ -12,16 +12,28 @@ import (
 // 5. beginHANDLEUpdate_document => beginHANDLEUpdate_document, HANDLEUpdate_document, Update_document, document
 // 6. BEGINHandleUpdate_document => BEGINHandleUpdate_document, HandleUpdate_document, Update_document, document
 func CamelSnakeSplit(s string) []string {
-	s = strings.Trim(s, ".-_")
-	if len(s) == 0 {
+	r := camelSnakeSplitInto(nil, s)
+	if r == nil {
 		return []string{}
 	}
+	return r
+}
 
-	var result []string
+// camelSnakeSplitInto appends the camel/snake sub-tokens of s to dst and returns
+// the extended slice (dst is returned unchanged when s is empty). The sub-tokens
+// are slices of s (no copy), so this lets hot callers reuse one buffer across many
+// tokens instead of allocating a fresh result slice per token. CamelSnakeSplit is
+// the allocating convenience wrapper.
+func camelSnakeSplitInto(dst []string, s string) []string {
+	s = strings.Trim(s, ".-_")
+	if len(s) == 0 {
+		return dst
+	}
+
 	var last = rune(s[0])
 	for i, r := range s {
 		if i == 0 {
-			result = append(result, s)
+			dst = append(dst, s)
 			continue
 		}
 
@@ -43,8 +55,8 @@ func CamelSnakeSplit(s string) []string {
 		if len(sub) < 3 {
 			break
 		}
-		result = append(result, sub)
+		dst = append(dst, sub)
 	}
 
-	return result
+	return dst
 }

--- a/core/vectorstore/graphstore.go
+++ b/core/vectorstore/graphstore.go
@@ -95,6 +95,23 @@ func (g *segGraphStore) GetNeighbors(id uint64, layer int) ([]uint64, error) {
 	return cp, nil
 }
 
+// getNeighborsRef returns the layer slice without copying (read-only; see interface).
+// A sealed segment's graph is immutable once searched, so no lock is needed.
+//
+// The returned slice is owned Go heap, NOT mmap. Only the segment's VECTORS
+// (vectors.dat) are mmap'd — those are resolved separately via GetVectorRef. The
+// neighbor TOPOLOGY lives in graph-<name>.dat, which openGraphFile reads into a heap
+// buffer (readWholeFile uses ReadAt, not mmap) and decodes into fresh make([]uint64)
+// slices; segGraphStore.neighbors is []map[int][]uint64 (a Go map can't alias mmap).
+// The graph is built-once / read-only thereafter and the search holds this store for
+// its whole duration, so the ref cannot be reallocated, mutated, or unmapped.
+func (g *segGraphStore) getNeighborsRef(id uint64, layer int) []uint64 {
+	if id >= uint64(len(g.neighbors)) || g.neighbors[id] == nil {
+		return nil
+	}
+	return g.neighbors[id][layer]
+}
+
 func (g *segGraphStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error {
 	if id >= uint64(len(g.neighbors)) || g.neighbors[id] == nil {
 		return fmt.Errorf("segGraphStore: SetNeighbors on unknown node %d", id)

--- a/core/vectorstore/graphstore_test.go
+++ b/core/vectorstore/graphstore_test.go
@@ -216,3 +216,23 @@ func TestSegGraphStore_MemEquivalence(t *testing.T) {
 		}
 	}
 }
+
+// TestSegGraphStore_getNeighborsRef_Guard covers getNeighborsRef's guard branch
+// (out-of-range id / nil-neighbors node) that the search tests never hit, since
+// search only ever passes valid node ids.
+func TestSegGraphStore_getNeighborsRef_Guard(t *testing.T) {
+	g := &segGraphStore{neighbors: []map[int][]uint64{nil}} // node 0 present but nil
+
+	if got := g.getNeighborsRef(5, 0); got != nil { // id >= len(neighbors)
+		t.Errorf("getNeighborsRef(out-of-range) = %v, want nil", got)
+	}
+	if got := g.getNeighborsRef(0, 0); got != nil { // neighbors[0] == nil
+		t.Errorf("getNeighborsRef(nil node) = %v, want nil", got)
+	}
+
+	g.neighbors[0] = map[int][]uint64{0: {7, 8}}
+	got := g.getNeighborsRef(0, 0)
+	if len(got) != 2 || got[0] != 7 || got[1] != 8 {
+		t.Errorf("getNeighborsRef(valid) = %v, want [7 8]", got)
+	}
+}

--- a/core/vectorstore/hnsw.go
+++ b/core/vectorstore/hnsw.go
@@ -628,10 +628,7 @@ func (h *hnswIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 			break
 		}
 
-		neighbors, err := h.store.GetNeighbors(c.id, layer)
-		if err != nil {
-			return nil, err
-		}
+		neighbors := h.store.getNeighborsRef(c.id, layer)
 
 		for _, nbId := range neighbors {
 			if visited.seen(nbId) {
@@ -656,11 +653,9 @@ func (h *hnswIndex) searchLayer(query []float32, entryId uint64, ef int, layer i
 	}
 
 	// Collect results.
-	out := make([]distItem, results.Len())
-	for i := range out {
-		out[i] = (*results)[i]
-	}
-	return out, nil
+	// results (resultsBuf) is a local heap, unused after this return — hand back its
+	// backing slice directly instead of copying it out.
+	return *results, nil
 }
 
 // searchLayerFiltered is searchLayer with an optional member gate
@@ -720,10 +715,7 @@ func (h *hnswIndex) searchLayerFiltered(query []float32, entryId uint64, ef int,
 			break
 		}
 
-		neighbors, err := h.store.GetNeighbors(c.id, layer)
-		if err != nil {
-			return nil, err
-		}
+		neighbors := h.store.getNeighborsRef(c.id, layer)
 
 		for _, nbId := range neighbors {
 			if visited.seen(nbId) {
@@ -755,11 +747,9 @@ func (h *hnswIndex) searchLayerFiltered(query []float32, entryId uint64, ef int,
 		}
 	}
 
-	out := make([]distItem, results.Len())
-	for i := range out {
-		out[i] = (*results)[i]
-	}
-	return out, nil
+	// results (resultsBuf) is a local heap, unused after this return — hand back its
+	// backing slice directly instead of copying it out.
+	return *results, nil
 }
 
 // selectNeighborsHeuristic selects up to M neighbors using the heuristic

--- a/core/vectorstore/memgraphstore.go
+++ b/core/vectorstore/memgraphstore.go
@@ -118,6 +118,19 @@ func (m *memGraphStore) GetNeighbors(id uint64, layer int) ([]uint64, error) {
 	return cp, nil
 }
 
+// getNeighborsRef returns the layer slice without copying (read-only; see interface).
+// SetNeighbors replaces the slice rather than editing in place, so a returned ref
+// stays valid even if the node is later updated.
+func (m *memGraphStore) getNeighborsRef(id uint64, layer int) []uint64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	layers, ok := m.neighbors[id]
+	if !ok {
+		return nil
+	}
+	return layers[layer]
+}
+
 func (m *memGraphStore) SetNeighbors(id uint64, layer int, neighbors []uint64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/core/vectorstore/nodestore.go
+++ b/core/vectorstore/nodestore.go
@@ -19,6 +19,12 @@ type graphNodeStore interface {
 	PutNode(id uint64, level int, vector []float32, docId int64) error
 	DeleteNode(id uint64) error
 	GetNeighbors(id uint64, layer int) ([]uint64, error)
+	// getNeighborsRef returns the node's layer neighbor slice WITHOUT copying, for
+	// read-only consumers on the search path (searchLayer/searchLayerFiltered). The
+	// caller MUST NOT mutate or retain the slice. Safe because graphs are mutated
+	// only single-threaded during build and are immutable once searched (and
+	// memGraphStore mutations replace the slice rather than editing it in place).
+	getNeighborsRef(id uint64, layer int) []uint64
 	SetNeighbors(id uint64, layer int, neighbors []uint64) error
 	GetEntryPoint() (uint64, int, error)
 	SetEntryPoint(id uint64, maxLayer int) error


### PR DESCRIPTION
A perf hunt across `core/` hot paths. **Every finding was cross-validated** — a before/after micro/macro-benchmark for the win, plus a correctness test (byte-identical output or unchanged search recall). Two candidates were **rejected by the benchmark** (see bottom) rather than shipped.

## Wins (each measured + correctness-verified)

### 1. vectorstore — HNSW search neighbor copy (the big one)
`searchLayer`/`searchLayerFiltered` `make+copy`'d each candidate's neighbor slice (a memprofile put it at 68 of 87 search allocs) and cloned the local result heap on return. Both are read-only/throwaway, and search-path graphs are immutable (or single-threaded during build), so: added `getNeighborsRef` (read-only, no copy) for the two search functions — the copying `GetNeighbors` stays for the mutating insert/prune callers — and return the result heap directly.
- `BenchmarkSearch_128_10k`: **87 → 18 allocs/op (−79%)**, 29120 → 10710 B/op (−63%), **recall@10 unchanged (0.7242)**. Full vectorstore suite green incl. mem-vs-seg equivalence.

### 2. documents — codec key builders
`encodeDocumentPathKey/MetaKey/WordsKey/MetaKey` used `fmt.Sprintf` on the per-document-save AND per-search-result paths. Hand-rolled with `strconv.AppendInt` + byte appends.
- `BenchmarkEncodeDocumentPathKey`: **65 ns/2 allocs → 18 ns/1 alloc (3.6×)**. Byte-identical (golden test added; prefixes <128, and ≥128 never round-tripped anyway). Round-trip tests pass.

### 3. tokenizer — reuse the camel/snake split buffer
`ASCIITokenizer.TokenizeForIndex` allocated a fresh slice per word in `CamelSnakeSplit` (~24% of its allocs). Added an append-into variant; the index loop reuses one buffer.
- `BenchmarkASCIITokenizeForIndex`: **116 → 77 allocs/op (−34%)**. Byte-identical splits (fidelity tests pass).

## Rejected by cross-validation (the point of measuring)
- **idtable `GetId` "hoist `string(key)`"** (a plausible static suggestion): the benchmark showed it made the *hot path WORSE* (1→2 allocs) by defeating the compiler's `m[string(b)]` no-alloc map-key optimization. The hit path was already 1 alloc. **Reverted.**
- **`CamelSnakeSplit` `make([]string,0,4)` preallocation**: same alloc count, *more* memory (most words are single-token). **Reverted.**

## Notes
- `-race` isn't available on this dev box (windows/arm64); the vectorstore change is covered by the full suite + the mem-vs-seg equivalence/recall tests, and the safety argument (immutable-when-searched, single-threaded build, replace-not-mutate) holds. CI runs the suite on Linux.
- Added first benchmarks to `documents` (codec) as regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)