### PR TITLE
refactor(idtable): extract into a standalone bbolt-backed component

### DIFF
--- a/core/engine/integration_test.go
+++ b/core/engine/integration_test.go
@@ -38,7 +38,7 @@ func buildIndexedStack(t *testing.T, docMap map[string][]string) *indexedStack {
 	q := queue.NewMpsc("engine-test-writes")
 	q.Start()
 
-	alloc, err := idtable.New(store, idtable.Options{})
+	alloc, err := idtable.Open(filepath.Join(tmpDir, "idtable.db"), idtable.Options{})
 	require.NoError(t, err)
 	ids := make(map[string]string, len(docMap))
 	for relPath := range docMap {

--- a/core/engine/readme_example_test.go
+++ b/core/engine/readme_example_test.go
@@ -38,9 +38,9 @@ func TestReadmeExample(t *testing.T) {
 
 	// Allocate a stable 8-byte document id from idtable (IDs must be exactly
 	// 8 bytes so the inverted-index codec can decode them correctly).
-	alloc, err := idtable.New(store, idtable.Options{})
+	alloc, err := idtable.Open(filepath.Join(tmpDir, "idtable.db"), idtable.Options{})
 	if err != nil {
-		t.Fatalf("idtable.New: %v", err)
+		t.Fatalf("idtable.Open: %v", err)
 	}
 	docID, err := alloc.GetId([]byte("main.go")) // path → stable 8-byte id
 	if err != nil {

--- a/core/idtable/closed_commit_test.go
+++ b/core/idtable/closed_commit_test.go
@@ -5,77 +5,53 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codetrek/haystack/core/kv/pebblekv"
 	"github.com/stretchr/testify/require"
 )
 
-// TestTryCommitAfterStoreClosed reproduces the -race BLOCKER: a periodic
-// commit tick that fires AFTER the backing KV has been closed out from under
-// the allocator (e.g. a test's t.Cleanup closes the store while a 5s tick is
-// in flight) must NOT panic with "pebble: closed". tryCommit drives
-// batch.Commit() on the now-closed pebble; without a closed-store re-check
-// under the allocator lock it panics.
-//
-// We simulate the in-flight tick deterministically: stage a non-empty batch,
-// close the store, then invoke the exact tick code path (tryCommit under
-// a.mu). It must return a clean error (no panic, no flush against closed KV).
-func TestTryCommitAfterStoreClosed(t *testing.T) {
-	dir := t.TempDir()
-	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
+// TestTryCommitAfterClose verifies the closed-state guard on the periodic-commit
+// path. With the standalone bbolt backend the Allocator OWNS its database and
+// Close stops the commit ticker BEFORE closing the db, so the old "tick commits
+// against a store closed out from under us" race (which panicked "pebble: closed"
+// under -race) is structurally impossible. This pins the remaining guard: driving
+// tryCommit after Close returns a clean error and never panics.
+func TestTryCommitAfterClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "idtable.db")
+	alloc, err := Open(path, Options{CommitInterval: time.Hour})
 	require.NoError(t, err)
 
-	// Long interval so the real background tick never races this test; we drive
-	// the tick path by hand.
-	alloc, err := New(store, Options{CommitInterval: time.Hour})
-	require.NoError(t, err)
-
-	// Stage pending writes so the batch is non-empty (tryCommit would Commit).
+	// Stage a pending allocation so tryCommit would have work to flush.
 	_, err = alloc.GetId([]byte("alpha"))
 	require.NoError(t, err)
-	require.Greater(t, alloc.batch.Count(), int32(0), "batch must be non-empty to exercise Commit")
+	require.Greater(t, len(alloc.pending), 0, "pending must be non-empty to exercise the flush path")
 
-	// Close the KV out from under the allocator (mimics external t.Cleanup).
-	require.NoError(t, store.Close())
-	require.True(t, store.IsClosed())
+	alloc.Close() // stops the ticker, flushes, then closes the bbolt db
 
-	// Drive the exact periodic-tick code path. Before the fix this panics with
-	// "pebble: closed"; after the fix it must return without panicking and
-	// without committing against the closed store.
+	// Drive the exact periodic-tick code path after Close. It must return a clean
+	// error (db is closed) and must not panic.
 	require.NotPanics(t, func() {
 		alloc.mu.Lock()
 		defer alloc.mu.Unlock()
-		if err := alloc.tryCommit(); err != nil {
-			// A clean error is acceptable; a panic is not.
-			t.Logf("tryCommit returned clean error on closed store: %v", err)
+		if err := alloc.tryCommit(); err == nil {
+			t.Error("tryCommit after Close should return an error")
 		}
-	}, "tryCommit on a closed store must not panic")
+	}, "tryCommit after Close must not panic")
 
-	// Close() must also be safe after the store is already closed.
-	require.NotPanics(t, func() { alloc.Close() }, "Close after store close must not panic")
+	// A second Close is also safe.
+	require.NotPanics(t, func() { alloc.Close() }, "double Close must not panic")
 }
 
-// TestPeriodicTickAfterStoreClosed exercises the real background ticker firing
-// after the store is closed: with a tiny interval the ticker reliably fires
-// while/after the KV is closed. It must not panic the process.
-func TestPeriodicTickAfterStoreClosed(t *testing.T) {
-	dir := t.TempDir()
-	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
+// TestPeriodicTickWithTinyInterval runs the real background ticker at a tiny
+// interval while allocations are staged, then Closes. Close must coordinate the
+// ticker shutdown cleanly (no panic, no deadlock) — the bbolt backend owns its
+// db so there is no external close to race.
+func TestPeriodicTickWithTinyInterval(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "idtable.db")
+	alloc, err := Open(path, Options{CommitInterval: time.Millisecond})
 	require.NoError(t, err)
 
-	// Tiny interval so the ticker fires many times.
-	alloc, err := New(store, Options{CommitInterval: time.Millisecond})
-	require.NoError(t, err)
-
-	// Stage pending writes so each tick has something to Commit.
 	_, err = alloc.GetId([]byte("beta"))
 	require.NoError(t, err)
+	time.Sleep(20 * time.Millisecond) // let the ticker fire many times
 
-	// Close the store under the allocator without calling alloc.Close() first,
-	// then let the ticker fire repeatedly against the closed KV.
-	require.NoError(t, store.Close())
-	time.Sleep(20 * time.Millisecond) // many ticks cross the closed store
-
-	// If a tick committed against the closed pebble, the process would have
-	// already panicked. Reaching here and closing cleanly proves the fix.
-	require.NotPanics(t, func() { alloc.Close() })
+	require.NotPanics(t, func() { alloc.Close() }, "Close during active ticking must not panic")
 }

--- a/core/idtable/commit_public_test.go
+++ b/core/idtable/commit_public_test.go
@@ -5,53 +5,50 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codetrek/haystack/core/kv/pebblekv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestCommit_DurableBeforeClose covers the public synchronous Commit: it must
-// flush the pending key→id batch + nextId counter to the KV (fsync'd) so the
-// allocations survive a crash that never reaches Close. A long CommitInterval
-// keeps the background tick from firing, so Commit is the only flush.
+// flush the pending key→id allocations + nextId counter to the bbolt db (fsync'd
+// on transaction commit) so the allocations survive a crash that never reaches
+// Close. A long CommitInterval keeps the background tick from firing, so Commit
+// is the only flush.
 func TestCommit_DurableBeforeClose(t *testing.T) {
-	dir := t.TempDir()
-	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
-	require.NoError(t, err)
-	defer store.Close()
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	alloc, err := New(store, Options{CommitInterval: time.Hour})
+	alloc, err := Open(path, Options{CommitInterval: time.Hour})
 	require.NoError(t, err)
-	id, err := alloc.GetId([]byte("alpha")) // stages key→id + nextId into the batch
+	id, err := alloc.GetId([]byte("alpha")) // stages a pending allocation + nextId
 	require.NoError(t, err)
 	require.Len(t, id, 8)
 
-	// Synchronous Commit makes it durable WITHOUT Close.
+	// Synchronous Commit makes it durable.
 	require.NoError(t, alloc.Commit())
-	// A second Commit with an empty batch is a no-op (no error).
+	require.Empty(t, alloc.pending, "Commit must drain the pending buffer")
+	// A second Commit with nothing pending is a no-op (no error).
 	require.NoError(t, alloc.Commit())
 
-	// Reopen over the same store (no Close of alloc) — the mapping must be present.
-	alloc2, err := New(store, Options{CommitInterval: time.Hour})
+	// Close is now a no-op flush (pending already drained by Commit); reopen and
+	// verify the mapping persisted via Commit.
+	alloc.Close()
+	alloc2, err := Open(path, Options{CommitInterval: time.Hour})
 	require.NoError(t, err)
 	got, err := alloc2.GetId([]byte("alpha"))
 	require.NoError(t, err)
-	assert.Equal(t, id, got, "id must survive via Commit, not Close")
+	assert.Equal(t, id, got, "id must survive via Commit")
 	alloc2.Close()
 }
 
-// TestCommit_OnClosedStoreErrors covers Commit's closed-store guard.
+// TestCommit_OnClosedStoreErrors covers Commit's closed-state guard.
 func TestCommit_OnClosedStoreErrors(t *testing.T) {
-	dir := t.TempDir()
-	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
-	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	alloc, err := New(store, Options{CommitInterval: time.Hour})
+	alloc, err := Open(path, Options{CommitInterval: time.Hour})
 	require.NoError(t, err)
-	require.NoError(t, store.Close()) // close the backing store under the allocator
+	alloc.Close() // close the allocator (and its bbolt db)
 
 	if err := alloc.Commit(); err == nil {
-		t.Fatal("Commit on a closed store should error")
+		t.Fatal("Commit on a closed allocator should error")
 	}
-	alloc.Close()
 }

--- a/core/idtable/commit_test.go
+++ b/core/idtable/commit_test.go
@@ -5,31 +5,26 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codetrek/haystack/core/kv/pebblekv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestTryCommitOnClose deterministically exercises tryCommit's flush path. A
 // long CommitInterval keeps the periodic-commit goroutine from firing, so the
-// pending batch is still non-empty when Close() calls tryCommit — making the
-// Commit/Reset path reliably covered (the default-interval tests race the
-// background goroutine, which can empty the batch first).
+// pending allocations are still present when Close() calls tryCommit — making
+// the flush path reliably covered.
 func TestTryCommitOnClose(t *testing.T) {
-	dir := t.TempDir()
-	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
-	require.NoError(t, err)
-	defer store.Close()
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	alloc, err := New(store, Options{CommitInterval: time.Hour})
+	alloc, err := Open(path, Options{CommitInterval: time.Hour})
 	require.NoError(t, err)
-	id, err := alloc.GetId([]byte("alpha")) // queues writes into the batch
+	id, err := alloc.GetId([]byte("alpha")) // stages a pending allocation
 	require.NoError(t, err)
 	require.Len(t, id, 8)
-	alloc.Close() // tryCommit flushes the non-empty batch
+	alloc.Close() // tryCommit flushes the pending allocation
 
 	// Reopen: the id must have been persisted by the close-time commit.
-	alloc2, err := New(store, Options{CommitInterval: time.Hour})
+	alloc2, err := Open(path, Options{CommitInterval: time.Hour})
 	require.NoError(t, err)
 	got, err := alloc2.GetId([]byte("alpha"))
 	require.NoError(t, err)

--- a/core/idtable/encode_id_test.go
+++ b/core/idtable/encode_id_test.go
@@ -1,11 +1,9 @@
 package idtable
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/codetrek/haystack/core/kv/pebblekv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,19 +48,11 @@ func TestDecodeId_ShortStringIsInvalid(t *testing.T) {
 // hands out for the same underlying counter value, so the int64 form and the
 // string form are interchangeable at storage boundaries.
 func TestEncodeId_MatchesGetId(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-encode-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
-	store, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
-	assert.NoError(t, err)
-	defer store.Close()
-
-	alloc, err := New(store, Options{})
+	alloc, err := Open(filepath.Join(t.TempDir(), "idtable.db"), Options{})
 	assert.NoError(t, err)
 	defer alloc.Close()
 
-	// The first allocated id corresponds to nextId == 1 (New seeds nextId = 1).
+	// The first allocated id corresponds to nextId == 1 (Open seeds nextId = 1).
 	got, err := alloc.GetId([]byte("some/path.go"))
 	assert.NoError(t, err)
 	assert.Equal(t, EncodeId(1), got)

--- a/core/idtable/idtable.go
+++ b/core/idtable/idtable.go
@@ -160,10 +160,13 @@ func (a *Allocator) GetId(key []byte) (string, error) {
 		return "", fmt.Errorf("database is closed")
 	}
 
-	sk := string(key)
-	if v, ok := a.lru.Get(sk); ok {
+	// Hot path: keep string(key) inline in the LRU lookup so the compiler's
+	// no-alloc map-key optimization applies — hoisting it to a variable would
+	// force an allocation of the key string on every cached hit.
+	if v, ok := a.lru.Get(string(key)); ok {
 		return EncodeId(v), nil
 	}
+	sk := string(key)
 	// pending is authoritative for uncommitted allocations (robust to LRU eviction).
 	if v, ok := a.pending[sk]; ok {
 		a.lru.Put(sk, v)
@@ -199,10 +202,10 @@ func (a *Allocator) Lookup(key []byte) (id int64, found bool, err error) {
 		return 0, false, fmt.Errorf("database is closed")
 	}
 
-	sk := string(key)
-	if v, ok := a.lru.Get(sk); ok {
+	if v, ok := a.lru.Get(string(key)); ok { // inline string(key): no-alloc map-key path
 		return v, true, nil
 	}
+	sk := string(key)
 	if v, ok := a.pending[sk]; ok {
 		return v, true, nil
 	}

--- a/core/idtable/idtable.go
+++ b/core/idtable/idtable.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	DefaultLRUCacheSize   = 200_000
-	DefaultCommitInterval = 5 * time.Second
+	DefaultCommitInterval = 1 * time.Second
 
 	// InvalidId is returned by DecodeId for a malformed (too-short) docid string.
 	InvalidId = int64(-1)
@@ -47,7 +47,7 @@ var (
 // Options configures an Allocator. Zero-value fields fall back to defaults.
 type Options struct {
 	LRUCacheSize   int           // default DefaultLRUCacheSize (200000)
-	CommitInterval time.Duration // default DefaultCommitInterval (5s)
+	CommitInterval time.Duration // default DefaultCommitInterval (1s)
 }
 
 // Allocator maps arbitrary keys to stable, compact int64 ids (returned as

--- a/core/idtable/idtable.go
+++ b/core/idtable/idtable.go
@@ -1,5 +1,9 @@
 // Package idtable allocates stable, compact int64 identifiers for arbitrary
-// byte keys, backed by a kv.Store with an LRU cache and background commit loop.
+// byte keys, backed by a self-owned bbolt file with an LRU cache and background
+// commit loop. It is a standalone component: each Allocator owns its own bbolt
+// database (no shared key-value store, no key-type prefixes), so it can be used
+// by independent subsystems (the document indexer, the vector store) without
+// colliding in a shared namespace.
 package idtable
 
 import (
@@ -10,102 +14,113 @@ import (
 	"sync"
 	"time"
 
-	"github.com/codetrek/haystack/core/kv"
+	bolt "go.etcd.io/bbolt"
 )
 
-// Default key-type prefix bytes (match the historical on-disk layout for on-disk compatibility).
 const (
-	DefaultKeyTypeNextId  = byte(28)
-	DefaultKeyTypeKey     = byte(29)
 	DefaultLRUCacheSize   = 200_000
-	DefaultBatchSize      = int32(100)
 	DefaultCommitInterval = 5 * time.Second
 
 	// InvalidId is returned by DecodeId for a malformed (too-short) docid string.
 	InvalidId = int64(-1)
+
+	// LegacyKeyTypeNextId / LegacyKeyTypeKey are the key-type prefix bytes the
+	// previous shared-kv.Store-backed allocator used by default. They are retained
+	// only as the default migration-source parameters for MigrateFromKV; the
+	// standalone bbolt layout uses buckets, not prefixes.
+	LegacyKeyTypeNextId = byte(28)
+	LegacyKeyTypeKey    = byte(29)
+
+	// openTimeout bounds how long Open waits for the bbolt file lock before
+	// failing, instead of blocking forever when another process holds it.
+	openTimeout = 5 * time.Second
+)
+
+// Bucket / meta-key names for the on-disk layout. These are stable: changing
+// them after data has been written makes previously allocated ids unreachable.
+var (
+	bucketKeys = []byte("keys") // raw key -> 8-byte big-endian id
+	bucketMeta = []byte("meta") // metadata bucket
+	metaNextId = []byte("nextId")
 )
 
 // Options configures an Allocator. Zero-value fields fall back to defaults.
 type Options struct {
-	// KeyTypeNextId is the single-byte KV key PREFIX under which the allocator
-	// persists its nextId counter. It namespaces the allocator's keys within a
-	// shared store. Changing it after data has been written is a breaking
-	// on-disk change: previously allocated ids become unreachable.
-	// A zero value selects DefaultKeyTypeNextId (28); byte 0 cannot be used as
-	// an explicit prefix because it is reserved to mean "use the default".
-	KeyTypeNextId byte
-	// KeyTypeKey is the single-byte KV key PREFIX under which the allocator
-	// persists each key→id mapping. The same breaking-change and zero-value
-	// ("use default", DefaultKeyTypeKey 29) constraints as KeyTypeNextId apply.
-	KeyTypeKey     byte
 	LRUCacheSize   int           // default DefaultLRUCacheSize (200000)
-	BatchSize      int32         // default DefaultBatchSize (100)
 	CommitInterval time.Duration // default DefaultCommitInterval (5s)
 }
 
-// Allocator maps arbitrary keys to stable, compact int64 ids (returned as 8-byte strings),
-// LRU-cached and persisted to the kv.Store, with a background commit loop.
+// Allocator maps arbitrary keys to stable, compact int64 ids (returned as
+// 8-byte big-endian strings), LRU-cached and persisted to a self-owned bbolt
+// database, with a background commit loop.
 type Allocator struct {
-	mu    sync.Mutex
-	store kv.Store
-	batch kv.Batch
-	// lru has its own internal locking, but every Allocator access to it
-	// (GetId, Close) already happens while holding a.mu, so its lock is
-	// effectively redundant here and never contended by this package.
-	lru            *lruCache
-	nextId         int64
-	keyTypeNextId  byte
-	keyTypeKey     byte
+	mu     sync.Mutex
+	db     *bolt.DB
+	closed bool
+	// lru has its own internal locking, but every Allocator access to it already
+	// happens while holding a.mu, so its lock is effectively redundant here.
+	lru *lruCache
+	// pending holds key->id allocations made since the last commit. It is the
+	// authoritative read-your-own-writes buffer: the LRU is bounded and may evict
+	// an uncommitted entry, so GetId/Lookup consult pending too before allocating
+	// a (duplicate) id. Cleared on every successful commit.
+	pending       map[string]int64
+	pendingNextId bool
+	nextId        int64
+
 	commitInterval time.Duration
 	closing        chan bool
 	done           chan bool
 }
 
-// New creates and starts an Allocator. Zero-value Options fields fall back to defaults.
-func New(store kv.Store, opts Options) (*Allocator, error) {
-	// Fill defaults
-	if opts.KeyTypeNextId == 0 {
-		opts.KeyTypeNextId = DefaultKeyTypeNextId
-	}
-	if opts.KeyTypeKey == 0 {
-		opts.KeyTypeKey = DefaultKeyTypeKey
-	}
+// Open creates and starts an Allocator backed by a bbolt file at path, creating
+// it if necessary. Zero-value Options fields fall back to defaults.
+func Open(path string, opts Options) (*Allocator, error) {
 	if opts.LRUCacheSize == 0 {
 		opts.LRUCacheSize = DefaultLRUCacheSize
-	}
-	if opts.BatchSize == 0 {
-		opts.BatchSize = DefaultBatchSize
 	}
 	if opts.CommitInterval == 0 {
 		opts.CommitInterval = DefaultCommitInterval
 	}
 
+	db, err := bolt.Open(path, 0600, &bolt.Options{Timeout: openTimeout})
+	if err != nil {
+		return nil, fmt.Errorf("idtable: open %s: %w", path, err)
+	}
+
+	// Ensure buckets exist and read the persisted nextId.
+	var nextId int64 = 1
+	err = db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(bucketKeys); err != nil {
+			return err
+		}
+		mb, err := tx.CreateBucketIfNotExists(bucketMeta)
+		if err != nil {
+			return err
+		}
+		if v := mb.Get(metaNextId); v != nil {
+			nextId = decodeId(v)
+		}
+		return nil
+	})
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	if nextId < 0 {
+		db.Close()
+		return nil, fmt.Errorf("idtable: invalid nextId value: %d, database malformed", nextId)
+	}
+
 	a := &Allocator{
-		store:          store,
-		keyTypeNextId:  opts.KeyTypeNextId,
-		keyTypeKey:     opts.KeyTypeKey,
+		db:             db,
+		lru:            newLRUCache(opts.LRUCacheSize),
+		pending:        make(map[string]int64),
+		nextId:         nextId,
 		commitInterval: opts.CommitInterval,
 		closing:        make(chan bool),
 		done:           make(chan bool),
 	}
-
-	v, err := store.Get(a.encodeIncrIdKey())
-	if err != nil {
-		return nil, err
-	}
-
-	if v == nil {
-		a.nextId = 1
-	} else {
-		a.nextId = parseId(string(v))
-	}
-
-	if a.nextId < 0 {
-		return nil, fmt.Errorf("invalid nextId value: %d, database malformed", a.nextId)
-	}
-
-	a.lru = newLRUCache(opts.LRUCacheSize)
-	a.batch = store.NewBatch(opts.BatchSize)
 
 	// Capture the channels locally so the goroutine never reads a.closing/a.done,
 	// which Close() nils out under a.mu (reading them in the goroutine would race).
@@ -141,41 +156,88 @@ func (a *Allocator) GetId(key []byte) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.store == nil || a.store.IsClosed() {
+	if a.closed {
 		return "", fmt.Errorf("database is closed")
 	}
 
-	if v, ok := a.lru.Get(string(key)); ok {
-		return string(toBytes(v)), nil
+	sk := string(key)
+	if v, ok := a.lru.Get(sk); ok {
+		return EncodeId(v), nil
+	}
+	// pending is authoritative for uncommitted allocations (robust to LRU eviction).
+	if v, ok := a.pending[sk]; ok {
+		a.lru.Put(sk, v)
+		return EncodeId(v), nil
 	}
 
-	v, err := a.store.Get(a.encodeIdKey(key))
+	id, found, err := a.readCommitted(key)
 	if err != nil {
-		return "", fmt.Errorf("failed to get id for key %s: %v", key, err)
+		return "", err
+	}
+	if found {
+		a.lru.Put(sk, id)
+		return EncodeId(id), nil
 	}
 
-	if v != nil {
-		a.lru.Put(string(key), fromBytes(v))
-		return string(v), nil
-	}
-
-	id := toBytes(a.nextId)
-	a.lru.Put(string(key), a.nextId)
-
+	// Allocate a new id.
+	id = a.nextId
 	a.nextId++
-
-	a.batch.Put(a.encodeIncrIdKey(), []byte(strconv.FormatInt(a.nextId, 10)))
-	a.batch.Put(a.encodeIdKey(key), id)
-
-	return string(id), nil
+	a.lru.Put(sk, id)
+	a.pending[sk] = id
+	a.pendingNextId = true
+	return EncodeId(id), nil
 }
 
-// Close flushes any pending batch writes, stops the background commit goroutine,
-// and clears the LRU cache.
+// Lookup resolves a key to its id WITHOUT allocating: it returns found=false for
+// a key that has never been assigned an id. It consults the LRU and the pending
+// (uncommitted) buffer before the durable store. Safe for concurrent use.
+func (a *Allocator) Lookup(key []byte) (id int64, found bool, err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return 0, false, fmt.Errorf("database is closed")
+	}
+
+	sk := string(key)
+	if v, ok := a.lru.Get(sk); ok {
+		return v, true, nil
+	}
+	if v, ok := a.pending[sk]; ok {
+		return v, true, nil
+	}
+
+	id, found, err = a.readCommitted(key)
+	if err != nil {
+		return 0, false, err
+	}
+	if found {
+		a.lru.Put(sk, id)
+	}
+	return id, found, nil
+}
+
+// readCommitted reads a committed key->id entry from bbolt. Callers hold a.mu.
+func (a *Allocator) readCommitted(key []byte) (id int64, found bool, err error) {
+	err = a.db.View(func(tx *bolt.Tx) error {
+		if v := tx.Bucket(bucketKeys).Get(key); v != nil {
+			id = decodeId(v)
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, false, fmt.Errorf("idtable: lookup failed: %w", err)
+	}
+	return id, found, nil
+}
+
+// Close flushes any pending writes, stops the background commit goroutine, and
+// closes the bbolt database.
 //
-// The mutex is released while waiting for the background goroutine to exit:
-// that goroutine's periodic-commit branch acquires a.mu, so holding the lock
-// across the <-done wait would deadlock if the timer fired concurrently.
+// The mutex is released while waiting for the background goroutine to exit: that
+// goroutine's periodic-commit branch acquires a.mu, so holding the lock across
+// the <-done wait would deadlock if the timer fired concurrently.
 func (a *Allocator) Close() {
 	a.mu.Lock()
 	if a.closing == nil {
@@ -195,59 +257,105 @@ func (a *Allocator) Close() {
 		log.Printf("[idtable] final commit on close failed: %v", err)
 	}
 	a.lru.Clear()
-	a.store = nil
+	a.closed = true
+	if a.db != nil {
+		a.db.Close()
+		a.db = nil
+	}
+}
+
+// CrashRelease drops the Allocator's OS-held resources the way a process kill
+// would: it stops the background commit goroutine and closes the bbolt file
+// WITHOUT the orderly final commit, so uncommitted (pending) allocations are
+// discarded and the file lock is released for a same-process reopen. It exists
+// for crash-recovery tests that simulate an abrupt termination; production code
+// uses Close. Safe to call more than once and after Close.
+func (a *Allocator) CrashRelease() {
+	a.mu.Lock()
+	if a.closing == nil {
+		// Already cleanly closed or crash-released: just ensure the db is gone.
+		a.closed = true
+		if a.db != nil {
+			a.db.Close()
+			a.db = nil
+		}
+		a.mu.Unlock()
+		return
+	}
+	closing, done := a.closing, a.done
+	a.closing, a.done = nil, nil
+	a.mu.Unlock()
+
+	close(closing)
+	<-done
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	// Deliberately NO tryCommit: pending allocations are discarded, mimicking a
+	// crash that never flushed the lazy batch.
+	a.closed = true
+	if a.db != nil {
+		a.db.Close()
+		a.db = nil
+	}
 }
 
 // Commit synchronously flushes any pending key→id mappings and the nextId
-// counter to the backing kv.Store, fsync'd (the underlying batch commits with
-// pebble.Sync). It is the public, on-demand counterpart to the lazy 5s tick and
-// the Close-time flush: callers that must make the id allocations durable at a
+// counter to the bbolt database (durable: bbolt fsyncs on transaction commit).
+// It is the public, on-demand counterpart to the lazy commit tick and the
+// Close-time flush: callers that must make the id allocations durable at a
 // precise point (e.g. before truncating an external write-ahead log that is the
 // only other record of those mappings) call this to close the durability gap.
 // It is safe for concurrent use and is a no-op when nothing is pending.
 func (a *Allocator) Commit() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.store == nil || a.store.IsClosed() {
+	if a.closed {
 		return fmt.Errorf("database is closed")
 	}
 	return a.tryCommit()
 }
 
-// encodeIncrIdKey returns the key used to store nextId.
-func (a *Allocator) encodeIncrIdKey() []byte {
-	return []byte{a.keyTypeNextId}
-}
-
-// encodeIdKey returns the key used to store the id for the given key.
-func (a *Allocator) encodeIdKey(key []byte) []byte {
-	result := make([]byte, 1+len(key))
-	result[0] = a.keyTypeKey
-	copy(result[1:], key)
-	return result
-}
-
-// tryCommit flushes the pending batch if it is non-empty, returning any
-// Commit error. Callers must hold a.mu.
+// tryCommit flushes the pending allocations and nextId in a single bbolt
+// transaction if anything is pending. Callers must hold a.mu.
 //
-// It re-checks the store's open state under a.mu immediately before driving
-// batch.Commit. The periodic-commit tick and the Close-time flush both reach
-// here, and the backing KV can be closed out from under the allocator (e.g. a
-// test's t.Cleanup closes the store while a tick is in flight). Committing a
-// batch against a closed pebble panics ("pebble: closed"), so when the store is
-// closed we skip the commit and return a clean error instead — consistent with
-// GetId/Commit's fail-closed guards. The check sits under a.mu (held by every
-// caller), so it cannot race a concurrent close-then-commit on this allocator.
+// It re-checks the closed state before driving the write: the periodic-commit
+// tick and the Close-time flush both reach here, and committing against a closed
+// db would error — when closed we skip and return a clean error instead,
+// consistent with GetId/Commit's fail-closed guards. The check sits under a.mu
+// (held by every caller), so it cannot race a concurrent close-then-commit.
 func (a *Allocator) tryCommit() error {
-	if a.store == nil || a.store.IsClosed() {
+	if a.closed || a.db == nil {
 		return fmt.Errorf("database is closed")
 	}
-	if a.batch.Count() > 0 {
-		if err := a.batch.Commit(); err != nil {
-			return err
-		}
-		a.batch.Reset()
+	if len(a.pending) == 0 && !a.pendingNextId {
+		return nil
 	}
+	err := a.db.Update(func(tx *bolt.Tx) error {
+		kb := tx.Bucket(bucketKeys)
+		for k, id := range a.pending {
+			// A fresh slice per Put: bbolt retains the value slice by reference
+			// until the transaction commits, so a reused buffer would make every
+			// entry take the last-written value.
+			if err := kb.Put([]byte(k), toBytes(id)); err != nil {
+				return err
+			}
+		}
+		if a.pendingNextId {
+			if err := tx.Bucket(bucketMeta).Put(metaNextId, toBytes(a.nextId)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// Reset pending only after a durable commit. Keep the map allocated for reuse.
+	for k := range a.pending {
+		delete(a.pending, k)
+	}
+	a.pendingNextId = false
 	return nil
 }
 
@@ -259,14 +367,18 @@ func parseId(id string) int64 {
 	return v
 }
 
+// decodeId reads an 8-byte big-endian id value; a short slice yields -1.
+func decodeId(v []byte) int64 {
+	if len(v) < 8 {
+		return -1
+	}
+	return int64(binary.BigEndian.Uint64(v))
+}
+
 func toBytes(v int64) []byte {
 	id := make([]byte, 8) // int64 is 8 bytes
 	binary.BigEndian.PutUint64(id, uint64(v))
 	return id
-}
-
-func fromBytes(buf []byte) int64 {
-	return int64(binary.BigEndian.Uint64(buf))
 }
 
 // EncodeId returns the canonical on-disk string form of a docid: its 8-byte

--- a/core/idtable/idtable_bench_test.go
+++ b/core/idtable/idtable_bench_test.go
@@ -1,0 +1,63 @@
+package idtable
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// benchKeys returns n realistic path-like keys.
+func benchKeys(n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = fmt.Appendf(nil, "src/pkg/dir%03d/file-%07d.go", i%256, i)
+	}
+	return keys
+}
+
+// BenchmarkGetId_CachedHit measures the LRU-hit fast path (backend-independent).
+func BenchmarkGetId_CachedHit(b *testing.B) {
+	a, err := Open(filepath.Join(b.TempDir(), "idtable.db"), Options{CommitInterval: time.Hour})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer a.Close()
+	key := []byte("src/pkg/hot/file.go")
+	a.GetId(key)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := a.GetId(key); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLookup_CommittedMiss measures the committed-read path (LRU miss →
+// backend point read): bbolt B+tree walk vs the legacy pebble LSM Get. A tiny
+// LRU forces a miss for every distinct key, isolating the backend read cost.
+func BenchmarkLookup_CommittedMiss(b *testing.B) {
+	const n = 50_000
+	keys := benchKeys(n)
+	a, err := Open(filepath.Join(b.TempDir(), "idtable.db"), Options{CommitInterval: time.Hour, LRUCacheSize: 1})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer a.Close()
+	for _, k := range keys {
+		if _, err := a.GetId(k); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := a.Commit(); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, found, err := a.Lookup(keys[i%n]); err != nil || !found {
+			b.Fatalf("found=%v err=%v", found, err)
+		}
+	}
+}

--- a/core/idtable/idtable_extra_test.go
+++ b/core/idtable/idtable_extra_test.go
@@ -1,14 +1,15 @@
 package idtable
 
 import (
-	"os"
+	"encoding/binary"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/codetrek/haystack/core/kv/pebblekv"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,73 +19,43 @@ func TestCloseWhenNotInitialized(t *testing.T) {
 	a.Close() // should be a no-op
 }
 
-// TestGetIdDBReadPath covers the path where the key exists in the database
-// but not in the LRU cache (cache miss, DB hit).
+// TestGetIdDBReadPath covers the path where the key exists in the durable store
+// but not in the LRU cache (cache miss, db hit).
 func TestGetIdDBReadPath(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-dbread-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
+	defer alloc.Close()
 
-	store, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
-	assert.NoError(t, err)
-	defer store.Close()
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err)
-
-	// Create a key.
 	key := []byte("db-read-test-key")
 	id1, err := alloc.GetId(key)
 	assert.NoError(t, err)
 
-	// Force a batch commit so the data is visible via store.Get.
-	alloc.mu.Lock()
-	alloc.tryCommit()
-	alloc.mu.Unlock()
-
-	// Evict it from cache so the next GetId must read from DB.
+	// Commit so the entry is visible via the durable store, then evict it from the
+	// LRU (and it is gone from pending after commit) so the next GetId reads bbolt.
+	assert.NoError(t, alloc.Commit())
 	alloc.lru.Delete(string(key))
 
-	// Get it again — should come from DB, not cache.
 	id2, err := alloc.GetId(key)
 	assert.NoError(t, err)
 	assert.Equal(t, id1, id2)
-
-	alloc.Close()
 }
 
 // TestPeriodicCommit covers the background goroutine's timer-triggered tryCommit path.
 func TestPeriodicCommit(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-periodic-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
+	defer alloc.Close()
 
-	store, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
-	assert.NoError(t, err)
-	defer store.Close()
-
-	// Use a short commit interval so we don't wait 5+ seconds.
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err)
-
-	// Create some keys so there's data in the batch.
 	for i := 0; i < 5; i++ {
-		key := []byte("periodic-key-" + strconv.Itoa(i))
-		_, err := alloc.GetId(key)
+		_, err := alloc.GetId([]byte("periodic-key-" + strconv.Itoa(i)))
 		assert.NoError(t, err)
 	}
 
 	// Wait long enough for the background goroutine's timer to fire.
 	time.Sleep(200 * time.Millisecond)
 
-	// Verify the keys are still accessible (the commit didn't break anything).
 	for i := 0; i < 5; i++ {
-		key := []byte("periodic-key-" + strconv.Itoa(i))
-		_, err := alloc.GetId(key)
+		_, err := alloc.GetId([]byte("periodic-key-" + strconv.Itoa(i)))
 		assert.NoError(t, err)
 	}
-
-	alloc.Close()
 }
 
 // TestCloseDuringPeriodicCommits exercises the Close() path while the background
@@ -94,18 +65,9 @@ func TestPeriodicCommit(t *testing.T) {
 // finish well within the test timeout and is most meaningful under -race.
 func TestCloseDuringPeriodicCommits(t *testing.T) {
 	for iter := 0; iter < 20; iter++ {
-		tempDir, err := os.MkdirTemp("", "haystack-idtable-closerace-*")
+		alloc, err := Open(filepath.Join(t.TempDir(), "idtable.db"), Options{CommitInterval: time.Microsecond})
 		assert.NoError(t, err)
 
-		store, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
-		assert.NoError(t, err)
-
-		// Tiny interval so the timer fires repeatedly while we hammer GetId.
-		alloc, err := New(store, Options{CommitInterval: time.Microsecond})
-		assert.NoError(t, err)
-
-		// Concurrently allocate ids so the batch keeps having data to commit
-		// right up to (and during) Close.
 		var wg sync.WaitGroup
 		stop := make(chan struct{})
 		for w := 0; w < 4; w++ {
@@ -125,111 +87,81 @@ func TestCloseDuringPeriodicCommits(t *testing.T) {
 			}(w)
 		}
 
-		// Let the timer fire many times.
-		time.Sleep(2 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond) // let the timer fire many times
 
 		// Close must not deadlock even though the commit goroutine is active.
 		close(stop)
 		wg.Wait()
 		alloc.Close()
-
-		store.Close()
-		os.RemoveAll(tempDir)
 	}
 }
+
 func TestGetIdMultipleCallsSameKey(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-same-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
-	store, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
-	assert.NoError(t, err)
-	defer store.Close()
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err)
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
+	defer alloc.Close()
 
 	key := []byte("same-key")
 
-	// Call GetId multiple times — should always return same ID (cache hit).
+	// Repeated GetId returns the same id (cache/pending hit).
 	id1, err := alloc.GetId(key)
 	assert.NoError(t, err)
-
 	id2, err := alloc.GetId(key)
 	assert.NoError(t, err)
 	assert.Equal(t, id1, id2)
 
-	// Force commit, evict from cache, then call again (DB read path).
-	alloc.mu.Lock()
-	alloc.tryCommit()
-	alloc.mu.Unlock()
-
+	// Commit, evict from cache, then call again (durable read path).
+	assert.NoError(t, alloc.Commit())
 	alloc.lru.Delete(string(key))
 	id3, err := alloc.GetId(key)
 	assert.NoError(t, err)
 	assert.Equal(t, id1, id3)
-
-	alloc.Close()
 }
 
-// TestGetIdWithExistingNextId covers New when the DB already has a nextId value.
+// TestGetIdWithExistingNextId covers Open when the db already has a nextId value.
 func TestGetIdWithExistingNextId(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-existid-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	dbPath := filepath.Join(tempDir, "data")
-	store, err := pebblekv.Open(dbPath, 0)
+	// Pre-seed nextId=100 directly into the meta bucket.
+	db, err := bolt.Open(path, 0600, &bolt.Options{Timeout: time.Second})
 	assert.NoError(t, err)
+	seed := make([]byte, 8)
+	binary.BigEndian.PutUint64(seed, 100)
+	err = db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(bucketMeta)
+		if err != nil {
+			return err
+		}
+		return b.Put(metaNextId, seed)
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, db.Close())
 
-	// Pre-seed a nextId into the DB.
-	err = store.Put([]byte{DefaultKeyTypeNextId}, []byte("100"))
+	alloc, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
 	assert.NoError(t, err)
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err)
+	defer alloc.Close()
 	assert.Equal(t, int64(100), alloc.nextId)
 
-	// The next ID assigned should be 100.
-	key := []byte("key-after-seed")
-	id, err := alloc.GetId(key)
+	// The next id assigned should be 100, advancing nextId to 101.
+	id, err := alloc.GetId([]byte("key-after-seed"))
 	assert.NoError(t, err)
-	assert.NotEmpty(t, id)
-	// nextId should have incremented to 101.
+	assert.Equal(t, uint64(100), binary.BigEndian.Uint64([]byte(id)))
 	assert.Equal(t, int64(101), alloc.nextId)
-
-	alloc.Close()
-	store.Close()
 }
 
-// TestCloseCommitsPendingBatch verifies that Close flushes the pending batch.
+// TestCloseCommitsPendingBatch verifies that Close flushes the pending allocations.
 func TestCloseCommitsPendingBatch(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-closecommit-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	dbPath := filepath.Join(tempDir, "data")
-	store, err := pebblekv.Open(dbPath, 0)
+	alloc, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
 	assert.NoError(t, err)
 
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err)
-
-	// Create keys that add to the batch.
 	key := []byte("batch-test-key")
 	id1, err := alloc.GetId(key)
 	assert.NoError(t, err)
 
-	// Close should flush the batch to the database.
-	alloc.Close()
-	store.Close()
+	alloc.Close() // flushes pending to the db
 
-	// Reopen and verify the key survived.
-	store2, err := pebblekv.Open(dbPath, 0)
-	assert.NoError(t, err)
-	defer store2.Close()
-
-	alloc2, err := New(store2, Options{CommitInterval: 50 * time.Millisecond})
+	alloc2, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
 	assert.NoError(t, err)
 	defer alloc2.Close()
 

--- a/core/idtable/idtable_extra_test.go
+++ b/core/idtable/idtable_extra_test.go
@@ -96,6 +96,28 @@ func TestCloseDuringPeriodicCommits(t *testing.T) {
 	}
 }
 
+// TestGetId_PendingSurvivesLRUEviction pins the pending buffer's reason to exist:
+// an uncommitted allocation that is evicted from a full LRU must still resolve
+// from `pending` — it must NOT be re-allocated a second (duplicate) id.
+func TestGetId_PendingSurvivesLRUEviction(t *testing.T) {
+	// LRUCacheSize 1 so the second alloc evicts the first; long interval so
+	// nothing is committed (the entries stay only in pending + the LRU).
+	a := openTestAlloc(t, Options{LRUCacheSize: 1, CommitInterval: time.Hour})
+	defer a.Close()
+
+	first, err := a.GetId([]byte("a")) // id 1: in LRU + pending (uncommitted)
+	assert.NoError(t, err)
+	_, err = a.GetId([]byte("b")) // id 2: evicts "a" from the size-1 LRU
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), a.nextId, "exactly two ids allocated so far")
+
+	// "a" is gone from the LRU and never committed → only `pending` can answer.
+	again, err := a.GetId([]byte("a"))
+	assert.NoError(t, err)
+	assert.Equal(t, first, again, "evicted-but-uncommitted key must keep its id")
+	assert.Equal(t, int64(3), a.nextId, "must not allocate a duplicate id for a pending key")
+}
+
 func TestGetIdMultipleCallsSameKey(t *testing.T) {
 	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
 	defer alloc.Close()

--- a/core/idtable/idtable_test.go
+++ b/core/idtable/idtable_test.go
@@ -2,91 +2,137 @@ package idtable
 
 import (
 	"encoding/binary"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/codetrek/haystack/core/kv"
-	"github.com/codetrek/haystack/core/kv/pebblekv"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/stretchr/testify/assert"
 )
 
-// openTestStore opens a pebble-backed kv.Store in a temporary directory.
-func openTestStore(t *testing.T, dir string) (kv.Store, error) {
+// openTestAlloc opens a fresh bbolt-backed Allocator in a temp file.
+func openTestAlloc(t *testing.T, opts Options) *Allocator {
 	t.Helper()
-	return pebblekv.Open(filepath.Join(dir, "data"), 0)
+	a, err := Open(filepath.Join(t.TempDir(), "idtable.db"), opts)
+	assert.NoError(t, err, "Open failed")
+	return a
 }
 
-// TestNew tests the New function with various scenarios.
+// TestNew tests Open initialization and nextId persistence across reopen.
 func TestNew(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	store, err := openTestStore(t, tempDir)
-	assert.NoError(t, err, "Failed to open kv store")
-	defer store.Close()
-
-	// Test initial initialization.
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err, "New failed")
+	alloc, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
+	assert.NoError(t, err, "Open failed")
 	assert.NotNil(t, alloc)
 
-	// Verify nextId is initialized to 1.
+	// Verify nextId is initialized to 1 on a fresh database.
 	assert.Equal(t, int64(1), alloc.nextId, "Expected nextId to be 1")
+
+	// Allocate 41 ids so nextId advances to 42, then flush + close.
+	for i := 0; i < 41; i++ {
+		_, err := alloc.GetId([]byte("seed-" + strconv.Itoa(i)))
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, alloc.Commit())
 	alloc.Close()
 
-	// Test re-initialization with existing data: seed a specific nextId.
-	testNextId := int64(42)
-	err = store.Put([]byte{DefaultKeyTypeNextId}, []byte(strconv.FormatInt(testNextId, 10)))
-	assert.NoError(t, err, "Failed to put nextId")
-
-	alloc2, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err, "Re-New failed")
+	// Reopen: nextId must be loaded from the persisted meta.
+	alloc2, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
+	assert.NoError(t, err, "Re-Open failed")
 	assert.NotNil(t, alloc2)
-	assert.Equal(t, testNextId, alloc2.nextId, "Expected nextId to be loaded correctly")
+	assert.Equal(t, int64(42), alloc2.nextId, "Expected nextId to be loaded correctly")
 	alloc2.Close()
 }
 
-// TestNewWithInvalidData tests New with corrupted data.
+// TestNewWithInvalidData tests Open with a corrupted nextId in the meta bucket.
 func TestNewWithInvalidData(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
+	path := filepath.Join(t.TempDir(), "idtable.db")
 
-	store, err := openTestStore(t, tempDir)
-	assert.NoError(t, err, "Failed to open kv store")
-	defer store.Close()
+	// Seed a negative nextId directly into the meta bucket.
+	seedNextId := func(t *testing.T, raw []byte) {
+		t.Helper()
+		db, err := bolt.Open(path, 0600, &bolt.Options{Timeout: time.Second})
+		assert.NoError(t, err)
+		err = db.Update(func(tx *bolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists(bucketMeta)
+			if err != nil {
+				return err
+			}
+			return b.Put(metaNextId, raw)
+		})
+		assert.NoError(t, err)
+		db.Close()
+	}
 
-	// Put invalid nextId value.
-	err = store.Put([]byte{DefaultKeyTypeNextId}, []byte("invalid"))
-	assert.NoError(t, err, "Failed to put invalid nextId")
+	// A negative big-endian nextId is malformed → Open must fail.
+	neg := make([]byte, 8)
+	var negVal int64 = -5
+	binary.BigEndian.PutUint64(neg, uint64(negVal))
+	seedNextId(t, neg)
+	_, err := Open(path, Options{})
+	assert.Error(t, err, "Expected Open to fail with negative nextId")
 
-	_, err = New(store, Options{})
-	assert.Error(t, err, "Expected New to fail with invalid nextId data")
+	// A too-short (non-8-byte) nextId is also malformed (decodeId yields -1).
+	short := filepath.Join(t.TempDir(), "idtable.db")
+	db, err := bolt.Open(short, 0600, &bolt.Options{Timeout: time.Second})
+	assert.NoError(t, err)
+	assert.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		b, e := tx.CreateBucketIfNotExists(bucketMeta)
+		if e != nil {
+			return e
+		}
+		return b.Put(metaNextId, []byte{1, 2, 3}) // 3 bytes
+	}))
+	db.Close()
+	_, err = Open(short, Options{})
+	assert.Error(t, err, "Expected Open to fail with a too-short nextId")
+}
 
-	// Test with negative nextId.
-	err = store.Put([]byte{DefaultKeyTypeNextId}, []byte("-5"))
-	assert.NoError(t, err, "Failed to put negative nextId")
+// TestCrashRelease verifies CrashRelease drops uncommitted (pending) allocations
+// and releases the file lock without flushing — mimicking an abrupt termination.
+func TestCrashRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "idtable.db")
+	alloc, err := Open(path, Options{CommitInterval: time.Hour})
+	assert.NoError(t, err)
 
-	_, err = New(store, Options{})
-	assert.Error(t, err, "Expected New to fail with negative nextId")
+	// Commit one mapping (durable), then allocate another that stays pending.
+	committed, err := alloc.GetId([]byte("durable"))
+	assert.NoError(t, err)
+	assert.NoError(t, alloc.Commit())
+	_, err = alloc.GetId([]byte("pending")) // staged, NOT committed
+	assert.NoError(t, err)
+
+	alloc.CrashRelease() // drop the lock WITHOUT flushing pending
+
+	// After CrashRelease the allocator is closed.
+	_, err = alloc.GetId([]byte("x"))
+	assert.Error(t, err, "GetId after CrashRelease must error")
+	// Double CrashRelease and a Close afterwards are safe no-ops.
+	alloc.CrashRelease()
+	alloc.Close()
+
+	// Reopen: the committed mapping survives; the pending one was discarded.
+	alloc2, err := Open(path, Options{CommitInterval: time.Hour})
+	assert.NoError(t, err)
+	defer alloc2.Close()
+	_, found, err := alloc2.Lookup([]byte("durable"))
+	assert.NoError(t, err)
+	assert.True(t, found, "committed mapping must survive CrashRelease")
+	got, err := alloc2.GetId([]byte("durable"))
+	assert.NoError(t, err)
+	assert.Equal(t, committed, got)
+
+	_, found, err = alloc2.Lookup([]byte("pending"))
+	assert.NoError(t, err)
+	assert.False(t, found, "uncommitted mapping must be discarded by CrashRelease")
 }
 
 // TestGetId tests the GetId method.
 func TestGetId(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
-
-	store, err := openTestStore(t, tempDir)
-	assert.NoError(t, err, "Failed to open kv store")
-	defer store.Close()
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err, "New failed")
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
 	defer alloc.Close()
 
 	// Test getting ID for a new key.
@@ -94,42 +140,53 @@ func TestGetId(t *testing.T) {
 	id1, err := alloc.GetId(testKey)
 	assert.NoError(t, err, "GetId failed")
 
-	// Verify the ID is returned as binary encoded bytes.
+	// Verify the ID is returned as 8 binary-encoded bytes.
 	assert.Equal(t, 8, len(id1), "Expected ID length to be 8 bytes")
+	assert.Equal(t, uint64(1), binary.BigEndian.Uint64([]byte(id1)), "Expected first ID to be 1")
 
-	// Convert the binary ID back to int64 to verify.
-	idValue := binary.BigEndian.Uint64([]byte(id1))
-	assert.Equal(t, uint64(1), idValue, "Expected first ID to be 1")
-
-	// Test getting ID for the same key should return the same ID.
+	// Same key returns the same ID.
 	id2, err := alloc.GetId(testKey)
 	assert.NoError(t, err, "GetId failed for existing key")
 	assert.Equal(t, id1, id2, "Expected same ID for same key")
 
-	// Test getting ID for a different key should return a different ID.
-	testKey2 := []byte("test-key-2")
-	id3, err := alloc.GetId(testKey2)
+	// A different key returns a different, incremented ID.
+	id3, err := alloc.GetId([]byte("test-key-2"))
 	assert.NoError(t, err, "GetId failed for second key")
-
 	assert.NotEqual(t, id1, id3, "Expected different IDs for different keys")
+	assert.Equal(t, uint64(2), binary.BigEndian.Uint64([]byte(id3)), "Expected second ID to be 2")
+}
 
-	// Verify the second ID is incremented.
-	idValue3 := binary.BigEndian.Uint64([]byte(id3))
-	assert.Equal(t, uint64(2), idValue3, "Expected second ID to be 2")
+// TestLookup verifies the non-allocating lookup path.
+func TestLookup(t *testing.T) {
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
+	defer alloc.Close()
+
+	// Unknown key: found=false, allocates nothing.
+	id, found, err := alloc.Lookup([]byte("never-seen"))
+	assert.NoError(t, err)
+	assert.False(t, found, "unknown key must not be found")
+	assert.Equal(t, int64(0), id)
+	assert.Equal(t, int64(1), alloc.nextId, "Lookup must not allocate")
+
+	// Allocate, then Lookup finds the same id (from pending, pre-commit).
+	got, err := alloc.GetId([]byte("k"))
+	assert.NoError(t, err)
+	id, found, err = alloc.Lookup([]byte("k"))
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, got, EncodeId(id), "Lookup id must match GetId")
+
+	// After commit it is found from the durable store too.
+	assert.NoError(t, alloc.Commit())
+	id, found, err = alloc.Lookup([]byte("k"))
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, int64(1), id)
 }
 
 // TestGetIdConcurrency tests GetId under concurrent access.
 func TestGetIdConcurrency(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
-
-	store, err := openTestStore(t, tempDir)
-	assert.NoError(t, err, "Failed to open kv store")
-	defer store.Close()
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err, "New failed")
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
 	defer alloc.Close()
 
 	numGoroutines := 10
@@ -163,57 +220,26 @@ func TestGetIdConcurrency(t *testing.T) {
 		}
 	}
 
-	// Verify all IDs are unique.
 	idSet := make(map[string]bool)
 	for _, id := range allResults {
 		idSet[id] = true
 	}
-
-	expectedIds := numGoroutines * numKeysPerGoroutine
-	assert.Equal(t, expectedIds, len(idSet), "Expected all IDs to be unique")
+	assert.Equal(t, numGoroutines*numKeysPerGoroutine, len(idSet), "Expected all IDs to be unique")
 }
 
-// TestGetIdWithClosedStore tests GetId with a closed store.
+// TestGetIdWithClosedStore tests GetId after Close.
 func TestGetIdWithClosedStore(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
-
-	store, err := openTestStore(t, tempDir)
-	assert.NoError(t, err, "Failed to open kv store")
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err, "New failed")
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
 	alloc.Close()
-	store.Close()
 
-	testKey := []byte("test-key")
-	_, err = alloc.GetId(testKey)
-	assert.Error(t, err, "Expected GetId to fail with closed store")
-}
+	_, err := alloc.GetId([]byte("test-key"))
+	assert.Error(t, err, "Expected GetId to fail after Close")
 
-// TestEncodeIncrIdKey tests the encodeIncrIdKey method.
-func TestEncodeIncrIdKey(t *testing.T) {
-	a := &Allocator{keyTypeNextId: DefaultKeyTypeNextId}
-	key := a.encodeIncrIdKey()
+	_, _, err = alloc.Lookup([]byte("test-key"))
+	assert.Error(t, err, "Expected Lookup to fail after Close")
 
-	expectedKey := []byte{DefaultKeyTypeNextId}
-	assert.Equal(t, len(expectedKey), len(key), "Expected key length to match")
-	assert.Equal(t, DefaultKeyTypeNextId, key[0], "Expected correct key type")
-}
-
-// TestEncodeIdKey tests the encodeIdKey method.
-func TestEncodeIdKey(t *testing.T) {
-	a := &Allocator{keyTypeKey: DefaultKeyTypeKey}
-	testKey := []byte("test-key")
-	encodedKey := a.encodeIdKey(testKey)
-
-	expectedLength := 1 + len(testKey)
-	assert.Equal(t, expectedLength, len(encodedKey), "Expected correct encoded key length")
-	assert.Equal(t, DefaultKeyTypeKey, encodedKey[0], "Expected correct key type")
-
-	keyContent := encodedKey[1:]
-	assert.Equal(t, string(testKey), string(keyContent), "Expected key content to match")
+	err = alloc.Commit()
+	assert.Error(t, err, "Expected Commit to fail after Close")
 }
 
 // TestParseId tests the parseId function.
@@ -240,16 +266,7 @@ func TestParseId(t *testing.T) {
 
 // TestGetIdWithLargeNumberOfKeys tests GetId with a large number of keys.
 func TestGetIdWithLargeNumberOfKeys(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
-
-	store, err := openTestStore(t, tempDir)
-	assert.NoError(t, err, "Failed to open kv store")
-	defer store.Close()
-
-	alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-	assert.NoError(t, err, "New failed")
+	alloc := openTestAlloc(t, Options{CommitInterval: 50 * time.Millisecond})
 	defer alloc.Close()
 
 	numKeys := 100
@@ -259,12 +276,7 @@ func TestGetIdWithLargeNumberOfKeys(t *testing.T) {
 		key := []byte("large-test-key-" + strconv.Itoa(i))
 		id, err := alloc.GetId(key)
 		assert.NoError(t, err, "GetId failed for key %d", i)
-
-		keyStr := string(key)
-		if existingId, exists := ids[keyStr]; exists {
-			assert.Equal(t, existingId, id, "Key %s should get consistent ID", keyStr)
-		}
-		ids[keyStr] = id
+		ids[string(key)] = id
 	}
 
 	idSet := make(map[string]bool)
@@ -273,53 +285,35 @@ func TestGetIdWithLargeNumberOfKeys(t *testing.T) {
 	}
 	assert.Equal(t, numKeys, len(idSet), "Expected all IDs to be unique")
 
-	// Test that requesting the same keys again returns the same IDs.
+	// Requesting the same keys again returns the same IDs.
 	for i := 0; i < numKeys; i++ {
 		key := []byte("large-test-key-" + strconv.Itoa(i))
 		id, err := alloc.GetId(key)
 		assert.NoError(t, err, "GetId failed for existing key %d", i)
-
-		expectedId := ids[string(key)]
-		assert.Equal(t, expectedId, id, "Expected consistent ID for key %s", string(key))
+		assert.Equal(t, ids[string(key)], id, "Expected consistent ID for key %s", string(key))
 	}
 }
 
-// TestGetIdPersistence tests that IDs persist across restarts.
+// TestGetIdPersistence tests that IDs persist across reopen.
 func TestGetIdPersistence(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "haystack-idtable-test-*")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir)
-
-	dbPath := filepath.Join(tempDir, "data")
+	path := filepath.Join(t.TempDir(), "idtable.db")
 	testKey := []byte("persistence-test-key")
 
 	var firstId string
 	{
-		store, err := pebblekv.Open(dbPath, 0)
-		assert.NoError(t, err, "Failed to open kv store")
-
-		alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-		assert.NoError(t, err, "New failed")
-
+		alloc, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
+		assert.NoError(t, err, "Open failed")
 		firstId, err = alloc.GetId(testKey)
 		assert.NoError(t, err, "GetId failed")
-
-		alloc.Close()
-		store.Close()
+		alloc.Close() // flushes pending on close
 	}
 
 	{
-		store, err := pebblekv.Open(dbPath, 0)
-		assert.NoError(t, err, "Failed to reopen kv store")
-		defer store.Close()
-
-		alloc, err := New(store, Options{CommitInterval: 50 * time.Millisecond})
-		assert.NoError(t, err, "New failed on reopen")
+		alloc, err := Open(path, Options{CommitInterval: 50 * time.Millisecond})
+		assert.NoError(t, err, "Open failed on reopen")
 		defer alloc.Close()
-
 		secondId, err := alloc.GetId(testKey)
 		assert.NoError(t, err, "GetId failed on reopen")
-
 		assert.Equal(t, firstId, secondId, "ID should be persistent across restarts")
 	}
 }

--- a/core/idtable/migrate.go
+++ b/core/idtable/migrate.go
@@ -69,9 +69,10 @@ func MigrateFromKV(src kv.Store, dstPath string, srcKeyTypeKey, srcKeyTypeNextId
 		if err != nil {
 			return err
 		}
-		// Idempotency: a destination that already has key entries was migrated
-		// before (or written by a running allocator); do not overwrite it.
-		if kb.Stats().KeyN > 0 {
+		// Idempotency: a destination that was already migrated (key entries OR the
+		// nextId counter present — the empty-source case writes only the counter)
+		// or written by a running allocator must not be overwritten.
+		if kb.Stats().KeyN > 0 || mb.Get(metaNextId) != nil {
 			return nil
 		}
 

--- a/core/idtable/migrate.go
+++ b/core/idtable/migrate.go
@@ -1,0 +1,91 @@
+package idtable
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/codetrek/haystack/core/kv"
+	bolt "go.etcd.io/bbolt"
+)
+
+// MigrateFromKV performs a one-time copy of a legacy kv.Store-backed idtable
+// (key→id entries under srcKeyTypeKey, the nextId counter under srcKeyTypeNextId)
+// into a standalone bbolt file at dstPath. It is idempotent: if dstPath already
+// holds migrated entries it is a no-op, so it is safe to call on every startup.
+//
+// The legacy layout (written by the old kv-backed allocator) is:
+//   - key:    {srcKeyTypeKey} + rawKey  ->  8-byte big-endian id
+//   - nextId: {srcKeyTypeNextId}         ->  decimal-string int64
+//
+// The bbolt layout matches Open's: keys bucket (rawKey -> 8-byte id) + meta
+// bucket (nextId -> 8-byte id). Byte-identical id values, so no reindex.
+func MigrateFromKV(src kv.Store, dstPath string, srcKeyTypeKey, srcKeyTypeNextId byte) error {
+	if src == nil {
+		return fmt.Errorf("idtable: migrate: source store is nil")
+	}
+
+	// Read everything from the source first, outside the bbolt transaction, so we
+	// never hold a write txn open across the legacy store's scan. The scan's key
+	// slices are only valid during the callback, so copy them.
+	type entry struct {
+		key []byte
+		id  int64
+	}
+	var entries []entry
+	err := src.Scan([]byte{srcKeyTypeKey}, func(k, v []byte) bool {
+		if len(k) < 1 || len(v) < 8 {
+			return true // skip malformed legacy rows
+		}
+		rawKey := append([]byte(nil), k[1:]...) // strip the key-type prefix byte
+		entries = append(entries, entry{key: rawKey, id: int64(binary.BigEndian.Uint64(v))})
+		return true
+	})
+	if err != nil {
+		return fmt.Errorf("idtable: migrate: scan source: %w", err)
+	}
+
+	nextId := int64(1)
+	if nv, err := src.Get([]byte{srcKeyTypeNextId}); err != nil {
+		return fmt.Errorf("idtable: migrate: read nextId: %w", err)
+	} else if nv != nil {
+		nextId = parseId(string(nv))
+	}
+	if nextId < 0 {
+		return fmt.Errorf("idtable: migrate: invalid source nextId")
+	}
+
+	db, err := bolt.Open(dstPath, 0600, &bolt.Options{Timeout: openTimeout})
+	if err != nil {
+		return fmt.Errorf("idtable: migrate: open dst %s: %w", dstPath, err)
+	}
+	defer db.Close()
+
+	return db.Update(func(tx *bolt.Tx) error {
+		kb, err := tx.CreateBucketIfNotExists(bucketKeys)
+		if err != nil {
+			return err
+		}
+		mb, err := tx.CreateBucketIfNotExists(bucketMeta)
+		if err != nil {
+			return err
+		}
+		// Idempotency: a destination that already has key entries was migrated
+		// before (or written by a running allocator); do not overwrite it.
+		if kb.Stats().KeyN > 0 {
+			return nil
+		}
+
+		for _, e := range entries {
+			// A fresh slice per Put: bbolt retains the value slice by reference until
+			// commit, so a reused buffer would corrupt earlier entries.
+			id := make([]byte, 8)
+			binary.BigEndian.PutUint64(id, uint64(e.id))
+			if err := kb.Put(e.key, id); err != nil {
+				return err
+			}
+		}
+		nv := make([]byte, 8)
+		binary.BigEndian.PutUint64(nv, uint64(nextId))
+		return mb.Put(metaNextId, nv)
+	})
+}

--- a/core/idtable/migrate_test.go
+++ b/core/idtable/migrate_test.go
@@ -1,0 +1,125 @@
+package idtable
+
+import (
+	"encoding/binary"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/codetrek/haystack/core/kv/pebblekv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLegacyEntry writes a key→id mapping in the legacy kv layout:
+// {LegacyKeyTypeKey}+rawKey -> 8-byte big-endian id.
+func writeLegacyEntry(t *testing.T, store interface {
+	Put(k, v []byte) error
+}, rawKey []byte, id int64) {
+	t.Helper()
+	k := append([]byte{LegacyKeyTypeKey}, rawKey...)
+	v := make([]byte, 8)
+	binary.BigEndian.PutUint64(v, uint64(id))
+	require.NoError(t, store.Put(k, v))
+}
+
+// TestMigrateFromKV copies a legacy kv-backed idtable into a bbolt file and
+// verifies the migrated mappings + nextId are served by an Allocator opened on it.
+func TestMigrateFromKV(t *testing.T) {
+	dir := t.TempDir()
+	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
+	require.NoError(t, err)
+
+	// Seed legacy entries + a legacy decimal-string nextId.
+	writeLegacyEntry(t, store, []byte("alpha.go"), 1)
+	writeLegacyEntry(t, store, []byte("beta.go"), 2)
+	writeLegacyEntry(t, store, []byte("dir/gamma.go"), 3)
+	require.NoError(t, store.Put([]byte{LegacyKeyTypeNextId}, []byte(strconv.FormatInt(4, 10))))
+
+	dstPath := filepath.Join(dir, "idtable.db")
+	require.NoError(t, MigrateFromKV(store, dstPath, LegacyKeyTypeKey, LegacyKeyTypeNextId))
+	require.NoError(t, store.Close())
+
+	alloc, err := Open(dstPath, Options{CommitInterval: time.Hour})
+	require.NoError(t, err)
+	defer alloc.Close()
+
+	// Migrated nextId carried over.
+	assert.Equal(t, int64(4), alloc.nextId)
+
+	// Migrated keys resolve to their original ids without allocating.
+	for raw, want := range map[string]int64{"alpha.go": 1, "beta.go": 2, "dir/gamma.go": 3} {
+		id, found, err := alloc.Lookup([]byte(raw))
+		require.NoError(t, err)
+		assert.True(t, found, "migrated key %q must be found", raw)
+		assert.Equal(t, want, id, "migrated key %q id", raw)
+	}
+	assert.Equal(t, int64(4), alloc.nextId, "Lookup must not allocate")
+
+	// A brand-new key gets the next id (4).
+	got, err := alloc.GetId([]byte("new.go"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(4), binary.BigEndian.Uint64([]byte(got)))
+}
+
+// TestMigrateFromKV_Idempotent verifies a second migration is a no-op and does
+// not clobber entries written after the first migration.
+func TestMigrateFromKV_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
+	require.NoError(t, err)
+	writeLegacyEntry(t, store, []byte("alpha.go"), 1)
+	require.NoError(t, store.Put([]byte{LegacyKeyTypeNextId}, []byte("2")))
+
+	dstPath := filepath.Join(dir, "idtable.db")
+	require.NoError(t, MigrateFromKV(store, dstPath, LegacyKeyTypeKey, LegacyKeyTypeNextId))
+
+	// Allocate a new key into the bbolt file after migration.
+	alloc, err := Open(dstPath, Options{CommitInterval: time.Hour})
+	require.NoError(t, err)
+	newId, err := alloc.GetId([]byte("postmigrate.go"))
+	require.NoError(t, err)
+	require.NoError(t, alloc.Commit())
+	alloc.Close()
+
+	// Re-run migration: it must skip (dst already populated), leaving the
+	// post-migration allocation intact.
+	require.NoError(t, MigrateFromKV(store, dstPath, LegacyKeyTypeKey, LegacyKeyTypeNextId))
+	require.NoError(t, store.Close())
+
+	alloc2, err := Open(dstPath, Options{CommitInterval: time.Hour})
+	require.NoError(t, err)
+	defer alloc2.Close()
+	got, found, err := alloc2.Lookup([]byte("postmigrate.go"))
+	require.NoError(t, err)
+	assert.True(t, found, "post-migration entry must survive a second migration")
+	assert.Equal(t, newId, EncodeId(got))
+}
+
+// TestMigrateFromKV_EmptySource migrates an empty legacy store: nextId defaults
+// to 1 and the allocator starts fresh.
+func TestMigrateFromKV_EmptySource(t *testing.T) {
+	dir := t.TempDir()
+	store, err := pebblekv.Open(filepath.Join(dir, "data"), 0)
+	require.NoError(t, err)
+
+	dstPath := filepath.Join(dir, "idtable.db")
+	require.NoError(t, MigrateFromKV(store, dstPath, LegacyKeyTypeKey, LegacyKeyTypeNextId))
+	require.NoError(t, store.Close())
+
+	alloc, err := Open(dstPath, Options{CommitInterval: time.Hour})
+	require.NoError(t, err)
+	defer alloc.Close()
+	assert.Equal(t, int64(1), alloc.nextId)
+
+	got, err := alloc.GetId([]byte("first.go"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), binary.BigEndian.Uint64([]byte(got)))
+}
+
+// TestMigrateFromKV_NilSource guards the nil-store input.
+func TestMigrateFromKV_NilSource(t *testing.T) {
+	err := MigrateFromKV(nil, filepath.Join(t.TempDir(), "idtable.db"), LegacyKeyTypeKey, LegacyKeyTypeNextId)
+	assert.Error(t, err)
+}

--- a/core/vectorstore/batch_test.go
+++ b/core/vectorstore/batch_test.go
@@ -18,7 +18,7 @@ func batchRandVec(rng *rand.Rand, dim int) []float32 {
 func TestBatch_DurableSearchableReopen(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(5))
 	dim := 16

--- a/core/vectorstore/bench_test.go
+++ b/core/vectorstore/bench_test.go
@@ -24,7 +24,7 @@ func benchOpenStore(b *testing.B, m Metric) *Store {
 	if err != nil {
 		b.Fatal(err)
 	}
-	s, err := Open(Options{Dir: b.TempDir(), KV: kvs, Metric: m})
+	s, err := Open(Options{Dir: b.TempDir(), Metric: m})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/core/vectorstore/coverage_phase4_test.go
+++ b/core/vectorstore/coverage_phase4_test.go
@@ -111,7 +111,7 @@ func TestSealLocked_WriteFaultPropagates(t *testing.T) {
 func TestCommitSealLocked_ReconcileErrorRollsBack(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(909))
 	bp := s.NewBatch()
@@ -151,8 +151,7 @@ func TestCommitSealLocked_ReconcileErrorRollsBack(t *testing.T) {
 // crash-before-commit orphan a later recover sweeps. We drive a real merge to the
 // swap with testHookReconcileErr armed, then confirm every doc survives.
 func TestCommitMergeLocked_ReconcileErrorRollsBack(t *testing.T) {
-	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	defer s.Close() // release output mmaps so t.TempDir cleanup works on Windows
 	rng := rand.New(rand.NewSource(808))

--- a/core/vectorstore/merge_abort_test.go
+++ b/core/vectorstore/merge_abort_test.go
@@ -23,7 +23,7 @@ import (
 // manifest was never rewritten, so the two inputs stay authoritative.
 func TestAbortMerge_WriteFaultRollsBackCleanly(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	s.maxSegSize = 5 // delete-driven repack packs into 5-row buckets
 	rng := rand.New(rand.NewSource(91))

--- a/core/vectorstore/merge_concurrent_race_test.go
+++ b/core/vectorstore/merge_concurrent_race_test.go
@@ -28,7 +28,7 @@ func TestMerge_ConcurrentDeletePutDuringInFlightMerge(t *testing.T) {
 	}
 	for iter := 0; iter < iters; iter++ {
 		kvStore := newTestKV(t)
-		s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: DotProduct})
+		s, err := Open(Options{Dir: t.TempDir(), Metric: DotProduct})
 		requireNoError(t, err)
 		rng := rand.New(rand.NewSource(int64(200 + iter)))
 		dim := 8

--- a/core/vectorstore/merge_concurrent_test.go
+++ b/core/vectorstore/merge_concurrent_test.go
@@ -147,7 +147,7 @@ func TestMerge_PutRehomeDuringWindow_NotDuplicated(t *testing.T) {
 // reconstructed from the durable docseg + tomb buckets, not an on-disk bitmap rescan).
 func TestMerge_DeleteDuringWindow_DurableAcrossRestart(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(22))
 	live := map[int64][]float32{}

--- a/core/vectorstore/merge_corrupt_payload_test.go
+++ b/core/vectorstore/merge_corrupt_payload_test.go
@@ -23,8 +23,7 @@ import (
 // after the fix it returns the decode error.
 func TestMerge_CorruptSealedPayload_AbortsFailClosed(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	requireNoError(t, s.Put("a", []float32{1, 0, 0}, Payload{"k": StringValue("v")}))
 	requireNoError(t, s.Seal()) // one-row sealed segment (segId 1), no attr declared
@@ -48,7 +47,7 @@ func TestMerge_CorruptSealedPayload_AbortsFailClosed(t *testing.T) {
 
 	// Reopen: the segment opens fine (header/lens intact); only the blob content is
 	// corrupt, so the failure surfaces at decode time during the merge pack.
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 	requireNoError(t, s2.WaitForIndex())

--- a/core/vectorstore/merge_crash_test.go
+++ b/core/vectorstore/merge_crash_test.go
@@ -24,7 +24,7 @@ func randVecN(rng *rand.Rand, dim int) []float32 {
 // inputs (still manifest-referenced) survive intact with every doc.
 func TestMergeCrash_BeforeSwap_OutputSwept(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(11))
 	b := s.NewBatch()
@@ -81,7 +81,7 @@ func TestMergeCrash_BeforeSwap_OutputSwept(t *testing.T) {
 // that recover() must sweep, and the merged output must carry every live doc.
 func TestMergeCrash_AfterSwap_OldInputSwept(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(12))
 	b := s.NewBatch()
@@ -128,7 +128,7 @@ func TestMergeCrash_AfterSwap_OldInputSwept(t *testing.T) {
 // resolves correctly (plan §7b).
 func TestMergeCrash_MidBuild_RecoverResumes(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(13))
 	live := map[int64][]float32{}
@@ -187,7 +187,7 @@ func TestMergeCrash_MidBuild_RecoverResumes(t *testing.T) {
 // round-trips the merge OUTPUTS (not the pre-merge inputs) across recovery.
 func TestMerge_SurvivesRecovery_EndToEnd(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	s.maxSegSize = 8
 	s.mcfg.Fanout = 2

--- a/core/vectorstore/merge_repend_race_test.go
+++ b/core/vectorstore/merge_repend_race_test.go
@@ -34,7 +34,7 @@ func TestMerge_RebuildRePendsInputDuringMergeWindow(t *testing.T) {
 	}
 	for iter := 0; iter < iters; iter++ {
 		kvStore := newTestKV(t)
-		s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: DotProduct})
+		s, err := Open(Options{Dir: t.TempDir(), Metric: DotProduct})
 		requireNoError(t, err)
 		rng := rand.New(rand.NewSource(int64(900 + iter)))
 		dim := 8
@@ -100,7 +100,7 @@ func TestMerge_CreateRePendsInputDuringMergeWindow(t *testing.T) {
 	}
 	for iter := 0; iter < iters; iter++ {
 		kvStore := newTestKV(t)
-		s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: DotProduct})
+		s, err := Open(Options{Dir: t.TempDir(), Metric: DotProduct})
 		requireNoError(t, err)
 		rng := rand.New(rand.NewSource(int64(1300 + iter)))
 		dim := 8

--- a/core/vectorstore/merge_trigger_test.go
+++ b/core/vectorstore/merge_trigger_test.go
@@ -166,8 +166,7 @@ func TestAutoMerge_CloseRaceNoPanic(t *testing.T) {
 		iters = 20
 	}
 	for iter := 0; iter < iters; iter++ {
-		kvStore := newTestKV(t)
-		s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+		s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 		requireNoError(t, err)
 		s.maxSegSize = 3
 		s.mcfg.Fanout = 2

--- a/core/vectorstore/metric_persist_test.go
+++ b/core/vectorstore/metric_persist_test.go
@@ -12,9 +12,8 @@ import (
 // is reachable by a config slip. The manifest must persist the metric and Open
 // must reject a mismatch with a clear error rather than silently wrong-restore.
 func TestOpen_RejectsMetricMismatch(t *testing.T) {
-	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(13))
 	dim := 8
@@ -33,14 +32,14 @@ func TestOpen_RejectsMetricMismatch(t *testing.T) {
 	requireNoError(t, s.Close())
 
 	// Reopen under a DIFFERENT metric: must error, not silently mis-read.
-	s2, err := Open(Options{Dir: dir, KV: kvStore, Metric: Euclidean})
+	s2, err := Open(Options{Dir: dir, Metric: Euclidean})
 	if err == nil {
 		_ = s2.Close()
 		t.Fatal("Open under Euclidean over a Cosine store should error (metric mismatch), got nil")
 	}
 
 	// Reopening under the SAME metric must still succeed.
-	s3, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s3, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s3.Close() })
 	if s3.Metric() != Cosine {

--- a/core/vectorstore/orphan_firstseal_test.go
+++ b/core/vectorstore/orphan_firstseal_test.go
@@ -14,7 +14,6 @@ import (
 // on the missing-manifest branch too (with an empty referenced set, every seg-*
 // dir is an orphan).
 func TestRecovery_OrphanSweptOnMissingManifest(t *testing.T) {
-	kvStore := newTestKV(t)
 	dir := t.TempDir()
 
 	// Simulate a crash during the FIRST seal: a half-written segment dir exists but
@@ -23,7 +22,7 @@ func TestRecovery_OrphanSweptOnMissingManifest(t *testing.T) {
 	requireNoError(t, os.MkdirAll(orphan, 0755))
 	requireNoError(t, os.WriteFile(filepath.Join(orphan, "vectors.dat"), []byte("garbage"), 0644))
 
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
 

--- a/core/vectorstore/orphan_test.go
+++ b/core/vectorstore/orphan_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRecovery_OrphanSegmentSwept(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(71))
 	dim := 8

--- a/core/vectorstore/phase2_coverage_test.go
+++ b/core/vectorstore/phase2_coverage_test.go
@@ -44,7 +44,7 @@ func TestSealedSegment_TombstoneOutOfRange(t *testing.T) {
 // loaded from control.db — and must be swept, never mistaken for live state.
 func TestRecovery_StrandedManifestTmpIgnored(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	requireNoError(t, s.Put("d-0", []float32{1, 0, 0, 0}, nil))
 	requireNoError(t, s.Seal()) // commits the control store (control.db)

--- a/core/vectorstore/recover_reopen_resume_race_test.go
+++ b/core/vectorstore/recover_reopen_resume_race_test.go
@@ -26,9 +26,8 @@ import (
 // -race`: with the two-phase recover, no builder exists while any reopen-write
 // runs, so the widen cannot produce a race. (Doc id: Phase-6 Task-8 recover race.)
 func TestRecover_ReopenWriteDoesNotRaceResumedBuild(t *testing.T) {
-	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 
 	// Suppress every merge so each Seal yields a distinct, surviving segment: a
@@ -112,7 +111,7 @@ func TestRecover_ReopenWriteDoesNotRaceResumedBuild(t *testing.T) {
 	testHookRecoverBeforeReopenWrite = func() { time.Sleep(8 * time.Millisecond) }
 	t.Cleanup(func() { testHookRecoverBeforeReopenWrite = nil })
 
-	s2, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s2.Close() })
 

--- a/core/vectorstore/recover_stray_graph_test.go
+++ b/core/vectorstore/recover_stray_graph_test.go
@@ -34,7 +34,7 @@ func putRandomSegment(t *testing.T, s *Store, n, dim int, seed int64) {
 func TestRecovery_StrayGraphSweptFromLiveSegDir(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	putRandomSegment(t, s, 60, 8, 91)
 
@@ -63,9 +63,8 @@ func TestRecovery_StrayGraphSweptFromLiveSegDir(t *testing.T) {
 // stray-graph sweep as a recover error, not a silent partial recovery (the error
 // leg of sweepStrayGraphsLocked).
 func TestRecovery_StrayGraphSweep_FsRemoveError(t *testing.T) {
-	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	putRandomSegment(t, s, 60, 8, 92)
 	stray := filepath.Join(s.dir, "seg-1-0", graphFileName("ghost"))
@@ -81,7 +80,7 @@ func TestRecovery_StrayGraphSweep_FsRemoveError(t *testing.T) {
 	}
 	defer func() { fsRemove = orig }()
 
-	s2, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	if err == nil {
 		_ = s2.Close()
 		t.Fatal("expected recover to surface the stray-graph unlink failure")

--- a/core/vectorstore/recovery_branches_test.go
+++ b/core/vectorstore/recovery_branches_test.go
@@ -1,7 +1,6 @@
 package vectorstore
 
 import (
-	"errors"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -18,7 +17,7 @@ import (
 func TestRecovery_DeleteSealedDocAfterReopen(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(101))
 	dim := 12
@@ -75,9 +74,8 @@ func TestRecovery_DeleteSealedDocAfterReopen(t *testing.T) {
 // must spawn a background builder for it; WaitForIndex blocks until it indexes;
 // Search must return results throughout (pending brute leg, then indexed graph).
 func TestRecovery_ResumesPendingBuild(t *testing.T) {
-	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(102))
 	dim := 12
@@ -127,7 +125,7 @@ func TestRecovery_ResumesPendingBuild(t *testing.T) {
 	requireNoError(t, cs.Close())
 
 	// Reopen: recover() loads the pending segment and resumes its build.
-	s2, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s2.Close() })
 
@@ -161,7 +159,7 @@ func TestRecovery_ResumesPendingBuild(t *testing.T) {
 func TestRecovery_CrossSegmentUpdateTombstoneNotFlushed(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(7777))
 	dim := 8
@@ -234,7 +232,7 @@ func TestRecovery_CrossSegmentUpdateTombstoneNotFlushed(t *testing.T) {
 func TestRecovery_SealHeadClearIsAtomicNoDoubleStore(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(103))
 	dim := 10
@@ -293,22 +291,21 @@ func TestRecovery_SealHeadClearIsAtomicNoDoubleStore(t *testing.T) {
 	}
 }
 
-// TestLookupDocID_KVErrorPropagates makes the KV fail on a cache-miss read, so
-// lookupDocID's direct idtable read errors. Get and Delete must surface that
-// error rather than silently treating the id as not-found.
-func TestLookupDocID_KVErrorPropagates(t *testing.T) {
-	fkv := &faultKV{Store: newTestKV(t)}
-	s, err := Open(Options{Dir: t.TempDir(), KV: fkv, Metric: Cosine})
+// TestLookupDocID_AllocErrorPropagates closes the idtable out from under the
+// store so lookupDocID's non-allocating idtable read errors. Get and Delete must
+// surface that error rather than silently treating the id as not-found.
+func TestLookupDocID_AllocErrorPropagates(t *testing.T) {
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
-	// Arm the fault AFTER open (idtable.New already read its counter).
-	fkv.getErr = errors.New("kv get boom")
+	// Close the idtable so a cache-miss lookup errors (database is closed).
+	s.alloc.Close()
 
-	// "ghost" was never Put → idToDoc cache miss → lookupDocID reads the KV → errors.
+	// "ghost" was never Put → idToDoc cache miss → lookupDocID asks the idtable → errors.
 	if _, _, _, err := s.Get("ghost"); err == nil {
-		t.Fatal("Get should propagate the KV lookup error")
+		t.Fatal("Get should propagate the idtable lookup error")
 	}
 	if err := s.Delete("ghost"); err == nil {
-		t.Fatal("Delete should propagate the KV lookup error")
+		t.Fatal("Delete should propagate the idtable lookup error")
 	}
 }

--- a/core/vectorstore/recovery_test.go
+++ b/core/vectorstore/recovery_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 // reopenStore closes s and reopens a fresh Store over the SAME dir + KV (recovery).
-func reopenStore(t *testing.T, s *Store, kvStore kv.Store) *Store {
+func reopenStore(t *testing.T, s *Store, _ kv.Store) *Store {
 	t.Helper()
 	dir := s.dir
 	requireNoError(t, s.Close())
-	s2, err := Open(Options{Dir: dir, KV: kvStore, Metric: s.metric})
+	s2, err := Open(Options{Dir: dir, Metric: s.metric})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s2.Close() })
 	return s2
@@ -20,7 +20,7 @@ func reopenStore(t *testing.T, s *Store, kvStore kv.Store) *Store {
 
 func TestRecovery_SealedSegmentsAndHead(t *testing.T) {
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(41))
 	dim := 16

--- a/core/vectorstore/seal_idtable_durability_test.go
+++ b/core/vectorstore/seal_idtable_durability_test.go
@@ -18,10 +18,10 @@ import (
 // KV. This is the unclean-crash pattern: nothing in s's process memory or its lazy
 // idtable batch is flushed — only what was committed to the control DB (and to the
 // KV) survives.
-func reopenUnclean(t *testing.T, s *Store, kvStore kv.Store) *Store {
+func reopenUnclean(t *testing.T, s *Store, _ kv.Store) *Store {
 	t.Helper()
 	crashRelease(t, s)
-	s2, err := Open(Options{Dir: s.dir, KV: kvStore, Metric: s.metric})
+	s2, err := Open(Options{Dir: s.dir, Metric: s.metric})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s2.Close() })
 	return s2
@@ -53,6 +53,7 @@ func crashRelease(t *testing.T, s *Store) {
 	}
 	s.mu.Unlock()
 	_ = s.cs.Close()
+	s.alloc.CrashRelease() // release the idtable bbolt flock the way a kill would, WITHOUT committing pending
 }
 
 // TestSeal_IdtableDurableBeforeHeadClear is the red-proof for the committed-data
@@ -67,7 +68,7 @@ func TestSeal_IdtableDurableBeforeHeadClear(t *testing.T) {
 		t.Skip("in-process crash sim reopens over the same KV with the old store's idtable commit goroutine still live; that POSIX-timing assumption is unreliable on Windows. A real Windows crash kills the process (no live goroutine) and pebble's committed state is durable cross-platform, so the property itself holds — it is exercised on Linux/macOS.")
 	}
 	kvStore := newTestKV(t)
-	s, err := Open(Options{Dir: t.TempDir(), KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	rng := rand.New(rand.NewSource(4242))
 	dim := 16

--- a/core/vectorstore/store.go
+++ b/core/vectorstore/store.go
@@ -11,22 +11,13 @@ import (
 	"sync/atomic"
 
 	"github.com/codetrek/haystack/core/idtable"
-	"github.com/codetrek/haystack/core/kv"
 	bolt "go.etcd.io/bbolt"
 )
 
-// Distinct idtable key-prefix bytes for the vectorstore allocator, so it never
-// collides with idtable's default doc-id allocator (28/29) when sharing a KV.
-const (
-	idtableKeyTypeNextId = byte(40)
-	idtableKeyTypeKey    = byte(41)
-)
-
-// Options configures a Store. KV backs the string→docId idtable; Dir holds the
-// bbolt control store (control.db) and the flat sealed-segment data dirs.
+// Options configures a Store. Dir holds the bbolt control store (control.db),
+// the standalone idtable (idtable.db), and the flat sealed-segment data dirs.
 type Options struct {
 	Dir    string
-	KV     kv.Store
 	Metric Metric
 }
 
@@ -63,7 +54,6 @@ type Store struct {
 	mu     sync.RWMutex
 	metric Metric
 	dir    string
-	kv     kv.Store
 	alloc  *idtable.Allocator
 	seg    *segment // the head
 	// cs is the bbolt-backed CONTROL plane: the small, transactional store
@@ -168,23 +158,16 @@ var testHookRecoverBeforeReopenWrite func()
 // Open creates or recovers a Store at opts.Dir, rebuilding the in-memory head
 // segment, the id↔docId map, and the allocator state from the bbolt head bucket.
 func Open(opts Options) (*Store, error) {
-	if opts.KV == nil {
-		return nil, errors.New("vectorstore: Options.KV is required")
-	}
 	if opts.Dir == "" {
 		return nil, errors.New("vectorstore: Options.Dir is required")
 	}
-	alloc, err := idtable.New(opts.KV, idtable.Options{
-		KeyTypeNextId: idtableKeyTypeNextId,
-		KeyTypeKey:    idtableKeyTypeKey,
-	})
-	if err != nil {
+	// The directory must exist before we create the idtable / control.db files in it.
+	if err := os.MkdirAll(opts.Dir, 0755); err != nil {
 		return nil, err
 	}
-	// The directory must exist before openControlStore (control.db) creates its
-	// file in it; create it here so a fresh Dir works.
-	if err := os.MkdirAll(opts.Dir, 0755); err != nil {
-		alloc.Close()
+	// idtable is a standalone bbolt component living under the store's own Dir.
+	alloc, err := idtable.Open(filepath.Join(opts.Dir, "idtable.db"), idtable.Options{})
+	if err != nil {
 		return nil, err
 	}
 	cs, err := openControlStore(opts.Dir)
@@ -195,7 +178,6 @@ func Open(opts Options) (*Store, error) {
 	s := &Store{
 		metric:   opts.Metric,
 		dir:      opts.Dir,
-		kv:       opts.KV,
 		alloc:    alloc,
 		seg:      newSegment(opts.Metric),
 		cs:       cs,
@@ -885,28 +867,17 @@ func (s *Store) docIDForAlloc(id string) (int64, error) {
 }
 
 // lookupDocID resolves a string id to its docId WITHOUT allocating, for the read
-// path (Get). It consults the in-memory idToDoc cache first; on a miss it reads
-// the idtable's durable key→id entry directly from the KV (the same key encoding
-// the allocator uses: {idtableKeyTypeKey}+id, value = 8-byte big-endian docId).
-// This is required so a sealed doc — whose head row was moved out of the head
-// bucket at seal time and whose string id is therefore absent from idToDoc after
-// recovery — is still resolvable on Get. A truly-unknown id (never Put) yields
-// found=false and, unlike GetId, allocates nothing.
+// path (Get). It consults the in-memory idToDoc cache first; on a miss it asks
+// the idtable for a non-allocating lookup. This is required so a sealed doc —
+// whose head row was moved out of the head bucket at seal time and whose string
+// id is therefore absent from idToDoc after recovery — is still resolvable on
+// Get. A truly-unknown id (never Put) yields found=false and, unlike GetId,
+// allocates nothing.
 func (s *Store) lookupDocID(id string) (int64, bool, error) {
 	if d, ok := s.idToDoc[id]; ok {
 		return d, true, nil
 	}
-	key := make([]byte, 1+len(id))
-	key[0] = idtableKeyTypeKey
-	copy(key[1:], id)
-	v, err := s.kv.Get(key)
-	if err != nil {
-		return 0, false, err
-	}
-	if len(v) != 8 {
-		return 0, false, nil // missing (nil) or malformed → unknown id
-	}
-	return int64(binary.BigEndian.Uint64(v)), true, nil
+	return s.alloc.Lookup([]byte(id))
 }
 
 // rebuildHead reconstructs the in-memory flat head from the durable head bucket.

--- a/core/vectorstore/store_attr_recovery_test.go
+++ b/core/vectorstore/store_attr_recovery_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestStore_CreateAttrIndex_SurvivesReopen(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	b := s.NewBatch()
 	for i := 0; i < 30; i++ {
@@ -23,7 +22,7 @@ func TestStore_CreateAttrIndex_SurvivesReopen(t *testing.T) {
 	requireNoError(t, s.Close())
 
 	// Reopen: the declared index must persist (manifest v3) and filter correctly.
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 	requireNoError(t, s2.WaitForIndex())
@@ -36,8 +35,7 @@ func TestStore_CreateAttrIndex_SurvivesReopen(t *testing.T) {
 
 func TestStore_AttrFile_Corrupt_RebuildsOnOpen(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	b := s.NewBatch()
 	for i := 0; i < 20; i++ {
@@ -57,7 +55,7 @@ func TestStore_AttrFile_Corrupt_RebuildsOnOpen(t *testing.T) {
 	}
 	requireNoError(t, os.WriteFile(matches[0], []byte("garbage"), 0644))
 
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 	requireNoError(t, s2.WaitForIndex())

--- a/core/vectorstore/store_filter_test.go
+++ b/core/vectorstore/store_filter_test.go
@@ -376,8 +376,7 @@ func TestSearch_Filter_AfterMerge_MatchesOracle(t *testing.T) {
 // the independent oracle.
 func TestSearch_Filter_RecoversAfterReopen(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	requireNoError(t, s.CreateAttrIndex("color", Keyword))
 	vecs := map[int64][]float32{}
@@ -402,7 +401,7 @@ func TestSearch_Filter_RecoversAfterReopen(t *testing.T) {
 	requireNoError(t, s.WaitForIndex())
 	requireNoError(t, s.Close())
 
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 	requireNoError(t, s2.WaitForIndex())
@@ -495,8 +494,7 @@ func TestDropAttrIndex_Unknown_NoOp(t *testing.T) {
 // flipped on disk so decodePayload rejects it; Get must return that error.
 func TestGet_MalformedPayload_Errors(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	requireNoError(t, s.Put("a", []float32{1, 0, 0}, Payload{"k": StringValue("v")}))
 	requireNoError(t, s.Seal()) // one-row sealed segment, no attr declared
@@ -519,7 +517,7 @@ func TestGet_MalformedPayload_Errors(t *testing.T) {
 
 	// Reopen WITHOUT declaring an attr index (so no attr scan decodes the blob first);
 	// the only decodePayload is in Get's sealed path.
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 	requireNoError(t, s2.WaitForIndex())

--- a/core/vectorstore/store_payload_test.go
+++ b/core/vectorstore/store_payload_test.go
@@ -55,14 +55,13 @@ func TestStore_Payload_SurvivesSealAndMerge(t *testing.T) {
 // recovery).
 func TestStore_Payload_SurvivesRecovery(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	p := Payload{"tag": StringValue("x"), "rank": Float64Value(2.5)}
 	requireNoError(t, s.Put("a", []float32{1, 0, 0}, p))
 	requireNoError(t, s.Close())
 
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 	_, got, found, err := s2.Get("a")

--- a/core/vectorstore/store_test.go
+++ b/core/vectorstore/store_test.go
@@ -1,7 +1,8 @@
 package vectorstore
 
 import (
-	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -12,14 +13,8 @@ func TestStore_OpenClose(t *testing.T) {
 	}
 }
 
-func TestStore_OpenRequiresKV(t *testing.T) {
-	if _, err := Open(Options{Dir: t.TempDir(), Metric: Cosine}); err == nil {
-		t.Fatal("Open without KV should error")
-	}
-}
-
 func TestStore_OpenRequiresDir(t *testing.T) {
-	if _, err := Open(Options{KV: newTestKV(t), Metric: Cosine}); err == nil {
+	if _, err := Open(Options{Metric: Cosine}); err == nil {
 		t.Fatal("Open without Dir should error")
 	}
 }
@@ -214,9 +209,8 @@ func TestStore_Search_RejectsBadVectorAndK(t *testing.T) {
 
 func TestStore_Reopen_AfterClose(t *testing.T) {
 	dir := t.TempDir()
-	store := newTestKV(t) // shared across both opens, closed at cleanup
 
-	s1, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s1, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	requireNoError(t, s1.Put("a", []float32{1, 0, 0}, Payload{"p": StringValue("pa")}))
 	requireNoError(t, s1.Put("b", []float32{0, 1, 0}, Payload{"p": StringValue("pb")}))
@@ -224,7 +218,7 @@ func TestStore_Reopen_AfterClose(t *testing.T) {
 	requireNoError(t, s1.Delete("b"))
 	requireNoError(t, s1.Close()) // graceful: commits idtable + closes control store
 
-	s2, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 
@@ -245,9 +239,8 @@ func TestStore_Reopen_AfterClose(t *testing.T) {
 
 func TestStore_CrashRecovery_NoClose_HeadBucketIsSourceOfTruth(t *testing.T) {
 	dir := t.TempDir()
-	store := newTestKV(t) // shared; NOT closed between opens
 
-	s1, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s1, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	requireNoError(t, s1.Put("a", []float32{1, 0, 0}, Payload{"p": StringValue("pa")}))
 	requireNoError(t, s1.Put("b", []float32{0, 1, 0}, Payload{"p": StringValue("pb")}))
@@ -264,7 +257,7 @@ func TestStore_CrashRecovery_NoClose_HeadBucketIsSourceOfTruth(t *testing.T) {
 	// Reopen over the SAME dir + SAME KV. Recovery must come entirely from the
 	// durable head bucket: the segment, the id→docId map, and a consistent
 	// allocator nextId.
-	s2, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s2.Close()
 
@@ -297,8 +290,7 @@ func TestStore_CrashRecovery_NoClose_HeadBucketIsSourceOfTruth(t *testing.T) {
 
 func TestStore_CloseSurfacesControlStoreError(t *testing.T) {
 	dir := t.TempDir()
-	store := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	// Force cs.Close to surface an error so Store.Close propagates it (the
 	// control store is now the only Close that returns an error).
@@ -310,8 +302,7 @@ func TestStore_CloseSurfacesControlStoreError(t *testing.T) {
 
 func TestStore_PutControlStoreCommitError(t *testing.T) {
 	dir := t.TempDir()
-	store := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s.Close()
 	// Force the next control-store commit (the Put's durable head-row write) to fail.
@@ -323,8 +314,7 @@ func TestStore_PutControlStoreCommitError(t *testing.T) {
 
 func TestStore_DeleteControlStoreCommitError(t *testing.T) {
 	dir := t.TempDir()
-	store := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: store, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	defer s.Close()
 	requireNoError(t, s.Put("a", []float32{1, 0}, nil))
@@ -342,8 +332,7 @@ func TestStore_DeleteControlStoreCommitError(t *testing.T) {
 // resurrected. A second, surviving Put proves the failed Put caused no cascade loss.
 func TestErroredPutNotResurrectedOnReopen(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
-	s, err := Open(Options{Dir: dir, KV: kvs, Metric: DotProduct})
+	s, err := Open(Options{Dir: dir, Metric: DotProduct})
 	requireNoError(t, err)
 	// Force the durable commit for "x" to fail.
 	s.cs.failNextUpdate = errInjected
@@ -354,7 +343,7 @@ func TestErroredPutNotResurrectedOnReopen(t *testing.T) {
 	requireNoError(t, s.Put("y", []float32{5, 6, 7, 8}, nil))
 	requireNoError(t, s.Close())
 
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: DotProduct})
+	s2, err := Open(Options{Dir: dir, Metric: DotProduct})
 	requireNoError(t, err)
 	defer s2.Close()
 	if _, _, found, _ := s2.Get("x"); found {
@@ -367,42 +356,22 @@ func TestErroredPutNotResurrectedOnReopen(t *testing.T) {
 
 func TestStore_OpenIdtableError(t *testing.T) {
 	dir := t.TempDir()
-	kvStore := &faultKV{Store: newTestKV(t), getErr: errors.New("kv get boom")}
-	// idtable.New issues a startup Get for nextId; faulting it fails Open before
-	// the control store is even opened.
-	if _, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine}); err == nil {
-		t.Fatal("Open should fail when the idtable startup read fails")
+	// Occupy the idtable's path with a directory so idtable.Open (bbolt) fails,
+	// which must fail Store.Open.
+	requireNoError(t, os.MkdirAll(filepath.Join(dir, "idtable.db"), 0o755))
+	if _, err := Open(Options{Dir: dir, Metric: Cosine}); err == nil {
+		t.Fatal("Open should fail when the idtable cannot be opened")
 	}
 }
 
 func TestStore_PutAllocError(t *testing.T) {
-	dir := t.TempDir()
-	kvStore := &faultKV{Store: newTestKV(t)}
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: Cosine})
 	requireNoError(t, err)
 	defer s.Close()
-	// Now make GetId fail (IsClosed) so docIDForAlloc errors on the Put path.
-	kvStore.isClosed = true
+	// Close the idtable out from under the store so GetId fails, making
+	// docIDForAlloc error on the Put path.
+	s.alloc.Close()
 	if err := s.Put("a", []float32{1, 0}, nil); err == nil {
 		t.Fatal("Put should surface a docId-allocation failure")
-	}
-}
-
-func TestStore_OpenHeadRebuildError(t *testing.T) {
-	dir := t.TempDir()
-	base := newTestKV(t)
-	kvStore := &faultKV{Store: base}
-
-	// Seed the head bucket with one durable row so the rebuild has work to do.
-	s1, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
-	requireNoError(t, err)
-	requireNoError(t, s1.Put("a", []float32{1, 0}, nil))
-	crashRelease(t, s1) // leave the row on disk; do not commit alloc, drop OS locks
-
-	// Reopen: idtable.New's startup Get succeeds, but the head rebuild drives
-	// docIDForAlloc -> GetId, which fails because the KV reports closed.
-	kvStore.isClosed = true
-	if _, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine}); err == nil {
-		t.Fatal("Open should fail when the head rebuild's docId re-allocation fails")
 	}
 }

--- a/core/vectorstore/storehelpers_test.go
+++ b/core/vectorstore/storehelpers_test.go
@@ -21,7 +21,7 @@ func newTestKV(t *testing.T) kv.Store {
 // openTestStore opens a Store in a fresh temp dir over a fresh KV.
 func openTestStore(t *testing.T, m Metric) *Store {
 	t.Helper()
-	s, err := Open(Options{Dir: t.TempDir(), KV: newTestKV(t), Metric: m})
+	s, err := Open(Options{Dir: t.TempDir(), Metric: m})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
 	return s
@@ -77,29 +77,4 @@ func bruteForceKNN(m Metric, q []float32, vecs map[int64][]float32, k int) []int
 		out[i] = hits[i].doc
 	}
 	return out
-}
-
-// faultKV wraps a kv.Store to inject failures into the two operations the
-// vectorstore relies on through idtable: a Get error (to fail idtable.New's
-// startup read) and an IsClosed() == true (to fail Allocator.GetId, which the
-// store reaches via docIDForAlloc on the Put and replay paths). All other Store
-// methods are promoted from the embedded real store.
-type faultKV struct {
-	kv.Store
-	getErr   error
-	isClosed bool
-}
-
-func (f *faultKV) Get(key []byte) ([]byte, error) {
-	if f.getErr != nil {
-		return nil, f.getErr
-	}
-	return f.Store.Get(key)
-}
-
-func (f *faultKV) IsClosed() bool {
-	if f.isClosed {
-		return true
-	}
-	return f.Store.IsClosed()
 }

--- a/core/vectorstore/vindex_metric_recover_test.go
+++ b/core/vectorstore/vindex_metric_recover_test.go
@@ -14,7 +14,7 @@ import (
 func TestStore_Recover_PreservesNonPrimaryMetric(t *testing.T) {
 	kvStore := newTestKV(t)
 	dir := t.TempDir()
-	s, err := Open(Options{Dir: dir, KV: kvStore, Metric: Cosine})
+	s, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 
 	rng := rand.New(rand.NewSource(202))

--- a/core/vectorstore/vindex_test.go
+++ b/core/vectorstore/vindex_test.go
@@ -276,7 +276,6 @@ func TestStore_DropVectorIndex_DefaultRefusedUnknownNoop(t *testing.T) {
 
 func TestStore_Recover_RestoresAllIndexesAndResumesPending(t *testing.T) {
 	dir := t.TempDir()
-	kvs := newTestKV(t)
 	rng := rand.New(rand.NewSource(61))
 	dim := 16
 	vecs := make(map[int64][]float32)
@@ -289,7 +288,7 @@ func TestStore_Recover_RestoresAllIndexesAndResumesPending(t *testing.T) {
 	}
 
 	{
-		s, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+		s, err := Open(Options{Dir: dir, Metric: Cosine})
 		requireNoError(t, err)
 		batchPutVecs(t, s, "a-", 60, randVec, vecs)
 		requireNoError(t, s.Seal()) // seg 1 (default builds N=1 graph)
@@ -300,7 +299,7 @@ func TestStore_Recover_RestoresAllIndexesAndResumesPending(t *testing.T) {
 
 	// Reopen: both indexes' configs + states load from the manifest; indexed graphs
 	// reopen from disk, no rebuild needed.
-	s2, err := Open(Options{Dir: dir, KV: kvs, Metric: Cosine})
+	s2, err := Open(Options{Dir: dir, Metric: Cosine})
 	requireNoError(t, err)
 	t.Cleanup(func() { _ = s2.Close() })
 	requireNoError(t, s2.WaitForIndex())

--- a/internal/core/storage/storage_test.go
+++ b/internal/core/storage/storage_test.go
@@ -163,8 +163,8 @@ func TestKeyTypeConstants(t *testing.T) {
 		{"invertedindex.DefaultKeyTypeTable", invertedindex.DefaultKeyTypeTable},
 		{"invertedindex.DefaultKeyTypeNextId", invertedindex.DefaultKeyTypeNextId},
 		// idtable (28-29)
-		{"idtable.DefaultKeyTypeNextId", idtable.DefaultKeyTypeNextId},
-		{"idtable.DefaultKeyTypeKey", idtable.DefaultKeyTypeKey},
+		{"idtable.LegacyKeyTypeNextId", idtable.LegacyKeyTypeNextId},
+		{"idtable.LegacyKeyTypeKey", idtable.LegacyKeyTypeKey},
 		// storage symbols (30, 31, 33)
 		{"storage.KeyTypeSymbol", KeyTypeSymbol},
 		{"storage.KeyTypeSymbolDocFunctions", KeyTypeSymbolDocFunctions},

--- a/internal/server/coverage_test.go
+++ b/internal/server/coverage_test.go
@@ -111,17 +111,18 @@ func TestRun_IdTableInitError(t *testing.T) {
 	conf.Get().Server.CacheSize = 8 * 1024 * 1024
 	conf.Get().Global.DataPath = tempDir
 
-	// Pre-seed a corrupt nextId so that idtable.New returns an error.
+	// Pre-seed a corrupt legacy nextId so the one-time idtable migration fails
+	// (it validates the source counter before copying it into the bbolt file).
 	dataDB, err := storage.Open(filepath.Join(tempDir, "data"), conf.Get().Server.CacheSize)
 	assert.NoError(t, err)
-	// KeyTypeNextId == 28 (DefaultKeyTypeNextId); write a non-numeric value.
-	err = dataDB.Put([]byte{idtable.DefaultKeyTypeNextId}, []byte("not-a-number"))
+	// LegacyKeyTypeNextId == 28; write a non-numeric value.
+	err = dataDB.Put([]byte{idtable.LegacyKeyTypeNextId}, []byte("not-a-number"))
 	assert.NoError(t, err)
 	dataDB.Close()
 
 	err = run()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error initializing id table")
+	assert.Contains(t, err.Error(), "error migrating id table")
 }
 
 // TestRun_LockError tests Run() when CheckAndLockServer fails (line 36-38).

--- a/internal/server/httpapi/handlers_test.go
+++ b/internal/server/httpapi/handlers_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 	// Inject the inverted index into the searcher so search handlers work.
 	searcher.Run(&runningWg, idx, st)
 
-	alloc, err := idtable.New(db, idtable.Options{})
+	alloc, err := idtable.Open(filepath.Join(tempDir, "idtable.db"), idtable.Options{})
 	if err != nil {
 		panic("Failed to init idtable: " + err.Error())
 	}

--- a/internal/server/indexer/parser_test.go
+++ b/internal/server/indexer/parser_test.go
@@ -28,9 +28,9 @@ func setupTestEnv(t *testing.T) (env *testutil.Env, teardown func()) {
 	var shutdownWg sync.WaitGroup
 	running.InitShutdown(&shutdownWg)
 
-	alloc, err := idtable.New(env.DB, idtable.Options{})
+	alloc, err := idtable.Open(filepath.Join(env.TempDir, "idtable.db"), idtable.Options{})
 	if err != nil {
-		t.Fatalf("idtable.New: %v", err)
+		t.Fatalf("idtable.Open: %v", err)
 	}
 	SetIdAllocator(alloc)
 	idx, err := invertedindex.New(env.DB, env.Mpsc, invertedindex.Options{})

--- a/internal/server/mcptools/mcptools_test.go
+++ b/internal/server/mcptools/mcptools_test.go
@@ -126,7 +126,7 @@ This is a test project.`,
 			return
 		}
 
-		alloc, allocErr := idtable.New(db, idtable.Options{})
+		alloc, allocErr := idtable.Open(filepath.Join(conf.Get().Global.DataPath, "idtable.db"), idtable.Options{})
 		if !assert.NoError(t, allocErr) {
 			return
 		}

--- a/internal/server/searcher/searcher_coverage_test.go
+++ b/internal/server/searcher/searcher_coverage_test.go
@@ -471,9 +471,9 @@ func TestFullIntegration(t *testing.T) {
 	var shutdownWg sync.WaitGroup
 	running.InitShutdown(&shutdownWg)
 
-	alloc, err := idtable.New(env.DB, idtable.Options{})
+	alloc, err := idtable.Open(filepath.Join(env.TempDir, "idtable.db"), idtable.Options{})
 	if err != nil {
-		t.Fatalf("idtable.New: %v", err)
+		t.Fatalf("idtable.Open: %v", err)
 	}
 	indexer.SetIdAllocator(alloc)
 	idx, err := invertedindex.New(env.DB, env.Mpsc, iiOpts)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,7 +85,16 @@ func run() error {
 	mpsc := queue.NewMpsc("DBQueue")
 	mpsc.Start()
 
-	idAlloc, err := idtable.New(db, idtable.Options{})
+	// idtable is now a standalone bbolt-backed component (no longer sharing the
+	// `data` pebble store). Migrate any pre-existing key→id entries out of the
+	// legacy 28/29 prefixes on `db` into the bbolt file on first run; the migration
+	// is idempotent (a no-op once the bbolt file holds entries).
+	idtablePath := filepath.Join(conf.Get().Global.DataPath, "idtable.db")
+	if err := idtable.MigrateFromKV(db, idtablePath, idtable.LegacyKeyTypeKey, idtable.LegacyKeyTypeNextId); err != nil {
+		running.Shutdown()
+		return fmt.Errorf("error migrating id table: %w", err)
+	}
+	idAlloc, err := idtable.Open(idtablePath, idtable.Options{})
 	if err != nil {
 		running.Shutdown()
 		return fmt.Errorf("error initializing id table: %w", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -213,7 +213,7 @@ func startTestServer(t *testing.T) func() {
 	mpsc := queue.NewMpsc("TestDBQueue")
 	mpsc.Start()
 
-	alloc, err := idtable.New(db, idtable.Options{})
+	alloc, err := idtable.Open(filepath.Join(conf.Get().Global.DataPath, "idtable.db"), idtable.Options{})
 	assert.NoError(t, err)
 	indexer.SetIdAllocator(alloc)
 


### PR DESCRIPTION
## What

`idtable` is now shared by two subsystems — the document indexer **and** the vector store — so pinning it inside the server's shared pebble store was the wrong coupling. This makes it own its storage.

- **`New(kv.Store)` → `Open(path)`**: each `Allocator` owns a self-contained **bbolt** file (buckets: `keys` = rawKey→8-byte big-endian id, `meta` = nextId). The `kv.Store` dependency and the shared-store key-type prefixes (28/29) are gone. The **LRU cache, the pending read-your-own-writes buffer, the lazy commit ticker, and the fail-closed guards are preserved**.
- **`Lookup(key) (int64, bool, error)`** — a non-allocating read, replacing the vector store's raw peek into idtable's key encoding (a removed leaky coupling).
- **`CrashRelease()`** — drops the file lock **without** flushing pending, for the vector store's crash-recovery tests (a real kill releases the flock; bbolt's exclusive lock would otherwise block a same-process reopen).
- **`MigrateFromKV`** — one-time, **idempotent** copy of the legacy kv-backed idtable (28/29 prefixes) into the bbolt file. The server runs it on startup, so existing deployments keep their key→id mappings — **no reindex** (byte-identical id values).
- Also tunes the default commit interval **5s → 1s** (narrows the crash-loss window for allocations; not a throughput bottleneck — writes stay batched, one fsync per tick).

## Consumers
- **server**: `MigrateFromKV(db, …)` then `idtable.Open(<data>/idtable.db)`; idtable data leaves the shared `data` pebble store.
- **vectorstore**: drops `Options.KV` entirely and opens its idtable under `Dir`, so the vector store is now **pebble-free** (bbolt control plane + flat segments + bbolt idtable). `lookupDocID` uses `idtable.Lookup`.

Owning the bbolt db also makes `Close` coordinate the commit ticker **before** closing the file, structurally eliminating the prior "tick commits against a store closed out from under us" race (the old `pebble: closed` `-race` flake).

## A real bug caught by the migration test
The first cut reused one byte buffer across bbolt `Put` calls — but **bbolt retains the value slice by reference until the transaction commits**, so every entry took the last-written value (a data-corruption-class bug for multi-entry migrations / multi-pending commits). The idempotency test caught it (`alpha.go` came back as `2`, not `1`); fixed by using a fresh slice per `Put` (same fix applied in `tryCommit`).

## Verification
- ✅ core suite green — including all vectorstore crash-recovery / reopen tests under bbolt's exclusive lock.
- ✅ internal 14 packages green — including the server startup + migration path (a corrupt legacy nextId now fails at the migration step).
- ✅ `go-cov` gate passes (TOTAL 92.6%; new `Lookup`/`CrashRelease`/`MigrateFromKV`/`decodeId` all covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)