### PR TITLE
perf(tokenizer): replace ASCII regexp with a hand-written scanner (~5x faster on real code)

### DIFF
--- a/core/tokenizer/ascii_scan.go
+++ b/core/tokenizer/ascii_scan.go
@@ -1,0 +1,154 @@
+package tokenizer
+
+// findASCIITokensInto appends to dst the tokens of s that reASCII would match,
+// using a hand-written byte scanner instead of the regexp engine (which
+// dominates ASCII tokenization CPU). It reproduces reASCII exactly:
+//
+//	ALT1: [a-zA-Z0-9][a-zA-Z0-9_]{1,78}[a-zA-Z0-9]   (alnum token, length 3..80)
+//	ALT2: ([0-9]{1,8}\.|[a-zA-Z0-9]{1,2}\.)+([0-9]{1,8}|[a-zA-Z0-9]{1,2})
+//
+// At each position ALT1 is tried first (leftmost-first); ALT2 only when ALT1
+// fails. Matches are non-overlapping, left to right. Equivalence to reASCII is
+// pinned by an exhaustive differential test.
+func findASCIITokensInto(dst []string, s string) []string {
+	p := 0
+	for p < len(s) {
+		if e := scanAlt1(s, p); e > p {
+			dst = append(dst, s[p:e])
+			p = e
+			continue
+		}
+		if e := scanAlt2(s, p); e > p {
+			dst = append(dst, s[p:e])
+			p = e
+			continue
+		}
+		p++
+	}
+	return dst
+}
+
+// findASCIITokenSpansInto is findASCIITokensInto but appends [start,end) byte
+// spans instead of substrings, for callers that need token positions (the
+// wildcard search path).
+func findASCIITokenSpansInto(dst [][2]int, s string) [][2]int {
+	p := 0
+	for p < len(s) {
+		if e := scanAlt1(s, p); e > p {
+			dst = append(dst, [2]int{p, e})
+			p = e
+			continue
+		}
+		if e := scanAlt2(s, p); e > p {
+			dst = append(dst, [2]int{p, e})
+			p = e
+			continue
+		}
+		p++
+	}
+	return dst
+}
+
+// scanAlt1 returns the end index of an ALT1 match starting at p, or p if none.
+func scanAlt1(s string, p int) int {
+	if p >= len(s) || !isAlnum(s[p]) {
+		return p
+	}
+	// Maximal run of [a-zA-Z0-9_] from p.
+	e := p
+	for e < len(s) && isAlnumU(s[e]) {
+		e++
+	}
+	hi := e - p
+	if hi > 80 {
+		hi = 80
+	}
+	// Greedy: longest L in [3, hi] whose last char is alnum (not '_').
+	for L := hi; L >= 3; L-- {
+		if isAlnum(s[p+L-1]) {
+			return p + L
+		}
+	}
+	return p
+}
+
+// scanAlt2 returns the end index of an ALT2 (dotted) match starting at p, or p
+// if none.
+func scanAlt2(s string, p int) int {
+	q := p
+	lastSegStart := -1
+	for {
+		segLen := scanSegment(s, q)
+		if segLen == 0 {
+			break
+		}
+		lastSegStart = q
+		q += segLen
+	}
+	if lastSegStart < 0 {
+		return p // ALT2's "+" needs at least one segment
+	}
+	if fl := scanFinal(s, q); fl > 0 {
+		return q + fl
+	}
+	// The "+" was greedy but no final follows the last segment; give it back and
+	// match the final against the last segment's value. This is only valid when a
+	// segment still remains before it (the "+" requires >= 1 segment), so a lone
+	// "X." with no final does not match.
+	if lastSegStart > p {
+		if fl := scanFinal(s, lastSegStart); fl > 0 {
+			return lastSegStart + fl
+		}
+	}
+	return p
+}
+
+// scanSegment matches one "X." segment at q — [0-9]{1,8}\. (tried first) or
+// [a-zA-Z0-9]{1,2}\. — and returns its byte length, or 0.
+func scanSegment(s string, q int) int {
+	// [0-9]{1,8}\. : the digit run (<=8) must be immediately followed by '.'.
+	if q < len(s) && isDigit(s[q]) {
+		k := 0
+		for q+k < len(s) && k < 8 && isDigit(s[q+k]) {
+			k++
+		}
+		if q+k < len(s) && s[q+k] == '.' {
+			return k + 1
+		}
+	}
+	// [a-zA-Z0-9]{1,2}\. : greedy 2 then 1 alnum, followed by '.'.
+	if q < len(s) && isAlnum(s[q]) {
+		if q+2 < len(s) && isAlnum(s[q+1]) && s[q+2] == '.' {
+			return 3
+		}
+		if q+1 < len(s) && s[q+1] == '.' {
+			return 2
+		}
+	}
+	return 0
+}
+
+// scanFinal matches the ALT2 final — [0-9]{1,8} (tried first) or
+// [a-zA-Z0-9]{1,2} — at q and returns its byte length, or 0.
+func scanFinal(s string, q int) int {
+	if q < len(s) && isDigit(s[q]) {
+		k := 0
+		for q+k < len(s) && k < 8 && isDigit(s[q+k]) {
+			k++
+		}
+		return k
+	}
+	if q < len(s) && isAlnum(s[q]) {
+		if q+1 < len(s) && isAlnum(s[q+1]) {
+			return 2
+		}
+		return 1
+	}
+	return 0
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+func isAlnum(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+func isAlnumU(c byte) bool { return isAlnum(c) || c == '_' }

--- a/core/tokenizer/ascii_scan_test.go
+++ b/core/tokenizer/ascii_scan_test.go
@@ -1,0 +1,127 @@
+package tokenizer
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// equalTokens compares two token slices, treating nil and empty as equal.
+func equalTokens(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestFindASCIITokensMatchesRegexExhaustive pins the hand scanner to reASCII
+// over every string up to length 7 from an alphabet that exercises each
+// character class reASCII distinguishes (digit, letter, underscore, dot, and a
+// separator).
+func TestFindASCIITokensMatchesRegexExhaustive(t *testing.T) {
+	alphabet := []byte{'0', 'a', '_', '.', '-'}
+	buf := make([]byte, 0, 7)
+	var rec func(depth, maxLen int)
+	checked := 0
+	rec = func(depth, maxLen int) {
+		s := string(buf)
+		got := findASCIITokensInto(nil, s)
+		want := reASCII.FindAllString(s, -1)
+		if !equalTokens(got, want) {
+			t.Fatalf("scanner != regex for %q:\n got=%q\nwant=%q", s, got, want)
+		}
+		checked++
+		if depth == maxLen {
+			return
+		}
+		for _, c := range alphabet {
+			buf = append(buf, c)
+			rec(depth+1, maxLen)
+			buf = buf[:len(buf)-1]
+		}
+	}
+	rec(0, 7)
+	t.Logf("exhaustive: %d strings checked", checked)
+}
+
+// TestFindASCIITokensMatchesRegexRandom hits the length bounds ({1,8} digit
+// runs, {1,2} alnum runs, 3..80 token length) with longer random strings over a
+// richer alphabet, plus targeted boundary strings.
+func TestFindASCIITokensMatchesRegexRandom(t *testing.T) {
+	check := func(s string) {
+		got := findASCIITokensInto(nil, s)
+		want := reASCII.FindAllString(s, -1)
+		if !equalTokens(got, want) {
+			t.Fatalf("scanner != regex for %q:\n got=%q\nwant=%q", s, got, want)
+		}
+	}
+
+	// Targeted boundary cases.
+	for _, s := range []string{
+		strings.Repeat("a", 79), strings.Repeat("a", 80), strings.Repeat("a", 81),
+		strings.Repeat("a", 200),
+		strings.Repeat("0", 7), strings.Repeat("0", 8), strings.Repeat("0", 9),
+		"1234567.8", "12345678.9", "123456789.0",
+		"a." + strings.Repeat("0", 8) + ".b", "a." + strings.Repeat("0", 9),
+		"x.1a.", "1.2.", "a.b.", ".1.2", "ab.", "_._._",
+		strings.Repeat("a_", 50) + "b", strings.Repeat("_", 90),
+		"a" + strings.Repeat("_", 80) + "b",
+	} {
+		check(s)
+	}
+
+	// Random strings over a rich alphabet, fixed seed for determinism.
+	alphabet := []byte("abXY09._-/ ")
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 500000; i++ {
+		n := 1 + r.Intn(24)
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = alphabet[r.Intn(len(alphabet))]
+		}
+		check(string(b))
+	}
+
+	// Real code / mixed samples.
+	for _, s := range []string{asciiSample, mixedSample, cjkSample} {
+		check(s)
+	}
+}
+
+// TestFindASCIITokenSpansMatchesRegex pins the span variant (used by the
+// wildcard search path) to reASCII.FindAllStringIndex.
+func TestFindASCIITokenSpansMatchesRegex(t *testing.T) {
+	check := func(s string) {
+		got := findASCIITokenSpansInto(nil, s)
+		want := reASCII.FindAllStringIndex(s, -1)
+		if len(got) != len(want) {
+			t.Fatalf("span count differs for %q: got=%v want=%v", s, got, want)
+		}
+		for i := range got {
+			if got[i][0] != want[i][0] || got[i][1] != want[i][1] {
+				t.Fatalf("span %d differs for %q: got=%v want=%v", i, s, got[i], want[i])
+			}
+		}
+	}
+	for _, s := range []string{
+		"", "abc", "a.b.c", "http.Request", "foo_bar baz-qux",
+		"*abc-def", "1.2.3 v4.5", "no_match_xx end", asciiSample, mixedSample,
+	} {
+		check(s)
+	}
+	alphabet := []byte("abXY09._-* ")
+	r := rand.New(rand.NewSource(2))
+	for i := 0; i < 100000; i++ {
+		n := 1 + r.Intn(20)
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = alphabet[r.Intn(len(alphabet))]
+		}
+		check(string(b))
+	}
+}

--- a/core/tokenizer/ascii_tokenizer.go
+++ b/core/tokenizer/ascii_tokenizer.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+// reASCII is the original token grammar, retained as the oracle for the
+// differential test that pins the hand-written scanner (findASCIITokensInto) to
+// it. Production tokenization uses the scanner, which is byte-for-byte equivalent
+// but avoids the regexp engine's backtracking that dominated tokenizer CPU.
 var reASCII = regexp.MustCompile(`[a-zA-Z0-9][a-zA-Z0-9_]{1,78}[a-zA-Z0-9]|([0-9]{1,8}\.|[a-zA-Z0-9]{1,2}\.)+([0-9]{1,8}|[a-zA-Z0-9]{1,2})`)
 
 // ASCIITokenizer handles tokenization of ASCII text (Latin alphabet, digits,
@@ -17,7 +21,7 @@ type ASCIITokenizer struct{}
 // It collects words from the string, splits them into smaller parts if necessary,
 // and returns a sorted list of unique words.
 func (t *ASCIITokenizer) TokenizeForIndex(str string) []string {
-	words := reASCII.FindAllString(str, -1)
+	words := findASCIITokensInto(nil, str)
 
 	uniqueWords := make(map[string]struct{}, len(words))
 	pushWord := func(word string) {
@@ -77,13 +81,13 @@ func (t *ASCIITokenizer) TokenizeForSearch(s string, exactMatching bool) ([]stri
 	}
 
 	if exactMatching {
-		for _, w := range reASCII.FindAllString(s, -1) {
+		for _, w := range findASCIITokensInto(nil, s) {
 			push(w)
 		}
 		return result, nil
 	}
 
-	poses := reASCII.FindAllStringIndex(s, -1)
+	poses := findASCIITokenSpansInto(nil, s)
 	for _, pos := range poses {
 		start := pos[0]
 		end := pos[1]

--- a/core/tokenizer/real_corpus_test.go
+++ b/core/tokenizer/real_corpus_test.go
@@ -1,0 +1,99 @@
+package tokenizer
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// collectRealCorpus reads source files under TOKENIZER_BENCH_ROOT (sorted,
+// capped) and returns their contents. Returns nil when the env var is unset.
+func collectRealCorpus(tb testing.TB) []string {
+	root := os.Getenv("TOKENIZER_BENCH_ROOT")
+	if root == "" {
+		return nil
+	}
+	const maxFiles = 600
+	const maxBytes = 4 << 20 // ~4 MB total
+	exts := map[string]bool{".rs": true, ".ts": true, ".py": true, ".js": true, ".go": true}
+
+	var paths []string
+	filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.Contains(p, "/node_modules/") || strings.Contains(p, "/target/") || strings.Contains(p, "/.git/") {
+			return nil
+		}
+		if exts[filepath.Ext(p)] {
+			paths = append(paths, p)
+		}
+		return nil
+	})
+	sort.Strings(paths) // deterministic order
+
+	var corpus []string
+	total := 0
+	for _, p := range paths {
+		if len(corpus) >= maxFiles || total >= maxBytes {
+			break
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		corpus = append(corpus, string(b))
+		total += len(b)
+	}
+	tb.Logf("real corpus: %d files, %d bytes from %s", len(corpus), total, root)
+	return corpus
+}
+
+// TestRealRepoTokensMatchRegex proves the hand scanner is byte-for-byte identical
+// to reASCII on real source code. Gated on TOKENIZER_BENCH_ROOT.
+func TestRealRepoTokensMatchRegex(t *testing.T) {
+	corpus := collectRealCorpus(t)
+	if corpus == nil {
+		t.Skip("set TOKENIZER_BENCH_ROOT to a source tree to diff scanner vs regex on real code")
+	}
+	tokens := 0
+	for fi, content := range corpus {
+		got := findASCIITokensInto(nil, content)
+		want := reASCII.FindAllString(content, -1)
+		if !equalTokens(got, want) {
+			// find first divergence for a readable message
+			n := len(got)
+			if len(want) < n {
+				n = len(want)
+			}
+			for i := 0; i < n; i++ {
+				if got[i] != want[i] {
+					t.Fatalf("file #%d: token %d differs: got=%q want=%q", fi, i, got[i], want[i])
+				}
+			}
+			t.Fatalf("file #%d: token count differs: got %d want %d", fi, len(got), len(want))
+		}
+		tokens += len(got)
+	}
+	t.Logf("real corpus: %d tokens, scanner == reASCII on every file", tokens)
+}
+
+// BenchmarkRealRepoTokenize benchmarks ASCIITokenizer.TokenizeForIndex over the
+// real corpus (production path; uses the scanner after the optimization, the
+// regexp before it). Gated on TOKENIZER_BENCH_ROOT.
+func BenchmarkRealRepoTokenize(b *testing.B) {
+	corpus := collectRealCorpus(b)
+	if corpus == nil {
+		b.Skip("set TOKENIZER_BENCH_ROOT to a source tree to benchmark on real code")
+	}
+	tok := &ASCIITokenizer{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, content := range corpus {
+			tok.TokenizeForIndex(content)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the ASCII token grammar's regexp (`reASCII`) with a hand-written byte
scanner. The regexp's backtracking dominated tokenizer CPU; the scanner is
**byte-for-byte equivalent** but much faster.

ASCII tokenization runs on every indexed source file, so this is an indexing
throughput win.

## How it was found

pprof of `DirectASCIITokenizeForIndex` showed **~65% of CPU was the regexp
engine** matching `reASCII` (`FindAllString`/`FindAllStringIndex`): `tryBacktrack`
+ `bitState.reset → memclrNoHeapPointers` (~14.5%, just zeroing the backtracking
bitmap — the `{1,78}`/`{1,8}` bounded repeats expand to many NFA states) +
`shouldVisit` + `MatchRune`.

## Change

`findASCIITokensInto` reproduces the grammar exactly:

```
ALT1: [a-zA-Z0-9][a-zA-Z0-9_]{1,78}[a-zA-Z0-9]            (alnum token, len 3..80)
ALT2: ([0-9]{1,8}\.|[a-zA-Z0-9]{1,2}\.)+([0-9]{1,8}|[a-zA-Z0-9]{1,2})   (dotted)
```

with Go regexp's **leftmost-first** semantics: at each position ALT1 is tried
before ALT2 (e.g. `192.168.1.1 → [192,168,1.1]` — ALT1 grabs `192` before ALT2
could span the whole thing); the ALT2 final prefers `[0-9]{1,8}` over alnum
(`1a.2b → [1a.2]`); and the greedy `+` backtracks exactly one segment when no
final follows, but only if a segment still remains (`x.1a. → [x.1]`). `reASCII`
is kept as the differential-test oracle.

## Correctness — byte-for-byte equivalent to the regex

- **exhaustive**: every string up to length 7 over `{0,a,_,.,-}` (97,656)
- **random**: 500k strings over a rich alphabet + length-bound cases
- **spans variant** vs `FindAllStringIndex` (100k + targeted)
- **real code (`/workspace/codex`)**: 600 files, **108,756 tokens, scanner ==
  reASCII on every file**
- existing index/search/golden suites unchanged, all green; `-race` green; the
  core `go-cov` per-function coverage gate passes (exit 0)

## Performance (benchstat, count=10, local AMD EPYC)

Synthetic (`~400`-char Go snippet):

| | Index | Search | geomean |
|---|---|---|---|
| sec/op | −68.7% | −60.9% | **−65.0%** |
| allocs/op | −49.4% | −63.3% | −56.9% |
| B/op | −16.5% | −28.3% | −22.6% |

Real codex source (600 files, 1.5 MB), regex (origin/main) vs scanner:

| | vs base |
|---|---|
| sec/op | 164.5m → 33.1m **−79.9% (~5×)** |
| allocs/op | 169.1k → 62.2k −63.2% |
| B/op | 17.65Mi → 12.41Mi −29.7% |

> Absolute ns are machine-local; eliminating backtracking is an algorithmic,
> architecture-independent win.

## Also measured and dropped

A byte-level `camelSnakeSplit` (avoiding `unicode.IsUpper`/rune decode) was
measured: geomean **−0.43%, p≈0.3 (not significant)**, allocs unchanged —
`unicode.IsUpper` already has a Latin-1 fast path and that code is <3% of CPU. Not
shipped (no real benefit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
