### PR TITLE
docs: add AGENTS.md working principles + CLAUDE.md (read on startup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md — Working Principles for AI Agents
+
+Mandatory working principles for any AI agent (Claude Code, etc.) operating in this
+repository. They override default behavior. **Read them at the start of every session.**
+
+## 1. Infrastructure: ship any real benefit, however small
+
+This work is infrastructure. If a change produces a **real, correct benefit — even a
+tiny one — do it.** Do not skip a sound improvement because the measured win looks
+marginal, and do not abandon the straightforward improvement in favor of a "bigger
+lever" or an easier alternative.
+
+- Don't reject a fix as "not worth it" on size alone — a small, real reduction in work
+  (fewer fsyncs, fewer allocations, less I/O, less churn) is worth making on its own.
+- Don't substitute a different, larger-scope change for the obvious small one.
+- Do the complete job: sweep **all** the safe cases, not just the big ones.
+
+## 2. Verify at the source — no substitute environment or method
+
+**Verify a problem, and its fix, WHERE the problem actually occurs.** Do not use a
+proxy environment or a substitute method and then draw conclusions from it.
+
+- If the problem is on CI (a specific OS/runner), reproduce and measure **on that CI**.
+  A local machine is NOT a valid stand-in — e.g. a local disk/AV setup behaves nothing
+  like a hosted Windows runner, so a local measurement of an AV/fsync-bound effect
+  proves nothing about CI.
+- Don't be clever or presumptuous. Go to where the issue is, reproduce it there, and
+  validate the fix there.
+- Do not propose unrequested "alternative approaches" in place of verifying the real
+  thing at its source.
+
+When the two meet: make the real infrastructure improvement (Principle 1) **and** prove
+it in the real failing environment (Principle 2) — never in a convenient substitute.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+**MANDATORY — read [AGENTS.md](AGENTS.md) at the start of every session.** It defines
+the working principles for AI agents in this repository and overrides default behavior.
+
+@AGENTS.md


### PR DESCRIPTION
Adds `AGENTS.md` with two mandatory working principles for AI agents, and a `CLAUDE.md` that references + `@`-imports it so it loads on session startup.

**1. Infrastructure — ship any real benefit, however small.** Don't skip a sound improvement because the win looks marginal; don't substitute a bigger-lever / alternative for the obvious fix; do the complete job (sweep all safe cases).

**2. Verify at the source — no substitute environment or method.** Reproduce and measure a problem (and its fix) WHERE it occurs — e.g. on the actual CI runner, never via a local proxy (a local disk/AV setup proves nothing about a hosted Windows runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)