### PR TITLE
perf(invertedindex): represent docid as int64 internally (search hot path)

### DIFF
--- a/core/documents/storage.go
+++ b/core/documents/storage.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/codetrek/haystack/core/idtable"
 	"github.com/codetrek/haystack/core/invertedindex"
 	"github.com/codetrek/haystack/core/kv"
 	"github.com/codetrek/haystack/core/queue"
@@ -260,5 +261,8 @@ func (s *Store) indexDocument(tableId int, docId string, newWords, oldWords []st
 	if s.idx == nil {
 		return
 	}
-	s.idx.Update(tableId, docId, newWords, oldWords)
+	// The inverted index keys postings by the docid's int64 value; docId here is
+	// its canonical 8-byte string form (as produced by idtable.GetId and used for
+	// the document-store keys), so decode it at this boundary.
+	s.idx.Update(tableId, idtable.DecodeId(docId), newWords, oldWords)
 }

--- a/core/engine/engine.go
+++ b/core/engine/engine.go
@@ -116,7 +116,7 @@ func (c *andClause) collectDocuments(collectionID int) (*invertedindex.SearchRes
 
 	if len(rs) == 0 {
 		return &invertedindex.SearchResult{
-			DocIds: make(map[string]struct{}),
+			DocIds: make(map[int64]struct{}),
 		}, nil
 	}
 
@@ -171,14 +171,14 @@ func (t *term) collectDocuments(collectionID int) invertedindex.SearchResult {
 	return result
 }
 
-func (t *term) collectWithKeywords(invertedID int, kws []string) map[string]struct{} {
+func (t *term) collectWithKeywords(invertedID int, kws []string) map[int64]struct{} {
 	if len(kws) == 0 {
-		return map[string]struct{}{}
+		return map[int64]struct{}{}
 	}
 
 	if t.engine.idx == nil {
 		log.Printf("[Engine] collectWithKeywords: inverted index not initialised")
-		return map[string]struct{}{}
+		return map[int64]struct{}{}
 	}
 
 	rs := t.engine.idx.Search(invertedID, kws[0], -1, nil)

--- a/core/engine/integration_test.go
+++ b/core/engine/integration_test.go
@@ -79,13 +79,18 @@ func buildIndexedStack(t *testing.T, docMap map[string][]string) *indexedStack {
 	return &indexedStack{idx: idx, docs: docs, colID: col.ID(), ids: ids}
 }
 
-func (s *indexedStack) collect(t *testing.T, query string) map[string]struct{} {
+func (s *indexedStack) collect(t *testing.T, query string) map[int64]struct{} {
 	t.Helper()
 	eng := engine.New(s.idx, s.docs, s.colID, engine.Options{MaxWildcardLength: 24, MaxKeywordDistance: 32})
 	require.NoError(t, eng.Compile(query, false))
 	res, err := eng.CollectDocuments()
 	require.NoError(t, err)
 	return res.DocIds
+}
+
+// id decodes the int64 docid for relPath (engine results are keyed by int64).
+func (s *indexedStack) id(relPath string) int64 {
+	return idtable.DecodeId(s.ids[relPath])
 }
 
 func TestEngineCollectDocuments(t *testing.T) {
@@ -97,31 +102,31 @@ func TestEngineCollectDocuments(t *testing.T) {
 
 	t.Run("single keyword hits all containing docs", func(t *testing.T) {
 		got := s.collect(t, "hello")
-		assert.Contains(t, got, s.ids["alpha.go"])
-		assert.Contains(t, got, s.ids["beta.go"])
-		assert.NotContains(t, got, s.ids["gamma.go"])
+		assert.Contains(t, got, s.id("alpha.go"))
+		assert.Contains(t, got, s.id("beta.go"))
+		assert.NotContains(t, got, s.id("gamma.go"))
 	})
 
 	t.Run("multiple AND keywords intersect", func(t *testing.T) {
 		// hello AND world → only alpha.go has both.
 		got := s.collect(t, "hello world")
-		assert.Contains(t, got, s.ids["alpha.go"])
-		assert.NotContains(t, got, s.ids["beta.go"])
-		assert.NotContains(t, got, s.ids["gamma.go"])
+		assert.Contains(t, got, s.id("alpha.go"))
+		assert.NotContains(t, got, s.id("beta.go"))
+		assert.NotContains(t, got, s.id("gamma.go"))
 	})
 
 	t.Run("OR clauses union and merge", func(t *testing.T) {
 		// "alpha | gamma" → alpha.go (via alpha) and gamma.go (via gamma).
 		got := s.collect(t, "alpha | gamma")
-		assert.Contains(t, got, s.ids["alpha.go"])
-		assert.Contains(t, got, s.ids["gamma.go"])
-		assert.NotContains(t, got, s.ids["beta.go"])
+		assert.Contains(t, got, s.id("alpha.go"))
+		assert.Contains(t, got, s.id("gamma.go"))
+		assert.NotContains(t, got, s.id("beta.go"))
 	})
 
 	t.Run("shared keyword across docs", func(t *testing.T) {
 		got := s.collect(t, "shared")
-		assert.Contains(t, got, s.ids["beta.go"])
-		assert.Contains(t, got, s.ids["gamma.go"])
+		assert.Contains(t, got, s.id("beta.go"))
+		assert.Contains(t, got, s.id("gamma.go"))
 	})
 
 	t.Run("keyword absent from index yields no docs", func(t *testing.T) {
@@ -134,9 +139,9 @@ func TestEngineCollectDocuments(t *testing.T) {
 		// collectWithKeywords' multi-keyword intersection loop. Only alpha.go
 		// has both "hello" and "world".
 		got := s.collect(t, `"hello world"`)
-		assert.Contains(t, got, s.ids["alpha.go"])
-		assert.NotContains(t, got, s.ids["beta.go"])
-		assert.NotContains(t, got, s.ids["gamma.go"])
+		assert.Contains(t, got, s.id("alpha.go"))
+		assert.NotContains(t, got, s.id("beta.go"))
+		assert.NotContains(t, got, s.id("gamma.go"))
 	})
 
 	t.Run("wildcard suffix prunes wild-only docs", func(t *testing.T) {
@@ -144,8 +149,8 @@ func TestEngineCollectDocuments(t *testing.T) {
 		// {alpha,gamma}; gamma is in WildDocIds but not DocIds, so it's pruned
 		// (exercises the WildDocIds delete branch).
 		got := s.collect(t, "hello*world")
-		assert.Contains(t, got, s.ids["alpha.go"])
-		assert.Contains(t, got, s.ids["beta.go"])
+		assert.Contains(t, got, s.id("alpha.go"))
+		assert.Contains(t, got, s.id("beta.go"))
 	})
 
 	t.Run("unknown collection id yields no docs", func(t *testing.T) {

--- a/core/engine/readme_example_test.go
+++ b/core/engine/readme_example_test.go
@@ -96,7 +96,7 @@ func TestReadmeExample(t *testing.T) {
 		t.Fatalf("eng.CollectDocuments: %v", err)
 	}
 
-	if _, found := result.DocIds[docID]; !found {
+	if _, found := result.DocIds[idtable.DecodeId(docID)]; !found {
 		t.Errorf("expected docID %q in results; got %v", docID, result.DocIds)
 	}
 

--- a/core/idtable/encode_id_test.go
+++ b/core/idtable/encode_id_test.go
@@ -1,0 +1,71 @@
+package idtable
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/codetrek/haystack/core/kv/pebblekv"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEncodeDecodeId_RoundTrip pins the EncodeId/DecodeId pair as exact inverses
+// across edge values, and confirms EncodeId always yields the fixed 8-byte form.
+func TestEncodeDecodeId_RoundTrip(t *testing.T) {
+	cases := []int64{0, 1, -1, 255, 256, 1 << 40, 9223372036854775807 /* max int64 */}
+	for _, id := range cases {
+		enc := EncodeId(id)
+		if len(enc) != 8 {
+			t.Errorf("EncodeId(%d) length = %d, want 8", id, len(enc))
+		}
+		if got := DecodeId(enc); got != id {
+			t.Errorf("DecodeId(EncodeId(%d)) = %d, want %d", id, got, id)
+		}
+	}
+}
+
+// TestEncodeId_BigEndianBytes pins the exact on-disk byte layout (big-endian),
+// which the documents store and inverted index depend on for key ordering and
+// value chunking.
+func TestEncodeId_BigEndianBytes(t *testing.T) {
+	// 0x0102030405060708 big-endian → bytes 01 02 03 04 05 06 07 08.
+	enc := EncodeId(0x0102030405060708)
+	want := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	if string(enc) != string(want) {
+		t.Errorf("EncodeId big-endian bytes = % x, want % x", enc, want)
+	}
+}
+
+// TestDecodeId_ShortStringIsInvalid pins that a too-short string (never a real
+// docid) decodes to InvalidId rather than panicking.
+func TestDecodeId_ShortStringIsInvalid(t *testing.T) {
+	for _, s := range []string{"", "abc", "1234567" /* 7 bytes */} {
+		if got := DecodeId(s); got != InvalidId {
+			t.Errorf("DecodeId(%q) = %d, want InvalidId(%d)", s, got, InvalidId)
+		}
+	}
+}
+
+// TestEncodeId_MatchesGetId confirms EncodeId reproduces the exact string GetId
+// hands out for the same underlying counter value, so the int64 form and the
+// string form are interchangeable at storage boundaries.
+func TestEncodeId_MatchesGetId(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "haystack-idtable-encode-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
+	assert.NoError(t, err)
+	defer store.Close()
+
+	alloc, err := New(store, Options{})
+	assert.NoError(t, err)
+	defer alloc.Close()
+
+	// The first allocated id corresponds to nextId == 1 (New seeds nextId = 1).
+	got, err := alloc.GetId([]byte("some/path.go"))
+	assert.NoError(t, err)
+	assert.Equal(t, EncodeId(1), got)
+	// And DecodeId recovers that counter value.
+	assert.Equal(t, int64(1), DecodeId(got))
+}

--- a/core/idtable/idtable.go
+++ b/core/idtable/idtable.go
@@ -20,6 +20,9 @@ const (
 	DefaultLRUCacheSize   = 200_000
 	DefaultBatchSize      = int32(100)
 	DefaultCommitInterval = 5 * time.Second
+
+	// InvalidId is returned by DecodeId for a malformed (too-short) docid string.
+	InvalidId = int64(-1)
 )
 
 // Options configures an Allocator. Zero-value fields fall back to defaults.
@@ -264,4 +267,23 @@ func toBytes(v int64) []byte {
 
 func fromBytes(buf []byte) int64 {
 	return int64(binary.BigEndian.Uint64(buf))
+}
+
+// EncodeId returns the canonical on-disk string form of a docid: its 8-byte
+// big-endian encoding. This is the exact byte sequence GetId hands out and that
+// documents.Store / invertedindex use as a key/value component, so callers that
+// hold a docid as an int64 (e.g. search results) can rebuild the string form
+// expected by the string-keyed Store APIs.
+func EncodeId(id int64) string {
+	return string(toBytes(id))
+}
+
+// DecodeId is the inverse of EncodeId: it decodes an 8-byte big-endian docid
+// string back to its int64 value. A string shorter than 8 bytes is malformed
+// (it can never be a docid this package produced) and yields InvalidId.
+func DecodeId(s string) int64 {
+	if len(s) < 8 {
+		return InvalidId
+	}
+	return int64(binary.BigEndian.Uint64([]byte(s[:8])))
 }

--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -1,6 +1,7 @@
 package invertedindex
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -137,35 +138,34 @@ func encodeTableValue(info TableInfo) []byte {
 	return content
 }
 
-func encodeInvertedValue(docids []string) []byte {
-	// Each docid is a 8-byte string
-	return []byte(strings.Join(docids, ""))
+// encodeInvertedValue packs docids into a fixed-width byte string: each docid is
+// its 8-byte big-endian form, concatenated with no delimiter. Big-endian keeps
+// the on-disk bytes identical to the previous string-docid representation (the
+// docid was always the big-endian encoding of an idtable int64), so the format
+// is unchanged and no reindex is required.
+func encodeInvertedValue(docids []int64) []byte {
+	buf := make([]byte, len(docids)*docIDSize)
+	for i, id := range docids {
+		binary.BigEndian.PutUint64(buf[i*docIDSize:], uint64(id))
+	}
+	return buf
 }
 
-func decodeInvertedValue(data []byte) []string {
-	// Each docid is an 8-byte string.
-	if len(data) == 0 || len(data)%8 != 0 {
-		return []string{}
+func decodeInvertedValue(data []byte) []int64 {
+	// Each docid is docIDSize bytes (big-endian int64).
+	if len(data) == 0 || len(data)%docIDSize != 0 {
+		return []int64{}
 	}
 
-	const size = 8
-	chunks := make([]string, 0, len(data)/size)
-	for i := 0; i+size <= len(data); i += size {
-		chunks = append(chunks, string(data[i:i+size]))
+	ids := make([]int64, 0, len(data)/docIDSize)
+	for i := 0; i+docIDSize <= len(data); i += docIDSize {
+		ids = append(ids, int64(binary.BigEndian.Uint64(data[i:i+docIDSize])))
 	}
-	return chunks
+	return ids
 }
 
-func decodeInvertedValueStr(data string) []string {
-	// Each docid is an 8-byte string.
-	if len(data) == 0 || len(data)%8 != 0 {
-		return []string{}
-	}
-
-	const size = 8
-	chunks := make([]string, 0, len(data)/size)
-	for i := 0; i+size <= len(data); i += size {
-		chunks = append(chunks, data[i:i+size])
-	}
-	return chunks
+func decodeInvertedValueStr(data string) []int64 {
+	// Each docid is docIDSize bytes (big-endian int64). The merger holds row
+	// values as strings; copy once into a byte slice and reuse the byte decoder.
+	return decodeInvertedValue([]byte(data))
 }

--- a/core/invertedindex/codec_delimiter_test.go
+++ b/core/invertedindex/codec_delimiter_test.go
@@ -55,7 +55,7 @@ func TestMerge_KeywordWithDelimiter_NoOrphan(t *testing.T) {
 	// Index several distinct docs per keyword across separate flushes (each flush
 	// writes a distinct tick'd row) so the merger's rewriteIndex path
 	// (len(Rows) >= 2) actually fires for every keyword.
-	docsByKw := map[string][]string{}
+	docsByKw := map[string][]int64{}
 	for round := 0; round < 3; round++ {
 		for ki, kw := range keywords {
 			doc := makeDocID(fmt.Sprintf("d%d-%d", ki, round))

--- a/core/invertedindex/codec_test.go
+++ b/core/invertedindex/codec_test.go
@@ -218,17 +218,24 @@ func TestEncodeTableValue(t *testing.T) {
 // encodeInvertedValue / decodeInvertedValue round-trip
 // ---------------------------------------------------------------------------
 func TestEncodeDecodeInvertedValue(t *testing.T) {
-	// Each docid is 8 bytes
-	docids := []string{"abcdefgh", "12345678", "XXXXXXXX"}
+	// Each docid is an 8-byte big-endian int64. These literals are the int64
+	// values whose big-endian bytes spell the ASCII labels below, so the encoded
+	// buffer is byte-identical to the previous string representation (no reindex).
+	docids := []int64{0x6162636465666768 /*abcdefgh*/, 0x3132333435363738 /*12345678*/, 0x5858585858585858 /*XXXXXXXX*/}
 	encoded := encodeInvertedValue(docids)
-	decoded := decodeInvertedValue(encoded)
 
+	// Byte-parity with the old string-docid format.
+	if string(encoded) != "abcdefgh12345678XXXXXXXX" {
+		t.Fatalf("encoded bytes = %q, want %q", string(encoded), "abcdefgh12345678XXXXXXXX")
+	}
+
+	decoded := decodeInvertedValue(encoded)
 	if len(decoded) != len(docids) {
 		t.Fatalf("expected %d docids, got %d", len(docids), len(decoded))
 	}
 	for i, want := range docids {
 		if decoded[i] != want {
-			t.Errorf("docids[%d]: got %q, want %q", i, decoded[i], want)
+			t.Errorf("docids[%d]: got %d, want %d", i, decoded[i], want)
 		}
 	}
 }
@@ -258,17 +265,17 @@ func TestDecodeInvertedValueEdgeCases(t *testing.T) {
 // decodeInvertedValueStr
 // ---------------------------------------------------------------------------
 func TestDecodeInvertedValueStr(t *testing.T) {
-	// Each docid is 8 bytes
-	docids := []string{"abcdefgh", "12345678"}
-	encoded := strings.Join(docids, "")
-	decoded := decodeInvertedValueStr(encoded)
+	// "abcdefgh12345678" → two 8-byte big-endian int64 docids.
+	data := "abcdefgh12345678"
+	want := []int64{0x6162636465666768, 0x3132333435363738}
+	decoded := decodeInvertedValueStr(data)
 
-	if len(decoded) != len(docids) {
-		t.Fatalf("expected %d docids, got %d", len(docids), len(decoded))
+	if len(decoded) != len(want) {
+		t.Fatalf("expected %d docids, got %d", len(want), len(decoded))
 	}
-	for i, want := range docids {
-		if decoded[i] != want {
-			t.Errorf("docids[%d]: got %q, want %q", i, decoded[i], want)
+	for i, w := range want {
+		if decoded[i] != w {
+			t.Errorf("docids[%d]: got %d, want %d", i, decoded[i], w)
 		}
 	}
 }
@@ -299,14 +306,14 @@ func TestDecodeInvertedValueStrEdgeCases(t *testing.T) {
 func TestRemoveDuplicatesEfficiently(t *testing.T) {
 	tests := []struct {
 		name  string
-		input []string
+		input []int64
 		want  int
 	}{
-		{"empty", []string{}, 0},
-		{"single", []string{"a"}, 1},
-		{"no duplicates", []string{"a", "b", "c"}, 3},
-		{"with duplicates", []string{"a", "b", "a", "c", "b"}, 3},
-		{"all same", []string{"x", "x", "x"}, 1},
+		{"empty", []int64{}, 0},
+		{"single", []int64{1}, 1},
+		{"no duplicates", []int64{1, 2, 3}, 3},
+		{"with duplicates", []int64{1, 2, 1, 3, 2}, 3},
+		{"all same", []int64{9, 9, 9}, 1},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -320,15 +327,15 @@ func TestRemoveDuplicatesEfficiently(t *testing.T) {
 
 // Verify ordering is preserved (first occurrence wins)
 func TestRemoveDuplicatesPreservesOrder(t *testing.T) {
-	input := []string{"b", "a", "c", "a", "b"}
+	input := []int64{2, 1, 3, 1, 2}
 	got := removeDuplicatesEfficiently(input)
-	expected := []string{"b", "a", "c"}
+	expected := []int64{2, 1, 3}
 	if len(got) != len(expected) {
 		t.Fatalf("expected len %d, got %d", len(expected), len(got))
 	}
 	for i, v := range expected {
 		if got[i] != v {
-			t.Errorf("index %d: got %q, want %q", i, got[i], v)
+			t.Errorf("index %d: got %d, want %d", i, got[i], v)
 		}
 	}
 }

--- a/core/invertedindex/index_test.go
+++ b/core/invertedindex/index_test.go
@@ -19,8 +19,9 @@ func forceFlush(idx *Index) {
 	idx.flushPendingDeletes(true, MaxInvertedIndexSize)
 }
 
-// makeDocID pads or truncates s to exactly 8 bytes (the canonical docid size).
-func makeDocID(s string) string {
+// makeDocID maps a label to the int64 docid the index stores (its canonical
+// 8-byte big-endian form), via the shared Doc2ID test helper.
+func makeDocID(s string) int64 {
 	return Doc2ID(s)
 }
 
@@ -383,7 +384,7 @@ func TestRemoveDocumentsFromInvertedIndex(t *testing.T) {
 
 	// Remove doc2 via removeDocumentsFromInvertedIndex
 	batch := env.DB.NewBatch(0)
-	err := env.idx.removeDocumentsFromInvertedIndex(batch, tableId, "target", []string{doc2}, MaxInvertedIndexSize)
+	err := env.idx.removeDocumentsFromInvertedIndex(batch, tableId, "target", []int64{doc2}, MaxInvertedIndexSize)
 	if err != nil {
 		t.Fatalf("removeDocumentsFromInvertedIndex failed: %v", err)
 	}
@@ -408,7 +409,7 @@ func TestRemoveDocumentsEmptyKeyword(t *testing.T) {
 
 	batch := env.DB.NewBatch(0)
 	// Empty keyword should be a no-op (returns nil)
-	err := env.idx.removeDocumentsFromInvertedIndex(batch, 1, "", []string{"doc"}, MaxInvertedIndexSize)
+	err := env.idx.removeDocumentsFromInvertedIndex(batch, 1, "", []int64{Doc2ID("doc")}, MaxInvertedIndexSize)
 	if err != nil {
 		t.Fatalf("expected nil error for empty keyword, got: %v", err)
 	}
@@ -421,22 +422,9 @@ func TestRemoveDocumentsEmptyDocids(t *testing.T) {
 
 	batch := env.DB.NewBatch(0)
 	// Empty docid list should be a no-op (returns nil)
-	err := env.idx.removeDocumentsFromInvertedIndex(batch, 1, "kw", []string{}, MaxInvertedIndexSize)
+	err := env.idx.removeDocumentsFromInvertedIndex(batch, 1, "kw", []int64{}, MaxInvertedIndexSize)
 	if err != nil {
 		t.Fatalf("expected nil error for empty docids, got: %v", err)
-	}
-	batch.Commit()
-}
-
-func TestRemoveDocumentsOnlyEmptyStringDocids(t *testing.T) {
-	env := setupTestEnv(t)
-	defer env.teardown()
-
-	batch := env.DB.NewBatch(0)
-	// Only empty-string docids should be a no-op (returns nil)
-	err := env.idx.removeDocumentsFromInvertedIndex(batch, 1, "kw", []string{"", ""}, MaxInvertedIndexSize)
-	if err != nil {
-		t.Fatalf("expected nil error for empty-string docids, got: %v", err)
 	}
 	batch.Commit()
 }
@@ -568,7 +556,7 @@ func TestWriteInvertedIndexDeduplicates(t *testing.T) {
 	// Directly call writeInvertedIndex with duplicates
 	batch := env.DB.NewBatch(0)
 	key := env.idx.encodeInvertedKey(tableId, "dupkw", 3)
-	writeInvertedIndex(batch, tableId, "dupkw", []string{doc, doc, doc}, key)
+	writeInvertedIndex(batch, tableId, "dupkw", []int64{doc, doc, doc}, key)
 	batch.Commit()
 
 	res := env.idx.GetDocs(tableId, "dupkw")
@@ -714,7 +702,7 @@ func TestUpdateManyDocuments(t *testing.T) {
 
 	tableId, _ := env.idx.CreateTable("many-docs-test")
 
-	docids := make([]string, 20)
+	docids := make([]int64, 20)
 	for i := 0; i < 20; i++ {
 		docids[i] = makeDocID("d" + string(rune('A'+i)))
 		env.idx.Update(tableId, docids[i], []string{"popular"}, nil)
@@ -734,16 +722,16 @@ func TestUpdateManyDocuments(t *testing.T) {
 func TestDoc2IDPadding(t *testing.T) {
 	tests := []struct {
 		input string
-		want  int
+		want  string // canonical 8-byte big-endian form
 	}{
-		{"a", 8},
-		{"abcdefgh", 8},
-		{"abcdefghijklm", 8}, // truncated
+		{"a", "0000000a"},
+		{"abcdefgh", "abcdefgh"},
+		{"abcdefghijklm", "abcdefgh"}, // truncated to first 8 bytes
 	}
 	for _, tc := range tests {
-		got := Doc2ID(tc.input)
-		if len(got) != tc.want {
-			t.Errorf("Doc2ID(%q) length = %d, want %d", tc.input, len(got), tc.want)
+		got := string(encodeInvertedValue([]int64{Doc2ID(tc.input)}))
+		if got != tc.want {
+			t.Errorf("Doc2ID(%q) canonical bytes = %q, want %q", tc.input, got, tc.want)
 		}
 	}
 }
@@ -765,7 +753,7 @@ func TestRemoveDocumentsPartial(t *testing.T) {
 
 	tableId, _ := env.idx.CreateTable("partial-remove-test")
 
-	docs := make([]string, 5)
+	docs := make([]int64, 5)
 	for i := 0; i < 5; i++ {
 		docs[i] = makeDocID("p" + string(rune('1'+i)))
 		env.idx.Update(tableId, docs[i], []string{"partkey"}, nil)
@@ -784,11 +772,11 @@ func TestRemoveDocumentsPartial(t *testing.T) {
 	res := env.idx.GetDocs(tableId, "partkey")
 	if len(res.DocIds) != 3 {
 		// Collect what we got for debugging
-		gotDocs := make([]string, 0, len(res.DocIds))
+		gotDocs := make([]int64, 0, len(res.DocIds))
 		for d := range res.DocIds {
 			gotDocs = append(gotDocs, d)
 		}
-		sort.Strings(gotDocs)
+		sort.Slice(gotDocs, func(i, j int) bool { return gotDocs[i] < gotDocs[j] })
 		t.Errorf("expected 3 docs after partial removal, got %d: %v", len(res.DocIds), gotDocs)
 	}
 

--- a/core/invertedindex/invertedindex.go
+++ b/core/invertedindex/invertedindex.go
@@ -4,6 +4,7 @@
 package invertedindex
 
 import (
+	"encoding/binary"
 	"log"
 	"strings"
 )
@@ -15,8 +16,8 @@ const MaxInvertedIndexSize = 1000
 // matches that came from wildcard expansion and may be filtered further by the
 // caller. Both are sets keyed by document id.
 type SearchResult struct {
-	DocIds     map[string]struct{} `json:"docIds"`
-	WildDocIds map[string]struct{} `json:"wildDocIds,omitempty"`
+	DocIds     map[int64]struct{} `json:"docIds"`
+	WildDocIds map[int64]struct{} `json:"wildDocIds,omitempty"`
 }
 
 // Search returns the union of document ids whose keywords match query within
@@ -26,7 +27,7 @@ type SearchResult struct {
 // the number of distinct document ids collected; limit <= 0 means unlimited.
 func (idx *Index) Search(tableId int, query string, limit int, filterKeyword func(string) bool) SearchResult {
 	results := SearchResult{
-		DocIds: make(map[string]struct{}),
+		DocIds: make(map[int64]struct{}),
 	}
 
 	err := idx.db.Scan(idx.encodeInvertedSearchKey(tableId, strings.ToLower(query)), func(key, value []byte) bool {
@@ -34,11 +35,11 @@ func (idx *Index) Search(tableId int, query string, limit int, filterKeyword fun
 			return true
 		}
 
-		// Iterate the packed 8-byte docids straight into the result set, avoiding
-		// the intermediate []string that decodeInvertedValue would allocate.
-		if len(value)%8 == 0 {
-			for i := 0; i < len(value); i += 8 {
-				results.DocIds[string(value[i:i+8])] = struct{}{}
+		// Iterate the packed 8-byte docids straight into the result set, decoding
+		// each big-endian int64 in place — no per-docid string allocation.
+		if len(value)%docIDSize == 0 {
+			for i := 0; i < len(value); i += docIDSize {
+				results.DocIds[int64(binary.BigEndian.Uint64(value[i:i+docIDSize]))] = struct{}{}
 			}
 		}
 
@@ -60,7 +61,7 @@ func (idx *Index) Search(tableId int, query string, limit int, filterKeyword fun
 // lower-casing) as an inverted-key prefix, with no limit or filtering.
 func (idx *Index) GetDocs(tableId int, key string) SearchResult {
 	results := SearchResult{
-		DocIds: make(map[string]struct{}),
+		DocIds: make(map[int64]struct{}),
 	}
 
 	want := key
@@ -74,7 +75,7 @@ func (idx *Index) GetDocs(tableId int, key string) SearchResult {
 		}
 		if len(value)%docIDSize == 0 {
 			for i := 0; i < len(value); i += docIDSize {
-				results.DocIds[string(value[i:i+docIDSize])] = struct{}{}
+				results.DocIds[int64(binary.BigEndian.Uint64(value[i:i+docIDSize]))] = struct{}{}
 			}
 		}
 		return true
@@ -89,7 +90,7 @@ func (idx *Index) GetDocs(tableId int, key string) SearchResult {
 // Update updates the keywords index for a document.
 // If len(newKeywords) == 0, it will remove the document from the keywords index.
 // This function MUST be called in dbMPSCQueue.
-func (idx *Index) Update(tableId int, docid string, newKeywords, oldKeywords []string) {
+func (idx *Index) Update(tableId int, docid int64, newKeywords, oldKeywords []string) {
 	// Handle the case of complete deletion
 	if len(newKeywords) == 0 {
 		if len(oldKeywords) > 0 {

--- a/core/invertedindex/invertedindex_internal.go
+++ b/core/invertedindex/invertedindex_internal.go
@@ -10,17 +10,11 @@ import (
 // updateIndex updates the keyword index in write cache.
 // It will add the document to the keyword index cache to merge with other
 // documents and flush later.
-func (idx *Index) updateIndex(tableId int, docid string, keywords []string) {
-	// Row values are fixed docIDSize-byte docids concatenated with no delimiter,
-	// so a docid of any other length (including the empty string) corrupts the
-	// value chunking on decode — fabricating/dropping docids that can never be
-	// searched or deleted. Reject at WRITE ingress. (The delete path needs no
-	// such guard: a wrong-length docid in a removal simply matches no stored
-	// 8-byte docid and is a harmless no-op.)
-	if len(docid) != docIDSize {
-		log.Printf("[Inverted] Warning: ignoring add for table %d: docid must be %d bytes, got %d", tableId, docIDSize, len(docid))
-		return
-	}
+func (idx *Index) updateIndex(tableId int, docid int64, keywords []string) {
+	// docids are fixed-width 8-byte big-endian int64s on disk; an int64 is always
+	// exactly that width by construction, so the value codec can never be
+	// corrupted by a malformed docid (the previous string-based ingress guard is
+	// no longer representable and has been removed).
 	cache := idx.getPendingWrite(tableId)
 	now := time.Now() // one timestamp for the whole update (per-keyword time.Now is hot)
 	for _, kw := range keywords {
@@ -34,7 +28,7 @@ func (idx *Index) updateIndex(tableId int, docid string, keywords []string) {
 	}
 }
 
-func (idx *Index) removeIndex(tableId int, docid string, keywords []string) {
+func (idx *Index) removeIndex(tableId int, docid int64, keywords []string) {
 	w := idx.getPendingDelete(tableId)
 	now := time.Now()
 	for _, kw := range keywords {
@@ -49,7 +43,7 @@ func (idx *Index) removeIndex(tableId int, docid string, keywords []string) {
 // writeInvertedIndex writes a keyword to the database.
 // Callers must pass the pre-computed key via idx.encodeInvertedKey so that the
 // configured key-type bytes are honoured.
-var writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []string, key []byte) {
+var writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []int64, key []byte) {
 	// Remove duplicates to ensure the data stored is clean
 	uniqueDocids := removeDuplicatesEfficiently(docids)
 	content := encodeInvertedValue(uniqueDocids)
@@ -58,18 +52,16 @@ var writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []s
 
 // removeDocumentsFromInvertedIndex removes a document from the keywords index.
 // It will remove the document from the keywords index and rewrite the keyword with new docids.
-func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, kw string, removingDocids []string,
+func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, kw string, removingDocids []int64,
 	maxKeywordIndexSize int) error {
 	if len(kw) == 0 {
 		log.Println("[Inverted] Warning: Removing document from keywords index, but keyword is empty")
 		return nil
 	}
 
-	removings := map[string]struct{}{}
+	removings := map[int64]struct{}{}
 	for _, id := range removingDocids {
-		if id != "" {
-			removings[id] = struct{}{}
-		}
+		removings[id] = struct{}{}
 	}
 
 	if len(removings) == 0 {
@@ -78,7 +70,7 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 	}
 
 	keys := []string{}
-	docids := map[string]struct{}{}
+	docids := map[int64]struct{}{}
 	err := idx.db.Scan(idx.encodeInvertedKeyPrefix(tableId, kw), func(key, value []byte) bool {
 		// The prefix "<tid>|<kw>|" also matches rows of any keyword "kw|..." (the
 		// keyword may contain '|'), so skip rows whose decoded keyword is not
@@ -87,7 +79,7 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 			return true
 		}
 		changed := false
-		tmpids := []string{}
+		tmpids := []int64{}
 
 		ids := decodeInvertedValue(value)
 		for _, id := range ids {
@@ -96,9 +88,7 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 				changed = true
 				continue
 			}
-			if id != "" {
-				tmpids = append(tmpids, id)
-			}
+			tmpids = append(tmpids, id)
 		}
 
 		if changed || len(tmpids) < maxKeywordIndexSize/2 {
@@ -115,7 +105,7 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 	}
 
 	for len(docids) > 0 {
-		docs := []string{}
+		docs := []int64{}
 		for id := range docids {
 			if len(docs) >= maxKeywordIndexSize {
 				break
@@ -145,13 +135,13 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 
 // removeDuplicatesEfficiently removes duplicates from the docids slice.
 // It returns a new slice with duplicates removed, preserving first-occurrence order.
-func removeDuplicatesEfficiently(docids []string) []string {
+func removeDuplicatesEfficiently(docids []int64) []int64 {
 	if len(docids) <= 1 {
 		return docids
 	}
 
-	seen := make(map[string]bool, len(docids))
-	result := make([]string, 0, len(docids))
+	seen := make(map[int64]bool, len(docids))
+	result := make([]int64, 0, len(docids))
 
 	for _, docid := range docids {
 		if !seen[docid] {

--- a/core/invertedindex/key_robustness_test.go
+++ b/core/invertedindex/key_robustness_test.go
@@ -56,25 +56,31 @@ func TestEncodeInvertedKey_UniqueWithinMicrosecond(t *testing.T) {
 	}
 }
 
-// B4/B5/B8 — non-8-byte docids (including empty) are rejected at ingress, so the
-// fixed-width value codec is never corrupted.
-func TestUpdate_RejectsNon8ByteDocid(t *testing.T) {
+// B4/B5/B8 — docids are int64 by type, so the fixed-width value codec can never
+// be fed a wrong-length docid (the old string-ingress length guard is no longer
+// representable). This pins the surviving invariant: arbitrary int64 docids —
+// including 0, negative, and max — round-trip through Update/GetDocs intact and
+// every stored value stays a multiple of docIDSize.
+func TestUpdate_Int64DocidRoundTrip(t *testing.T) {
 	env := setupTestEnv(t)
 	defer env.teardown()
-	env.idx.Update(1, "short", []string{"kw"}, nil)         // 5 bytes -> rejected
-	env.idx.Update(1, "", []string{"kw"}, nil)              // empty   -> rejected
-	env.idx.Update(1, "toolongdocid", []string{"kw"}, nil)  // 12 bytes -> rejected
-	env.idx.Update(1, makeDocID("ok"), []string{"kw"}, nil) // 8 bytes -> accepted
+
+	docids := []int64{0, 1, -1, 1 << 40, 9223372036854775807 /* max int64 */}
+	for _, id := range docids {
+		env.idx.Update(1, id, []string{"kw"}, nil)
+	}
 	forceFlush(env.idx)
 
 	res := env.idx.GetDocs(1, "kw")
-	if len(res.DocIds) != 1 {
-		t.Errorf("expected only the 8-byte doc indexed, got %d docs: %v", len(res.DocIds), res.DocIds)
+	if len(res.DocIds) != len(docids) {
+		t.Errorf("expected %d docs indexed, got %d: %v", len(docids), len(res.DocIds), res.DocIds)
 	}
-	if _, ok := res.DocIds[makeDocID("ok")]; !ok {
-		t.Error("the valid 8-byte doc was not indexed")
+	for _, id := range docids {
+		if _, ok := res.DocIds[id]; !ok {
+			t.Errorf("docid %d was not indexed/retrieved", id)
+		}
 	}
-	// No stored value may have a non-multiple-of-8 length (would corrupt decode).
+	// No stored value may have a non-multiple-of-docIDSize length (would corrupt decode).
 	_ = env.DB.Scan([]byte{env.idx.keyTypeRow}, func(k, v []byte) bool {
 		if len(v)%docIDSize != 0 {
 			t.Errorf("corrupt value length %d for key %q", len(v), k)
@@ -95,7 +101,7 @@ func TestMerge_SkipsInvalidIdGarbageRow(t *testing.T) {
 	// Garbage key with a non-numeric tableId ("\x01") -> decodes to InvalidId, and
 	// its \x01 second byte sorts it just before the real "\x141|kw|..." rows.
 	garbage := append([]byte{env.idx.keyTypeRow}, []byte("\x01|kw|3|999")...)
-	_ = env.DB.Put(garbage, encodeInvertedValue([]string{makeDocID("evil")}))
+	_ = env.DB.Put(garbage, encodeInvertedValue([]int64{makeDocID("evil")}))
 
 	m := merging{NextIter: string(env.idx.keyTypeRow)}
 	for i := 0; i < 5; i++ {

--- a/core/invertedindex/keywords_merger.go
+++ b/core/invertedindex/keywords_merger.go
@@ -178,7 +178,7 @@ var rewriteIndex = func(batch kv.Batch, idx *Index, index *invertedIndexEntry, m
 	rows := index.Rows
 	remainingDocCount := index.DocCount
 	for len(rows) > 1 {
-		docids := map[string]struct{}{}
+		docids := map[int64]struct{}{}
 		for len(rows) > 0 && (len(docids) < maxKeywordIndexSize /* docs batched */ || remainingDocCount < max(maxKeywordIndexSize/5, 4) /* docs left */) {
 			row := rows[0]
 			rows = rows[1:]
@@ -190,7 +190,7 @@ var rewriteIndex = func(batch kv.Batch, idx *Index, index *invertedIndexEntry, m
 			}
 		}
 
-		ids := make([]string, 0, len(docids))
+		ids := make([]int64, 0, len(docids))
 		for id := range docids {
 			ids = append(ids, id)
 		}

--- a/core/invertedindex/keywords_merger_test.go
+++ b/core/invertedindex/keywords_merger_test.go
@@ -1,6 +1,7 @@
 package invertedindex
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"testing"
@@ -19,7 +20,7 @@ const (
 type mockBatchWrite struct {
 	deleted     []string
 	writtenKeys []string
-	writtenData [][]string
+	writtenData [][]int64
 	tableIds    []int
 	keywords    []string
 }
@@ -49,7 +50,7 @@ func (m *mockBatchWrite) DeletePrefix(prefix []byte) error {
 func setupTestMocks() func() {
 	// Override the writeKeywordIndex function for testing
 	originalWriteKeywordIndex := writeInvertedIndex
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {
 		mockBatch := batch.(*mockBatchWrite)
 		mockBatch.tableIds = append(mockBatch.tableIds, tableId)
 		mockBatch.keywords = append(mockBatch.keywords, keyword)
@@ -67,7 +68,7 @@ func newMockBatch(db kv.Store) *mockBatchWrite {
 	return &mockBatchWrite{
 		deleted:     []string{},
 		writtenKeys: []string{},
-		writtenData: [][]string{},
+		writtenData: [][]int64{},
 		tableIds:    []int{},
 		keywords:    []string{},
 	}
@@ -94,7 +95,7 @@ func verifyWriteOperations(t *testing.T, mockBatch *mockBatchWrite, index *inver
 
 	// For cases with merged data, check unique doc count
 	if len(mockBatch.writtenData) > 0 && expectedDocIDs > 0 {
-		uniqueDocs := make(map[string]struct{})
+		uniqueDocs := make(map[int64]struct{})
 		for _, docs := range mockBatch.writtenData {
 			for _, doc := range docs {
 				uniqueDocs[doc] = struct{}{}
@@ -210,22 +211,23 @@ func TestRewriteIndexWellBatched(t *testing.T) {
 	}
 }
 
-func Doc2ID(doc string) string {
-	// docid MUST be a 16 character string
+func Doc2ID(doc string) int64 {
+	// Reproduce the historical 8-byte (ASCII '0'-left-padded) docid label and read
+	// it as the big-endian int64 the index now stores. The bytes are identical to
+	// the previous string docid, so persisted encodings are unchanged.
 	if len(doc) > 8 {
-		return doc[0:8]
+		doc = doc[0:8]
 	}
-
-	return fmt.Sprintf("%s%s", strings.Repeat("0", 8-len(doc)), doc)
+	padded := strings.Repeat("0", 8-len(doc)) + doc
+	return int64(binary.BigEndian.Uint64([]byte(padded)))
 }
 
 func MakeDocsForKeyword(docs ...string) string {
-	result := ""
-	for _, doc := range docs {
-		result += Doc2ID(doc)
+	ids := make([]int64, len(docs))
+	for i, doc := range docs {
+		ids[i] = Doc2ID(doc)
 	}
-
-	return result
+	return string(encodeInvertedValue(ids))
 }
 
 // TestRewriteIndexMultipleBatches tests when multiple merge operations are needed
@@ -388,11 +390,11 @@ func TestMergeKeywordsIndexSingleTable(t *testing.T) {
 
 	writtenTables := []int{}
 	writtenKeywords := []string{}
-	writtenDocIDs := [][]string{}
+	writtenDocIDs := [][]int64{}
 
 	batch := newMockBatch(nil)
 	// Mock only the writeKeywordIndex function
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {
 		writtenTables = append(writtenTables, tableId)
 		writtenKeywords = append(writtenKeywords, keyword)
 		writtenDocIDs = append(writtenDocIDs, docIDs)
@@ -470,7 +472,7 @@ func TestMergeKeywordsIndexSingleTable(t *testing.T) {
 	if len(writtenDocIDs) != 1 {
 		t.Errorf("Expected 1 docID group, got %d", len(writtenDocIDs))
 	} else {
-		uniqueDocs := make(map[string]struct{})
+		uniqueDocs := make(map[int64]struct{})
 		for _, docID := range writtenDocIDs[0] {
 			uniqueDocs[docID] = struct{}{}
 		}
@@ -479,7 +481,7 @@ func TestMergeKeywordsIndexSingleTable(t *testing.T) {
 			t.Errorf("Expected 5 unique doc IDs, got %d", len(uniqueDocs))
 		}
 
-		expectedDocs := []string{Doc2ID("doc1"), Doc2ID("doc2"), Doc2ID("doc3"), Doc2ID("doc4"), Doc2ID("doc5")}
+		expectedDocs := []int64{Doc2ID("doc1"), Doc2ID("doc2"), Doc2ID("doc3"), Doc2ID("doc4"), Doc2ID("doc5")}
 		for _, doc := range expectedDocs {
 			if _, ok := uniqueDocs[doc]; !ok {
 				t.Errorf("Expected to find doc ID %q but it was missing", doc)
@@ -498,7 +500,7 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 	}()
 
 	// Track writes by table
-	writtenData := make(map[int]map[string][]string) // tableId -> keyword -> docIDs
+	writtenData := make(map[int]map[string][]int64) // tableId -> keyword -> docIDs
 	deletedKeys := []string{}
 
 	// Create mock batch
@@ -520,9 +522,9 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 	}
 
 	// Mock only the writeKeywordIndex function
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {
 		if _, ok := writtenData[tableId]; !ok {
-			writtenData[tableId] = make(map[string][]string)
+			writtenData[tableId] = make(map[string][]int64)
 		}
 		writtenData[tableId][keyword] = docIDs
 	}
@@ -599,7 +601,7 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 		if docs, ok := ws1Data["keyword1"]; !ok {
 			t.Errorf("Expected keyword1 data for table1 but found none")
 		} else {
-			uniqueDocs := make(map[string]struct{})
+			uniqueDocs := make(map[int64]struct{})
 			for _, doc := range docs {
 				uniqueDocs[doc] = struct{}{}
 			}
@@ -608,10 +610,10 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 				t.Errorf("Expected 5 unique docs for table1, got %d", len(uniqueDocs))
 			}
 
-			expectedDocs := []string{Doc2ID("doc1"), Doc2ID("doc2"), Doc2ID("doc3"), Doc2ID("doc4"), Doc2ID("doc5")}
+			expectedDocs := []int64{Doc2ID("doc1"), Doc2ID("doc2"), Doc2ID("doc3"), Doc2ID("doc4"), Doc2ID("doc5")}
 			for _, doc := range expectedDocs {
 				if _, ok := uniqueDocs[doc]; !ok {
-					t.Errorf("Expected doc %s in table1 but it was missing", doc)
+					t.Errorf("Expected doc %d in table1 but it was missing", doc)
 				}
 			}
 		}
@@ -628,7 +630,7 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 		if docs, ok := ws2Data["keyword1"]; !ok {
 			t.Errorf("Expected keyword1 data for table2 but found none")
 		} else {
-			uniqueDocs := make(map[string]struct{})
+			uniqueDocs := make(map[int64]struct{})
 			for _, doc := range docs {
 				uniqueDocs[doc] = struct{}{}
 			}
@@ -637,10 +639,10 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 				t.Errorf("Expected 5 unique docs for table2, got %d", len(uniqueDocs))
 			}
 
-			expectedDocs := []string{Doc2ID("doc6"), Doc2ID("doc7"), Doc2ID("doc8"), Doc2ID("doc9"), Doc2ID("doc10")}
+			expectedDocs := []int64{Doc2ID("doc6"), Doc2ID("doc7"), Doc2ID("doc8"), Doc2ID("doc9"), Doc2ID("doc10")}
 			for _, doc := range expectedDocs {
 				if _, ok := uniqueDocs[doc]; !ok {
-					t.Errorf("Expected doc %s in table2 but it was missing", doc)
+					t.Errorf("Expected doc %d in table2 but it was missing", doc)
 				}
 			}
 		}
@@ -741,7 +743,7 @@ func TestMergeKeywordsIndexTimeout(t *testing.T) {
 	}
 
 	// Mock only the writeKeywordIndex function
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {
 		// No-op for this test
 	}
 
@@ -900,7 +902,7 @@ func TestKeywordsMerger_RunMergeWithData(t *testing.T) {
 		newBatch = origBatch
 	}()
 
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {
 		// no-op: we don't need to persist data
 	}
 	newBatch = func(db kv.Store) kv.Batch {
@@ -977,7 +979,7 @@ func TestKeywordsMerger_NewScanAfterComplete(t *testing.T) {
 		newBatch = origBatch
 	}()
 
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {}
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {}
 	newBatch = func(db kv.Store) kv.Batch {
 		return &mockBatchWriteWithFuncs{
 			deleteFunc: func(key []byte) error { return nil },
@@ -1037,7 +1039,7 @@ func TestMergeKeywordsIndex_WellBatchedSkip(t *testing.T) {
 		newBatch = origBatch
 	}()
 
-	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []string, data []byte) {}
+	writeInvertedIndex = func(batch kv.Batch, tableId int, keyword string, docIDs []int64, data []byte) {}
 	newBatch = func(db kv.Store) kv.Batch {
 		return &mockBatchWriteWithFuncs{
 			deleteFunc: func(key []byte) error { return nil },
@@ -1081,7 +1083,7 @@ func TestKeywordsMerger_RunWithPendingWrites(t *testing.T) {
 	// Insert pending writes so the merge task sees them and sets WaitingForFlushCache.
 	pw := env.idx.getPendingWrite(1)
 	pw.InvertedIndex["testword"] = relatedDocs{
-		DocIds:    []string{"doc1"},
+		DocIds:    []int64{Doc2ID("doc1")},
 		UpdatedAt: time.Now(),
 	}
 

--- a/core/invertedindex/pending_writes.go
+++ b/core/invertedindex/pending_writes.go
@@ -6,7 +6,7 @@ import (
 )
 
 type relatedDocs struct {
-	DocIds    []string
+	DocIds    []int64
 	UpdatedAt time.Time
 }
 

--- a/core/invertedindex/search_bench_test.go
+++ b/core/invertedindex/search_bench_test.go
@@ -1,0 +1,65 @@
+package invertedindex
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/codetrek/haystack/core/kv/pebblekv"
+	"github.com/codetrek/haystack/core/queue"
+)
+
+// benchSearchEnv builds an index holding a single keyword "kw" with nDocs
+// postings, flushed to one row. It exercises the Search decode-into-set hot
+// path (the per-docid allocation that the int64 representation removes).
+func benchSearchEnv(b *testing.B, nDocs int) (*Index, func()) {
+	b.Helper()
+	tempDir, err := os.MkdirTemp("", "haystack-inv-bench-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	db, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	q := queue.NewMpsc("BenchInvQueue")
+	q.Start()
+	idx, err := New(db, q, Options{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := range nDocs {
+		idx.Update(1, makeDocID(fmt.Sprintf("d%07d", i)), []string{"kw"}, nil)
+	}
+	forceFlush(idx)
+	cleanup := func() {
+		idx.CloseAndWait()
+		q.Stop()
+		db.Close()
+		os.RemoveAll(tempDir)
+	}
+	return idx, cleanup
+}
+
+// BenchmarkSearchCollect measures Search building the result set over a posting
+// list. allocs/op is the deterministic signal for the docid-as-int64 change.
+func BenchmarkSearchCollect(b *testing.B) {
+	log.SetOutput(io.Discard) // silence the index's flush/merge logs so they don't corrupt benchmark output
+	for _, n := range []int{50, 1000} {
+		b.Run(fmt.Sprintf("docs=%d", n), func(b *testing.B) {
+			idx, cleanup := benchSearchEnv(b, n)
+			defer cleanup()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				res := idx.Search(1, "kw", -1, nil)
+				if len(res.DocIds) != n {
+					b.Fatalf("got %d docids, want %d", len(res.DocIds), n)
+				}
+			}
+		})
+	}
+}

--- a/core/invertedindex/test_helper_test.go
+++ b/core/invertedindex/test_helper_test.go
@@ -45,7 +45,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	newBatch = func(db kv.Store) kv.Batch {
 		return db.NewBatch(MaxBatchSize)
 	}
-	writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []string, key []byte) {
+	writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []int64, key []byte) {
 		uniqueDocids := removeDuplicatesEfficiently(docids)
 		content := encodeInvertedValue(uniqueDocids)
 		batch.Put(key, content)

--- a/internal/core/symbols/function.go
+++ b/internal/core/symbols/function.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/codetrek/haystack/core/idtable"
 	"github.com/codetrek/haystack/core/kv"
 	"github.com/codetrek/haystack/core/tokenizer"
 	"github.com/codetrek/haystack/internal/conf"
@@ -197,14 +198,14 @@ func updateSymbolWordsInverseIndex(workspaceid int, docId string, newFuncNames, 
 			wordsInOldFuncNames = append(wordsInOldFuncNames, strings.ToLower(word))
 		}
 	}
-	idxInst.Update(sw.InvertedId, docId, wordsInNewFuncNames, wordsInOldFuncNames)
+	idxInst.Update(sw.InvertedId, idtable.DecodeId(docId), wordsInNewFuncNames, wordsInOldFuncNames)
 
 	s, err := GetSymbolTable(workspaceid)
 	if err != nil {
 		log.Println("[Symbols] Error: failed to get symbol table:", err)
 		return
 	}
-	idxInst.Update(s.InvertedId, docId, newFuncNames, oldFuncNames)
+	idxInst.Update(s.InvertedId, idtable.DecodeId(docId), newFuncNames, oldFuncNames)
 }
 
 func DeleteDocument(workspaceId int, docId string) error {
@@ -228,7 +229,7 @@ func DeleteDocument(workspaceId int, docId string) error {
 			log.Println("[Symbols] Error: failed to get existing functions for document:", docId, err)
 			return err
 		}
-		idxInst.Update(s.InvertedId, docId, []string{}, getUniqueFunctionNames(oldFunctions))
+		idxInst.Update(s.InvertedId, idtable.DecodeId(docId), []string{}, getUniqueFunctionNames(oldFunctions))
 
 		batch := NewBatch(db)
 		batch.Delete(EncodeDocFunctionsKey(workspaceId, docId))

--- a/internal/server/searcher/searcher.go
+++ b/internal/server/searcher/searcher.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/codetrek/haystack/core/documents"
 	"github.com/codetrek/haystack/core/engine"
+	"github.com/codetrek/haystack/core/idtable"
 	"github.com/codetrek/haystack/core/invertedindex"
 	"github.com/codetrek/haystack/internal/conf"
 	"github.com/codetrek/haystack/internal/core/workspace"
@@ -52,20 +53,21 @@ type QueryFilters struct {
 }
 
 func sortDocuments(workspaceId int, editor *types.Editor, sr *invertedindex.SearchResult,
-	filter func(path string) bool) []string {
+	filter func(path string) bool) []int64 {
 	start := time.Now()
 
-	docs := map[string]string{}
+	docs := map[string]int64{}
 	if len(sr.DocIds) > 10000 {
 		stInst.ScanFiles(workspaceId, func(docid, relPath string) bool {
-			if _, ok := sr.DocIds[docid]; ok {
-				docs[relPath] = docid
+			id := idtable.DecodeId(docid)
+			if _, ok := sr.DocIds[id]; ok {
+				docs[relPath] = id
 			}
 			return true
 		})
 	} else {
 		for docid := range sr.DocIds {
-			relPath := stInst.GetDocumentPath(workspaceId, docid)
+			relPath := stInst.GetDocumentPath(workspaceId, idtable.EncodeId(docid))
 			if relPath != "" {
 				docs[relPath] = docid
 			}
@@ -81,7 +83,7 @@ func sortDocuments(workspaceId int, editor *types.Editor, sr *invertedindex.Sear
 		}
 	}
 
-	sorted := make([]string, 0, len(sr.DocIds))
+	sorted := make([]int64, 0, len(sr.DocIds))
 	if editor != nil {
 		var add = func(dir string) {
 			if dir != "" {
@@ -310,7 +312,7 @@ func SearchContent(workspace *workspace.Workspace, req *types.SearchContentReque
 			break
 		}
 
-		doc, err := stInst.GetDocument(workspace.Id, docid, false)
+		doc, err := stInst.GetDocument(workspace.Id, idtable.EncodeId(docid), false)
 		if err != nil || doc == nil {
 			continue
 		}

--- a/internal/server/searcher/searcher_boost_test.go
+++ b/internal/server/searcher/searcher_boost_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestSortDocuments_FilterRejectsDocs(t *testing.T) {
 	sr := &invertedindex.SearchResult{
-		DocIds:     map[string]struct{}{},
-		WildDocIds: map[string]struct{}{},
+		DocIds:     map[int64]struct{}{},
+		WildDocIds: map[int64]struct{}{},
 	}
 	result := sortDocuments(0, nil, sr, func(_ string) bool { return false })
 	assert.NotNil(t, result)
@@ -29,8 +29,8 @@ func TestSortDocuments_FilterRejectsDocs(t *testing.T) {
 
 func TestSortDocuments_EditorEmpty(t *testing.T) {
 	sr := &invertedindex.SearchResult{
-		DocIds:     map[string]struct{}{},
-		WildDocIds: map[string]struct{}{},
+		DocIds:     map[int64]struct{}{},
+		WildDocIds: map[int64]struct{}{},
 	}
 	editor := &types.Editor{}
 	result := sortDocuments(0, editor, sr, func(_ string) bool { return true })

--- a/internal/server/searcher/searcher_coverage_test.go
+++ b/internal/server/searcher/searcher_coverage_test.go
@@ -874,8 +874,8 @@ func TestFullIntegration(t *testing.T) {
 		ws := makeWS(t, map[string]string{"main.go": "package main\n"})
 
 		sr := &invertedindex.SearchResult{
-			DocIds:     map[string]struct{}{},
-			WildDocIds: map[string]struct{}{},
+			DocIds:     map[int64]struct{}{},
+			WildDocIds: map[int64]struct{}{},
 		}
 		result := sortDocuments(ws.Id, nil, sr, func(p string) bool { return true })
 		assert.NotNil(t, result)
@@ -888,8 +888,8 @@ func TestFullIntegration(t *testing.T) {
 		})
 
 		sr := &invertedindex.SearchResult{
-			DocIds:     map[string]struct{}{},
-			WildDocIds: map[string]struct{}{},
+			DocIds:     map[int64]struct{}{},
+			WildDocIds: map[int64]struct{}{},
 		}
 		editor := &types.Editor{
 			ActiveFile: "main.go",
@@ -930,7 +930,7 @@ func TestFullIntegration(t *testing.T) {
 			return relPath == "keep.go"
 		})
 		for _, docid := range sorted {
-			doc, _ := stInst.GetDocument(sharedWS.Id, docid, false)
+			doc, _ := stInst.GetDocument(sharedWS.Id, idtable.EncodeId(docid), false)
 			if doc != nil {
 				assert.Equal(t, "keep.go", doc.RelPath)
 			}
@@ -967,8 +967,8 @@ func TestFullIntegration(t *testing.T) {
 		assert.NotEmpty(t, docId, "wild.go must be indexed")
 
 		sr := &invertedindex.SearchResult{
-			DocIds:     map[string]struct{}{docId: {}},
-			WildDocIds: map[string]struct{}{docId: {}},
+			DocIds:     map[int64]struct{}{idtable.DecodeId(docId): {}},
+			WildDocIds: map[int64]struct{}{idtable.DecodeId(docId): {}},
 		}
 		result := sortDocuments(sharedWS.Id, nil, sr, func(_ string) bool { return true })
 		assert.NotNil(t, result)
@@ -988,8 +988,8 @@ func TestFullIntegration(t *testing.T) {
 		assert.NotEmpty(t, docId, "reject_wild.go must be indexed")
 
 		sr := &invertedindex.SearchResult{
-			DocIds:     map[string]struct{}{docId: {}},
-			WildDocIds: map[string]struct{}{docId: {}},
+			DocIds:     map[int64]struct{}{idtable.DecodeId(docId): {}},
+			WildDocIds: map[int64]struct{}{idtable.DecodeId(docId): {}},
 		}
 		result := sortDocuments(sharedWS.Id, nil, sr, func(_ string) bool { return false })
 		assert.NotNil(t, result)
@@ -999,19 +999,19 @@ func TestFullIntegration(t *testing.T) {
 	// --- sortDocuments: large DocIds triggers ScanFiles path (line 50-55) ---
 	t.Run("sortDocuments large docids uses ScanFiles", func(t *testing.T) {
 		// Build a SearchResult with >10000 fake DocIds to trigger the ScanFiles branch.
-		largeDocIds := make(map[string]struct{}, 10001)
+		largeDocIds := make(map[int64]struct{}, 10001)
 		for i := 0; i < 10001; i++ {
-			largeDocIds[fmt.Sprintf("fake-doc-%d", i)] = struct{}{}
+			largeDocIds[int64(1_000_000+i)] = struct{}{} // high range to avoid colliding with real small docids
 		}
 		// Also insert real indexed doc IDs so ScanFiles finds matches.
 		stInst.ScanFiles(sharedWS.Id, func(id, relPath string) bool {
-			largeDocIds[id] = struct{}{}
+			largeDocIds[idtable.DecodeId(id)] = struct{}{}
 			return true
 		})
 
 		sr := &invertedindex.SearchResult{
 			DocIds:     largeDocIds,
-			WildDocIds: map[string]struct{}{},
+			WildDocIds: map[int64]struct{}{},
 		}
 		result := sortDocuments(sharedWS.Id, nil, sr, func(_ string) bool { return true })
 		assert.NotNil(t, result)
@@ -1965,7 +1965,7 @@ func TestFullIntegration(t *testing.T) {
 		// Only files containing BOTH terms should survive intersection.
 		// Verify by resolving doc IDs to paths.
 		for docId := range result.DocIds {
-			doc, _ := stInst.GetDocument(sharedWS.Id, docId, false)
+			doc, _ := stInst.GetDocument(sharedWS.Id, idtable.EncodeId(docId), false)
 			if doc != nil {
 				assert.Equal(t, "andfileA.go", doc.RelPath,
 					"only andfileA.go should survive AND intersection")

--- a/internal/server/searcher/symbols_searcher.go
+++ b/internal/server/searcher/symbols_searcher.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/codetrek/haystack/core/documents"
+	"github.com/codetrek/haystack/core/idtable"
 	"github.com/codetrek/haystack/internal/core/symbols"
 	"github.com/codetrek/haystack/internal/core/workspace"
 	"github.com/codetrek/haystack/internal/server/indexer"
@@ -141,7 +142,7 @@ func fuzzySearchSymbols(workspace *workspace.Workspace, req *types.SearchSymbols
 			break
 		}
 
-		s, err := getFunctionFileMatch(workspace, words, docId)
+		s, err := getFunctionFileMatch(workspace, words, idtable.EncodeId(docId))
 		if err != nil {
 			continue
 		}
@@ -188,8 +189,9 @@ func searchSymbols(workspace *workspace.Workspace, req *types.SearchSymbolsReque
 	symbolFiles := make(map[string][]types.SymbolsFileMatch)
 
 	for docId := range r.DocIds {
+		docIdStr := idtable.EncodeId(docId)
 		// Get document info for file path
-		doc, err := stInst.GetDocument(workspace.Id, docId, false)
+		doc, err := stInst.GetDocument(workspace.Id, docIdStr, false)
 		if err != nil || doc == nil {
 			continue
 		}
@@ -199,7 +201,7 @@ func searchSymbols(workspace *workspace.Workspace, req *types.SearchSymbolsReque
 		}
 
 		// Get functions from this document
-		functions, err := symbols.GetDocFunctions(workspace.Id, docId)
+		functions, err := symbols.GetDocFunctions(workspace.Id, docIdStr)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## What

The docid was always the 8-byte big-endian encoding of an idtable `int64`, but it flowed through the index → engine → searcher as an opaque **string**. Every posting scanned in `Search` allocated an 8-byte heap string, and the engine's union/intersection set math ran over `map[string]` keyed by those strings.

This PR switches the **in-memory** representation to `int64` along the read/write hot path, while keeping the **storage** bytes byte-identical (fixed 8-byte big-endian) — so the on-disk format is unchanged and **no reindex is required**.

### Boundary (per design discussion: "对外 = wire 契约")
The product wire/JSON contract never carried a docid (`Document.ID` is `json:"-"`; responses use relpath), so it is unaffected by construction.

- **int64 island:** `invertedindex` (`SearchResult`, `Update`, codec, pending writes, merger), `engine` (`CollectDocuments` set math), `searcher`/`symbols` set math.
- **string kept at the storage boundary:** `idtable.GetId` and `documents.Store` keep their string-keyed APIs; new `idtable.EncodeId`/`DecodeId` convert **once** at the documents/symbols write sites and the searcher/symbols read sites.

### Notable
- `Search`/`GetDocs` decode each posting straight to `int64` via `binary.BigEndian.Uint64` — no per-docid string allocation.
- The old write-ingress length guard (`docid must be 8 bytes`) is **removed**: an `int64` is fixed-width by construction, so the value codec can no longer be fed a malformed docid. The corresponding rejection test is replaced by an int64 round-trip test (incl. `0`, negative, `max int64`).

## No reindex — byte parity
The docid was already big-endian on disk; the int64 form re-encodes to the exact same bytes. A golden test asserts `encodeInvertedValue([]int64{…})` is byte-for-byte equal to the old `strings.Join` form, and `idtable.EncodeId` is verified to reproduce the exact string `GetId` hands out.

## Verification
- ✅ core suite green + internal 14 packages green. The searcher's ~20 end-to-end tests exercise the full `Search → sortDocuments → GetDocument` path, covering the boundary-conversion parity.
- ✅ `go-cov` gate passes (TOTAL 92.9%; new `EncodeId`/`DecodeId` have direct tests).
- ✅ `gofmt` clean.

## Measured win
`benchstat`, n=6, p=0.002, `core/invertedindex` `BenchmarkSearchCollect` (alloc/op is deterministic and machine-independent — local is the correct source for this microbenchmark):

| metric | docs=1000 | geomean |
|---|---|---|
| **allocs/op** | 1027 → **27** (−97%) | **−95%** |
| **B/op** | 115Ki → 73Ki (−36%) | −50% |
| **sec/op** | 132µs → 93µs (−29%) | −59% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)