### PR TITLE
test(vectorstore): batch incidental setup puts + add AGENTS.md principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — Working Principles for AI Agents
+
+Mandatory working principles for any AI agent (Claude Code, etc.) operating in this
+repository. They override default behavior. **Read them at the start of every session.**
+
+## 1. Infrastructure: ship any real benefit, however small
+
+This work is infrastructure. If a change produces a **real, correct benefit — even a
+tiny one — do it.** Do not skip a sound improvement because the measured win looks
+marginal, and do not abandon the straightforward improvement in favor of a "bigger
+lever" or an easier alternative.
+
+- Don't reject a fix as "not worth it" on size alone — a small, real reduction in work
+  (fewer fsyncs, fewer allocations, less I/O, less churn) is worth making on its own.
+- Don't substitute a different, larger-scope change for the obvious small one.
+- Do the complete job: sweep **all** the safe cases, not just the big ones.
+
+## 2. Verify at the source — no substitute environment or method
+
+**Verify a problem, and its fix, WHERE the problem actually occurs.** Do not use a
+proxy environment or a substitute method and then draw conclusions from it.
+
+- If the problem is on CI (a specific OS/runner), reproduce and measure **on that CI**.
+  A local machine is NOT a valid stand-in — e.g. a local disk/AV setup behaves nothing
+  like a hosted Windows runner, so a local measurement of an AV/fsync-bound effect
+  proves nothing about CI.
+- Don't be clever or presumptuous. Go to where the issue is, reproduce it there, and
+  validate the fix there.
+- Do not propose unrequested "alternative approaches" in place of verifying the real
+  thing at its source. Don't spin up a new worktree/PR for a small in-flight change —
+  make it directly in the branch you are already working in.
+
+When the two meet: make the real infrastructure improvement (Principle 1) **and** prove
+it in the real failing environment (Principle 2) — never in a convenient substitute.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+**MANDATORY — read [AGENTS.md](AGENTS.md) at the start of every session.** It defines
+the working principles for AI agents in this repository and overrides default behavior.
+
+@AGENTS.md

