### PR TITLE
perf(invertedindex): delta-varint encode posting-row values

### DIFF
--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -3,6 +3,7 @@ package invertedindex
 import (
 	"encoding/binary"
 	"encoding/json"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -16,12 +17,6 @@ const (
 	DefaultKeyTypeNextId = byte(22)
 
 	InvalidId = -1
-
-	// docIDSize is the fixed on-disk width of a doc id. Row values are docids
-	// concatenated with NO delimiter (see encodeInvertedValue), so the decoder
-	// chunks the value into docIDSize-byte ids — a docid of any other length
-	// corrupts every subsequent chunk. The add/remove paths validate against this.
-	docIDSize = 8
 )
 
 func isKeyType(key string, keyType byte) bool {
@@ -138,34 +133,65 @@ func encodeTableValue(info TableInfo) []byte {
 	return content
 }
 
-// encodeInvertedValue packs docids into a fixed-width byte string: each docid is
-// its 8-byte big-endian form, concatenated with no delimiter. Big-endian keeps
-// the on-disk bytes identical to the previous string-docid representation (the
-// docid was always the big-endian encoding of an idtable int64), so the format
-// is unchanged and no reindex is required.
+// encodeInvertedValue encodes a posting row's docids as a delta-varint sequence:
+// the docids are sorted (by their unsigned 64-bit bit pattern) and written as the
+// first id followed by successive gaps, each a base-128 uvarint. Real docids are
+// small, densely-allocated idtable ids, so the gaps are tiny and most encode to a
+// single byte — far smaller than the previous fixed 8-byte-per-id layout, and
+// cheaper to decode than a general-purpose block compressor. Order within a row
+// is irrelevant (the docids are a set), so sorting here is free; deduplication
+// remains the caller's responsibility. Sorting/subtracting in uint64 space (not
+// int64) keeps every gap non-negative and makes the round-trip exact for any
+// int64 docid, including negative and max values. This is an on-disk format
+// change from the old big-endian layout and requires a reindex.
 func encodeInvertedValue(docids []int64) []byte {
-	buf := make([]byte, len(docids)*docIDSize)
+	if len(docids) == 0 {
+		return []byte{}
+	}
+	us := make([]uint64, len(docids))
 	for i, id := range docids {
-		binary.BigEndian.PutUint64(buf[i*docIDSize:], uint64(id))
+		us[i] = uint64(id)
+	}
+	slices.Sort(us)
+
+	buf := make([]byte, 0, len(us)+len(us)/2) // most ids encode to ~1 byte
+	var tmp [binary.MaxVarintLen64]byte
+	var prev uint64
+	for i, u := range us {
+		delta := u
+		if i > 0 {
+			delta = u - prev // non-negative: us is sorted ascending in uint64 space
+		}
+		n := binary.PutUvarint(tmp[:], delta)
+		buf = append(buf, tmp[:n]...)
+		prev = u
 	}
 	return buf
 }
 
+// decodeInvertedValue is the inverse of encodeInvertedValue: it reads successive
+// uvarint gaps, accumulating each into the running docid. A truncated trailing
+// varint stops the decode; values this package wrote always decode fully.
 func decodeInvertedValue(data []byte) []int64 {
-	// Each docid is docIDSize bytes (big-endian int64).
-	if len(data) == 0 || len(data)%docIDSize != 0 {
+	if len(data) == 0 {
 		return []int64{}
 	}
-
-	ids := make([]int64, 0, len(data)/docIDSize)
-	for i := 0; i+docIDSize <= len(data); i += docIDSize {
-		ids = append(ids, int64(binary.BigEndian.Uint64(data[i:i+docIDSize])))
+	ids := make([]int64, 0, len(data)) // upper bound: one byte per id
+	var cur uint64
+	for i := 0; i < len(data); {
+		delta, n := binary.Uvarint(data[i:])
+		if n <= 0 {
+			break
+		}
+		cur += delta
+		ids = append(ids, int64(cur))
+		i += n
 	}
 	return ids
 }
 
 func decodeInvertedValueStr(data string) []int64 {
-	// Each docid is docIDSize bytes (big-endian int64). The merger holds row
-	// values as strings; copy once into a byte slice and reuse the byte decoder.
+	// The merger holds row values as strings; copy once into a byte slice and
+	// reuse the byte decoder.
 	return decodeInvertedValue([]byte(data))
 }

--- a/core/invertedindex/codec_test.go
+++ b/core/invertedindex/codec_test.go
@@ -2,6 +2,7 @@ package invertedindex
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -215,49 +216,53 @@ func TestEncodeTableValue(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// encodeInvertedValue / decodeInvertedValue round-trip
+// encodeInvertedValue / decodeInvertedValue round-trip (delta-varint)
 // ---------------------------------------------------------------------------
 func TestEncodeDecodeInvertedValue(t *testing.T) {
-	// Each docid is an 8-byte big-endian int64. These literals are the int64
-	// values whose big-endian bytes spell the ASCII labels below, so the encoded
-	// buffer is byte-identical to the previous string representation (no reindex).
-	docids := []int64{0x6162636465666768 /*abcdefgh*/, 0x3132333435363738 /*12345678*/, 0x5858585858585858 /*XXXXXXXX*/}
+	// Unsorted, realistic densely-allocated docids. encode sorts and delta-varint
+	// encodes them; decode returns the ascending set.
+	docids := []int64{100, 5, 5000, 6, 101, 9}
+	want := []int64{5, 6, 9, 100, 101, 5000}
 	encoded := encodeInvertedValue(docids)
 
-	// Byte-parity with the old string-docid format.
-	if string(encoded) != "abcdefgh12345678XXXXXXXX" {
-		t.Fatalf("encoded bytes = %q, want %q", string(encoded), "abcdefgh12345678XXXXXXXX")
+	// Delta-varint must be far smaller than the old fixed 8-byte-per-id layout.
+	if len(encoded) >= len(docids)*8 {
+		t.Errorf("delta-varint did not shrink value: %d bytes for %d ids", len(encoded), len(docids))
 	}
 
 	decoded := decodeInvertedValue(encoded)
-	if len(decoded) != len(docids) {
-		t.Fatalf("expected %d docids, got %d", len(docids), len(decoded))
-	}
-	for i, want := range docids {
-		if decoded[i] != want {
-			t.Errorf("docids[%d]: got %d, want %d", i, decoded[i], want)
-		}
+	if !slices.Equal(decoded, want) {
+		t.Fatalf("round-trip mismatch: got %v, want %v", decoded, want)
 	}
 }
 
 func TestDecodeInvertedValueEdgeCases(t *testing.T) {
-	tests := []struct {
+	// Round-trip cases: encode then decode reproduces the ascending docid set.
+	roundTrips := []struct {
 		name string
-		data []byte
-		want int
+		ids  []int64
+		want []int64
 	}{
-		{"empty data", []byte{}, 0},
-		{"not multiple of 8", []byte("abc"), 0},
-		{"exactly 8 bytes", []byte("12345678"), 1},
-		{"16 bytes", []byte("1234567890abcdef"), 2},
+		{"empty", nil, []int64{}},
+		{"single", []int64{42}, []int64{42}},
+		{"adjacent", []int64{7, 8, 9}, []int64{7, 8, 9}},
+		{"large gaps", []int64{0, 1 << 50}, []int64{0, 1 << 50}},
 	}
-	for _, tc := range tests {
+	for _, tc := range roundTrips {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decodeInvertedValue(tc.data)
-			if len(got) != tc.want {
-				t.Errorf("decodeInvertedValue(%q): got %d docids, want %d", tc.data, len(got), tc.want)
+			got := decodeInvertedValue(encodeInvertedValue(tc.ids))
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("round-trip(%v): got %v, want %v", tc.ids, got, tc.want)
 			}
 		})
+	}
+
+	// A truncated trailing varint (a dangling continuation byte) stops the decode
+	// after the valid prefix instead of corrupting it.
+	valid := encodeInvertedValue([]int64{3, 70000}) // 70000 needs a multi-byte varint
+	truncated := valid[:len(valid)-1]
+	if got := decodeInvertedValue(truncated); len(got) == 0 || got[0] != 3 {
+		t.Errorf("truncated decode: got %v, want the valid prefix [3 ...]", got)
 	}
 }
 
@@ -265,38 +270,20 @@ func TestDecodeInvertedValueEdgeCases(t *testing.T) {
 // decodeInvertedValueStr
 // ---------------------------------------------------------------------------
 func TestDecodeInvertedValueStr(t *testing.T) {
-	// "abcdefgh12345678" → two 8-byte big-endian int64 docids.
-	data := "abcdefgh12345678"
-	want := []int64{0x6162636465666768, 0x3132333435363738}
+	want := []int64{2, 4, 8, 4096}
+	data := string(encodeInvertedValue(want))
 	decoded := decodeInvertedValueStr(data)
-
-	if len(decoded) != len(want) {
-		t.Fatalf("expected %d docids, got %d", len(want), len(decoded))
-	}
-	for i, w := range want {
-		if decoded[i] != w {
-			t.Errorf("docids[%d]: got %d, want %d", i, decoded[i], w)
-		}
+	if !slices.Equal(decoded, want) {
+		t.Fatalf("got %v, want %v", decoded, want)
 	}
 }
 
 func TestDecodeInvertedValueStrEdgeCases(t *testing.T) {
-	tests := []struct {
-		name string
-		data string
-		want int
-	}{
-		{"empty string", "", 0},
-		{"not multiple of 8", "abcde", 0},
-		{"exactly 8 chars", "12345678", 1},
+	if got := decodeInvertedValueStr(""); len(got) != 0 {
+		t.Errorf("empty string: got %v, want none", got)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := decodeInvertedValueStr(tc.data)
-			if len(got) != tc.want {
-				t.Errorf("decodeInvertedValueStr(%q): got %d docids, want %d", tc.data, len(got), tc.want)
-			}
-		})
+	if got := decodeInvertedValueStr(string(encodeInvertedValue([]int64{99}))); !slices.Equal(got, []int64{99}) {
+		t.Errorf("single: got %v, want [99]", got)
 	}
 }
 

--- a/core/invertedindex/index_test.go
+++ b/core/invertedindex/index_test.go
@@ -1,6 +1,7 @@
 package invertedindex
 
 import (
+	"encoding/binary"
 	"sort"
 	"testing"
 	"time"
@@ -729,17 +730,29 @@ func TestDoc2IDPadding(t *testing.T) {
 		{"abcdefghijklm", "abcdefgh"}, // truncated to first 8 bytes
 	}
 	for _, tc := range tests {
-		got := string(encodeInvertedValue([]int64{Doc2ID(tc.input)}))
-		if got != tc.want {
+		// The canonical docid form is its 8-byte big-endian encoding (idtable's
+		// docid identity), independent of the inverted-value codec.
+		var b [8]byte
+		binary.BigEndian.PutUint64(b[:], uint64(Doc2ID(tc.input)))
+		if got := string(b[:]); got != tc.want {
 			t.Errorf("Doc2ID(%q) canonical bytes = %q, want %q", tc.input, got, tc.want)
 		}
 	}
 }
 
 func TestMakeDocsForKeyword(t *testing.T) {
-	result := MakeDocsForKeyword("doc1", "doc2")
-	if len(result) != 16 {
-		t.Errorf("expected 16 bytes, got %d", len(result))
+	// MakeDocsForKeyword delta-varint encodes the docids; decode must recover the
+	// same set (ascending in uint64 order).
+	got := decodeInvertedValue([]byte(MakeDocsForKeyword("doc1", "doc2")))
+	want := []int64{Doc2ID("doc1"), Doc2ID("doc2")}
+	sort.Slice(want, func(i, j int) bool { return uint64(want[i]) < uint64(want[j]) })
+	if len(got) != len(want) {
+		t.Fatalf("got %d docids, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("docid[%d] = %d, want %d", i, got[i], want[i])
+		}
 	}
 }
 

--- a/core/invertedindex/invertedindex.go
+++ b/core/invertedindex/invertedindex.go
@@ -35,12 +35,17 @@ func (idx *Index) Search(tableId int, query string, limit int, filterKeyword fun
 			return true
 		}
 
-		// Iterate the packed 8-byte docids straight into the result set, decoding
-		// each big-endian int64 in place — no per-docid string allocation.
-		if len(value)%docIDSize == 0 {
-			for i := 0; i < len(value); i += docIDSize {
-				results.DocIds[int64(binary.BigEndian.Uint64(value[i:i+docIDSize]))] = struct{}{}
+		// Accumulate the value's delta-varint docids straight into the result set,
+		// reconstructing each id from the running gap — no per-docid allocation.
+		var cur uint64
+		for i := 0; i < len(value); {
+			delta, n := binary.Uvarint(value[i:])
+			if n <= 0 {
+				break
 			}
+			cur += delta
+			results.DocIds[int64(cur)] = struct{}{}
+			i += n
 		}
 
 		if limit > 0 && len(results.DocIds) >= limit {
@@ -73,10 +78,15 @@ func (idx *Index) GetDocs(tableId int, key string) SearchResult {
 		if _, kw, _, _ := idx.decodeInvertedKey(string(k)); kw != want {
 			return true
 		}
-		if len(value)%docIDSize == 0 {
-			for i := 0; i < len(value); i += docIDSize {
-				results.DocIds[int64(binary.BigEndian.Uint64(value[i:i+docIDSize]))] = struct{}{}
+		var cur uint64
+		for i := 0; i < len(value); {
+			delta, n := binary.Uvarint(value[i:])
+			if n <= 0 {
+				break
 			}
+			cur += delta
+			results.DocIds[int64(cur)] = struct{}{}
+			i += n
 		}
 		return true
 	})

--- a/core/invertedindex/key_robustness_test.go
+++ b/core/invertedindex/key_robustness_test.go
@@ -1,6 +1,7 @@
 package invertedindex
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -56,11 +57,11 @@ func TestEncodeInvertedKey_UniqueWithinMicrosecond(t *testing.T) {
 	}
 }
 
-// B4/B5/B8 — docids are int64 by type, so the fixed-width value codec can never
-// be fed a wrong-length docid (the old string-ingress length guard is no longer
-// representable). This pins the surviving invariant: arbitrary int64 docids —
+// B4/B5/B8 — docids are int64 by type, so the value codec can never be fed a
+// wrong-length docid. This pins the surviving invariant: arbitrary int64 docids —
 // including 0, negative, and max — round-trip through Update/GetDocs intact and
-// every stored value stays a multiple of docIDSize.
+// every stored value is a canonical delta-varint sequence (decode then re-encode
+// reproduces it exactly; a truncated/garbage value would not).
 func TestUpdate_Int64DocidRoundTrip(t *testing.T) {
 	env := setupTestEnv(t)
 	defer env.teardown()
@@ -80,10 +81,11 @@ func TestUpdate_Int64DocidRoundTrip(t *testing.T) {
 			t.Errorf("docid %d was not indexed/retrieved", id)
 		}
 	}
-	// No stored value may have a non-multiple-of-docIDSize length (would corrupt decode).
+	// Every stored value must be a canonical delta-varint encoding (decode∘encode
+	// is the identity on it); anything else would corrupt the decoder.
 	_ = env.DB.Scan([]byte{env.idx.keyTypeRow}, func(k, v []byte) bool {
-		if len(v)%docIDSize != 0 {
-			t.Errorf("corrupt value length %d for key %q", len(v), k)
+		if !bytes.Equal(encodeInvertedValue(decodeInvertedValue(v)), v) {
+			t.Errorf("non-canonical value (len %d) for key %q", len(v), k)
 		}
 		return true
 	})

--- a/core/invertedindex/keywords_merger_test.go
+++ b/core/invertedindex/keywords_merger_test.go
@@ -151,9 +151,9 @@ func TestRewriteIndexMultipleRows(t *testing.T) {
 		TableId: testTable1,
 		Keyword: "keyword1",
 		Rows: []recordRow{
-			{Key: "key1", Value: "cdocdoc1cdocdoc2", DocCount: 2},
-			{Key: "key2", Value: "cdocdoc3cdocdoc4", DocCount: 2},
-			{Key: "key3", Value: "cdocdoc5cdocdoc6", DocCount: 2},
+			{Key: "key1", Value: MakeDocsForKeyword("doc1", "doc2"), DocCount: 2},
+			{Key: "key2", Value: MakeDocsForKeyword("doc3", "doc4"), DocCount: 2},
+			{Key: "key3", Value: MakeDocsForKeyword("doc5", "doc6"), DocCount: 2},
 		},
 		DocCount: 6,
 	}

--- a/internal/core/storage/storage.go
+++ b/internal/core/storage/storage.go
@@ -9,7 +9,12 @@ import (
 	"github.com/codetrek/haystack/core/kv/pebblekv"
 )
 
-const StorageVersion = "1.4"
+// StorageVersion names the on-disk KV directory. Bump it on any breaking
+// on-disk format change to force a clean reindex into a fresh directory; add the
+// previous version to cleanup's list so the stale DB is removed. 1.5 switches the
+// inverted-index posting-row values from fixed 8-byte big-endian docids to a
+// delta-varint encoding, which the 1.4 decoder cannot read.
+const StorageVersion = "1.5"
 
 func cleanup(storagePath string) {
 	// Perform cleanup tasks here, such as removing old files or directories
@@ -20,6 +25,7 @@ func cleanup(storagePath string) {
 		"1.1",
 		"1.2",
 		"1.3",
+		"1.4", // pre-delta-varint posting-value format; superseded by 1.5
 	}
 
 	for _, item := range cleanupList {

--- a/internal/core/storage/storage_test.go
+++ b/internal/core/storage/storage_test.go
@@ -131,7 +131,7 @@ func TestCleanup_PartialOldDirs(t *testing.T) {
 }
 
 func TestStorageVersion(t *testing.T) {
-	assert.Equal(t, "1.4", StorageVersion)
+	assert.Equal(t, "1.5", StorageVersion)
 }
 
 func TestIsKeyType(t *testing.T) {


### PR DESCRIPTION
## What

Inverted-index posting-row values stored each docid as a fixed 8-byte big-endian
int64. Docids are small, densely-allocated `idtable` ids, so ~6 of every 8 bytes
were zero. This re-encodes a row's docids as a **delta-varint** sequence: sort by
unsigned 64-bit value, then write the first id followed by successive gaps as
base-128 uvarints. Real gaps are tiny, so most ids take a single byte.

The `Search`/`GetDocs` hot paths decode straight into the result set (accumulate
each gap), so there is no extra allocation. Sorting and subtracting in uint64
space keeps the round-trip exact for any int64 docid (negative, zero, max).

## Measured (pebble, real source corpora, real disk)

Isolated A/B of just this change (old 8-byte vs delta-varint):

| corpus | on-disk | build | search |
|---|---|---|---|
| codex (760K postings) | 18.4 → **15.0 MiB** (−18%) | ~flat | ~flat (small values) |
| linux kernel (37M postings) | 389 → **325 MiB** (−16%) | ~flat | 1820 → **1614 µs/query** (−11%) |

Search gets faster at scale because high-frequency terms return large posting
lists, and the smaller values mean fewer sstable bytes to read and decompress —
which outweighs the slightly higher per-docid decode cost. Identical search hit
counts before/after (correctness).

## Breaking on-disk change → reindex

The 1.4 decoder cannot read delta-varint values, so this bumps
`StorageVersion` **1.4 → 1.5** (opens a fresh directory and reindexes on upgrade)
and adds `1.4` to the storage cleanup list to remove the stale DB. This is the
same reindex-on-upgrade mechanism used for the earlier 1.0–1.4 bumps.

## Tests

Updated the value-codec golden tests (round-trip + truncation + the canonical
delta-varint invariant) and the `StorageVersion` pin. Full `core/` and
`internal/...` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)