--- a/core/vectorstore/coverage_phase4_test.go
+++ b/core/vectorstore/coverage_phase4_test.go
@@ -28,9 +28,11 @@ func TestLiveRatio_ZeroCountIsOne(t *testing.T) {
 // quiescence drain). The call is a no-op that returns nil.
 func TestMergeNow_NoOpWhenClosing(t *testing.T) {
 	s := openTestStore(t, Cosine)
+	bp := s.NewBatch()
 	for i := 0; i < 6; i++ {
-		requireNoError(t, s.Put("d-"+itoa(i), []float32{float32(i), 1, 0, 0, 0, 0, 0, 0}, nil))
+		bp.Put("d-"+itoa(i), []float32{float32(i), 1, 0, 0, 0, 0, 0, 0}, nil)
 	}
+	requireNoError(t, bp.Commit())
 	requireNoError(t, s.Seal())
 	requireNoError(t, s.WaitForIndex())
 
@@ -80,9 +82,11 @@ func TestMergeNow_NoOpWhenInputPending(t *testing.T) {
 func TestSealLocked_WriteFaultPropagates(t *testing.T) {
 	s := openTestStore(t, Cosine)
 	rng := rand.New(rand.NewSource(101))
+	bp := s.NewBatch()
 	for i := 0; i < 6; i++ {
-		requireNoError(t, s.Put("d-"+itoa(i), randVecN(rng, 8), nil))
+		bp.Put("d-"+itoa(i), randVecN(rng, 8), nil)
 	}
+	requireNoError(t, bp.Commit())
 	withCreateFault(t, func(f *faultFile) { f.failWrite = true })
 	if err := s.Seal(); err == nil {
 		t.Fatal("Seal should surface a writeSealedSegment write fault")
@@ -110,9 +114,11 @@ func TestCommitSealLocked_ReconcileErrorRollsBack(t *testing.T) {
 	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(909))
+	bp := s.NewBatch()
 	for i := 0; i < 6; i++ {
-		requireNoError(t, s.Put("d-"+itoa(i), randVecN(rng, 8), nil))
+		bp.Put("d-"+itoa(i), randVecN(rng, 8), nil)
 	}
+	requireNoError(t, bp.Commit())
 	testHookReconcileErr = errInjected
 	if err := s.Seal(); err == nil {
 		testHookReconcileErr = nil
@@ -150,9 +156,11 @@ func TestCommitMergeLocked_ReconcileErrorRollsBack(t *testing.T) {
 	requireNoError(t, err)
 	defer s.Close() // release output mmaps so t.TempDir cleanup works on Windows
 	rng := rand.New(rand.NewSource(808))
+	bp := s.NewBatch()
 	for i := 0; i < 12; i++ {
-		requireNoError(t, s.Put("d-"+itoa(i), randVecN(rng, 8), nil))
+		bp.Put("d-"+itoa(i), randVecN(rng, 8), nil)
 	}
+	requireNoError(t, bp.Commit())
 	requireNoError(t, s.Seal())
 	requireNoError(t, s.WaitForIndex()) // no pending builds → the hook only hits the merge commit
 
@@ -186,9 +194,11 @@ func TestCommitMergeLocked_ReconcileErrorRollsBack(t *testing.T) {
 func TestSealLocked_NoBuildSpawnWhenClosing(t *testing.T) {
 	s := openTestStore(t, Cosine)
 	rng := rand.New(rand.NewSource(102))
+	bp := s.NewBatch()
 	for i := 0; i < 6; i++ {
-		requireNoError(t, s.Put("d-"+itoa(i), randVecN(rng, 8), nil))
+		bp.Put("d-"+itoa(i), randVecN(rng, 8), nil)
 	}
+	requireNoError(t, bp.Commit())
 	s.mu.Lock()
 	s.closing = true
 	err := s.sealLocked() // seals durably but skips the build spawn (and maybeMerge)

--- a/core/vectorstore/merge_test.go
+++ b/core/vectorstore/merge_test.go
@@ -245,9 +245,11 @@ func TestMerge_CompactOfOne(t *testing.T) {
 func TestMerge_MultiInputRehomesOnlyMovedDocs(t *testing.T) {
 	s := openTestStore(t, DotProduct)
 	mkSeg := func(ids []string) {
+		b := s.NewBatch()
 		for _, id := range ids {
-			requireNoError(t, s.Put(id, []float32{float32(len(id)), 1, 0}, nil))
+			b.Put(id, []float32{float32(len(id)), 1, 0}, nil)
 		}
+		requireNoError(t, b.Commit())
 		requireNoError(t, s.Seal())
 	}
 	mkSeg([]string{"a", "aa"}) // seg 1

--- a/core/vectorstore/recovery_branches_test.go
+++ b/core/vectorstore/recovery_branches_test.go
@@ -29,14 +29,18 @@ func TestRecovery_DeleteSealedDocAfterReopen(t *testing.T) {
 		}
 		return v
 	}
+	sb := s.NewBatch()
 	for i := 0; i < 60; i++ {
-		requireNoError(t, s.Put("s-"+itoa(i), randVec(), Payload{"p": StringValue("p")}))
+		sb.Put("s-"+itoa(i), randVec(), Payload{"p": StringValue("p")})
 	}
+	requireNoError(t, sb.Commit())
 	requireNoError(t, s.Seal())
 	requireNoError(t, s.WaitForIndex()) // segment becomes indexed → recover reopens graph.dat
+	hb := s.NewBatch()
 	for i := 0; i < 5; i++ {
-		requireNoError(t, s.Put("h-"+itoa(i), randVec(), nil))
+		hb.Put("h-"+itoa(i), randVec(), nil)
 	}
+	requireNoError(t, hb.Commit())
 
 	s2 := reopenStore(t, s, kvStore)
 
@@ -84,9 +88,11 @@ func TestRecovery_ResumesPendingBuild(t *testing.T) {
 		}
 		return v
 	}
+	pb := s.NewBatch()
 	for i := 0; i < 40; i++ {
-		requireNoError(t, s.Put("p-"+itoa(i), randVec(), nil))
+		pb.Put("p-"+itoa(i), randVec(), nil)
 	}
+	requireNoError(t, pb.Commit())
 	requireNoError(t, s.Seal())
 	requireNoError(t, s.WaitForIndex())
 	requireNoError(t, s.Close())
@@ -169,9 +175,11 @@ func TestRecovery_CrossSegmentUpdateTombstoneNotFlushed(t *testing.T) {
 	// Seal a batch so doc "x" lives in a sealed segment (slot 0).
 	const n = 6
 	requireNoError(t, s.Put("x", randVec(), Payload{"v": StringValue("old")}))
+	fb := s.NewBatch()
 	for i := 0; i < n; i++ {
-		requireNoError(t, s.Put("f-"+itoa(i), randVec(), nil))
+		fb.Put("f-"+itoa(i), randVec(), nil)
 	}
+	requireNoError(t, fb.Commit())
 	requireNoError(t, s.Seal())
 	requireNoError(t, s.WaitForIndex())
 	xDoc := s.idToDoc["x"]
@@ -238,9 +246,11 @@ func TestRecovery_SealHeadClearIsAtomicNoDoubleStore(t *testing.T) {
 		return v
 	}
 	const n = 40
+	cb := s.NewBatch()
 	for i := 0; i < n; i++ {
-		requireNoError(t, s.Put("c-"+itoa(i), randVec(), nil))
+		cb.Put("c-"+itoa(i), randVec(), nil)
 	}
+	requireNoError(t, cb.Commit())
 
 	// Real Seal: dumps the head to a sealed segment AND clears the head bucket in
 	// one atomic control-store commit. alloc.Commit (inside Seal) makes the

--- a/core/vectorstore/seal_idtable_durability_test.go
+++ b/core/vectorstore/seal_idtable_durability_test.go
@@ -81,10 +81,15 @@ func TestSeal_IdtableDurableBeforeHeadClear(t *testing.T) {
 
 	// Put a batch of docs, capturing the docId each string id was assigned.
 	docIDOf := make(map[string]int64)
+	dids := make([]string, 40)
+	db := s.NewBatch()
 	for i := 0; i < 40; i++ {
-		id := "d-" + itoa(i)
-		requireNoError(t, s.Put(id, randVec(), nil))
-		docIDOf[id] = s.idToDoc[id]
+		dids[i] = "d-" + itoa(i)
+		db.Put(dids[i], randVec(), nil)
+	}
+	requireNoError(t, db.Commit())
+	for i := 0; i < 40; i++ {
+		docIDOf[dids[i]] = s.idToDoc[dids[i]]
 	}
 	// Seal: dumps the records durably, but (pre-fix) leaves the idtable batch
 	// uncommitted while clearing the head bucket that carried the id→docId records.

--- a/core/vectorstore/store_attr_test.go
+++ b/core/vectorstore/store_attr_test.go
@@ -53,10 +53,12 @@ func TestCreateAttrIndex_Idempotent_And_KindMismatch(t *testing.T) {
 // filter on the dropped field falls back to a correct residual scan.
 func TestDropAttrIndex_RemovesDeclarationAndAttrDat(t *testing.T) {
 	s := openTestStore(t, Cosine)
+	ab := s.NewBatch()
 	for i := 0; i < 10; i++ {
-		requireNoError(t, s.Put("k"+itoa(i), []float32{float32(i + 1), 0, 0},
-			Payload{"color": StringValue([]string{"red", "blue"}[i%2])}))
+		ab.Put("k"+itoa(i), []float32{float32(i + 1), 0, 0},
+			Payload{"color": StringValue([]string{"red", "blue"}[i%2])})
 	}
+	requireNoError(t, ab.Commit())
 	requireNoError(t, s.Seal())
 	requireNoError(t, s.WaitForIndex())
 	requireNoError(t, s.CreateAttrIndex("color", Keyword))
@@ -239,10 +241,12 @@ func TestSearch_Filter_AfterCompact_DeclsCarried(t *testing.T) {
 // correct.
 func TestSearch_Filter_UnIndexedSegment_ResidualFallback(t *testing.T) {
 	s := openTestStore(t, Cosine)
+	ab := s.NewBatch()
 	for i := 0; i < 12; i++ {
-		requireNoError(t, s.Put("k"+itoa(i), []float32{float32(i + 1), 0, 0},
-			Payload{"color": StringValue([]string{"red", "blue"}[i%2])}))
+		ab.Put("k"+itoa(i), []float32{float32(i + 1), 0, 0},
+			Payload{"color": StringValue([]string{"red", "blue"}[i%2])})
 	}
+	requireNoError(t, ab.Commit())
 	requireNoError(t, s.Seal()) // sealed with NO declarations → ss.attr stays nil
 	requireNoError(t, s.WaitForIndex())
 	// Declare on the head only; the sealed segment was already frozen with no attr

--- a/core/vectorstore/store_test.go
+++ b/core/vectorstore/store_test.go
@@ -125,9 +125,11 @@ func TestStore_Search_MatchesOracle_Cosine(t *testing.T) {
 		"c": {0.9, 0.1, 0, 0},
 		"d": {0, 0, 1, 0},
 	}
+	rb := s.NewBatch()
 	for id, v := range raw {
-		requireNoError(t, s.Put(id, v, nil))
+		rb.Put(id, v, nil)
 	}
+	requireNoError(t, rb.Commit())
 	q := []float32{1, 0, 0, 0}
 	res, err := s.Search("default", q, 2, nil)
 	requireNoError(t, err)
@@ -155,9 +157,11 @@ func TestStore_Search_MatchesOracle_Euclidean(t *testing.T) {
 		"c": {1, 1},   // dist ~1.41
 		"d": {10, 10}, // far
 	}
+	rb := s.NewBatch()
 	for id, v := range raw {
-		requireNoError(t, s.Put(id, v, nil))
+		rb.Put(id, v, nil)
 	}
+	requireNoError(t, rb.Commit())
 	q := []float32{0, 0}
 	res, err := s.Search("default", q, 3, nil)
 	requireNoError(t, err)


### PR DESCRIPTION
## Batching sweep (Windows CI / fsync)

Each `s.Put` is one durable bbolt write-txn = one fsync, so an N-doc setup loop did N fsyncs. This converts the **incidental-population** loops to a single `NewBatch`+`Commit` (1 fsync, identical end state) — where the puts are just setup (default `maxSegSize`, the test asserts post-state, not per-Put / seal / crash timing).

**Converted:** `recovery_branches` (5 loops, 151 puts), `store_attr` (2), `coverage_phase4` (5), `store_test` MatchesOracle (2), `merge_test` `mkSeg` (1), `seal_idtable_durability` (1 — subject is Seal's `alloc.Commit`/head-clear atomicity, not the puts).
**Not converted (per-Put IS the subject):** seal-timing tests (`autoseal` / `batch` / `merge_*` with `maxSegSize` overrides) and race tests. Recall/search/filter were already batched by prior work.

Full `core/vectorstore` suite green; no behavior change.

> **Verification:** per `AGENTS.md` Principle 2, this is being measured **on CI** (the Windows runner where the fsync/AV cost lives), not locally — a local box's fsync is cheap and proves nothing. See the Windows Core job timing.

## AGENTS.md (separate commit)

Adds working principles + `CLAUDE.md` (`@`-imports it, read on startup): (1) infra — ship any real benefit however small; (2) verify at the source, no substitute env/method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)