### PR TITLE
refactor(invertedindex): own each document's keyword set via a forward map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,16 @@ proxy environment or a substitute method and then draw conclusions from it.
 
 When the two meet: make the real infrastructure improvement (Principle 1) **and** prove
 it in the real failing environment (Principle 2) — never in a convenient substitute.
+
+## 3. Author large files incrementally — chunk, don't dump
+
+When creating a large file (a plan, spec, design doc, or sizable code file), **do not
+emit the whole thing in one giant write.** Build it up in chunks: create the file with
+its header/skeleton first, then append one section at a time.
+
+- Write the file in pieces (header → section → section …), each a small, self-contained
+  append — not a single multi-hundred-line dump.
+- This keeps every step reviewable, lets the user course-correct mid-way instead of
+  after the entire artifact lands, and produces a cleaner edit history.
+- Applies to generated docs and plans especially, but to any long file: prefer a
+  sequence of focused appends over one monolithic write.

--- a/core/collection/catalog.go
+++ b/core/collection/catalog.go
@@ -354,10 +354,9 @@ func (c *Collection) DeleteDocument(docID string) error {
 }
 
 // GetDocument retrieves a document from this collection.
-// If includeWords is true, the document's Words field is populated.
 // Returns nil, nil if the document does not exist.
-func (c *Collection) GetDocument(docID string, includeWords bool) (*documents.Document, error) {
-	return c.catalog.docs.GetDocument(c.id, docID, includeWords)
+func (c *Collection) GetDocument(docID string) (*documents.Document, error) {
+	return c.catalog.docs.GetDocument(c.id, docID)
 }
 
 // Count returns the number of documents in this collection.

--- a/core/collection/catalog_test.go
+++ b/core/collection/catalog_test.go
@@ -512,7 +512,7 @@ func TestCollection_DocumentDelegation(t *testing.T) {
 	assert.Equal(t, 2, col.Count())
 
 	// GetDocument
-	d, err := col.GetDocument("file1.go", false)
+	d, err := col.GetDocument("file1.go")
 	require.NoError(t, err)
 	require.NotNil(t, d)
 	assert.Equal(t, "file1.go", d.RelPath)
@@ -531,7 +531,10 @@ func TestCollection_DocumentDelegation(t *testing.T) {
 	assert.Equal(t, []string{"file2.go"}, found)
 }
 
-// TestCollection_Update verifies Collection.Update delegates to documents.UpdateDocuments.
+// TestCollection_Update verifies Collection.Update delegates to
+// documents.UpdateDocuments and persists the new document (metadata). The
+// keyword re-index on Update is covered deterministically in
+// invertedindex/forward_test.go (TestForward_UpdateDiffsAgainstStoredSet).
 func TestCollection_Update(t *testing.T) {
 	env := setupFull(t)
 	defer env.teardown()
@@ -540,21 +543,21 @@ func TestCollection_Update(t *testing.T) {
 	require.NoError(t, err)
 
 	initial := []*documents.Document{
-		{ID: "doc1.go", RelPath: "doc1.go", Words: []string{"alpha", "beta"}},
+		{ID: "doc1.go", RelPath: "doc1.go", Size: 10, Hash: "h1", Words: []string{"alpha", "beta"}},
 	}
-	err = col.Save(initial)
-	require.NoError(t, err)
+	require.NoError(t, col.Save(initial))
 
 	updated := []*documents.Document{
-		{ID: "doc1.go", RelPath: "doc1.go", Words: []string{"gamma", "delta"}},
+		{ID: "doc1.go", RelPath: "doc1_renamed.go", Size: 20, Hash: "h2", Words: []string{"gamma", "delta"}},
 	}
-	err = col.Update(updated)
-	require.NoError(t, err)
+	require.NoError(t, col.Update(updated))
 
-	d, err := col.GetDocument("doc1.go", true)
+	d, err := col.GetDocument("doc1.go")
 	require.NoError(t, err)
 	require.NotNil(t, d)
-	assert.Equal(t, []string{"gamma", "delta"}, d.Words)
+	assert.Equal(t, "doc1_renamed.go", d.RelPath)
+	assert.Equal(t, int64(20), d.Size)
+	assert.Equal(t, "h2", d.Hash)
 }
 
 // TestMeta_SnapshotCopy verifies Meta() returns a snapshot (copy) not a live pointer.

--- a/core/documents/README.md
+++ b/core/documents/README.md
@@ -26,26 +26,29 @@ It is a standalone library package: it has no dependency on `internal/`.
 Keys are prefixed with a single key-type byte. The prefix bytes are configurable
 via `Options`; a zero field selects the default. The defaults are:
 
-| Constant                     | Byte | Contents                       |
-|------------------------------|------|--------------------------------|
-| `DefaultKeyTypeDocWorkspace` | 10   | Workspace metadata             |
-| `DefaultKeyTypeDocWords`     | 11   | Document words                 |
-| `DefaultKeyTypeDocMeta`      | 12   | Document metadata              |
-| `DefaultKeyTypeDocPath`      | 13   | Document path information      |
+| Constant                      | Byte | Contents                       |
+|-------------------------------|------|--------------------------------|
+| `DefaultKeyTypeDocCollection` | 10   | Workspace metadata             |
+| _(retired)_                   | 11   | Was document words (see below) |
+| `DefaultKeyTypeDocMeta`       | 12   | Document metadata              |
+| `DefaultKeyTypeDocPath`       | 13   | Document path information      |
 
 Byte 0 (NUL) is reserved as the "use default" sentinel and cannot be selected as
 a custom prefix. Changing a key-type byte after data has been written is a
 breaking on-disk change.
 
+Byte 11 (formerly `DefaultKeyTypeDocWords`) is retired in this (data) db:
+per-document keywords are now owned by the inverted index's forward map (in the
+separate `index` db), not duplicated here. Do not reuse byte 11 in this db
+without updating the key-space canary.
+
 Key formats:
 
-- Workspace metadata: `{KeyTypeDocWorkspace}{workspaceId}`
+- Workspace metadata: `{KeyTypeDocCollection}{workspaceId}`
 - Document metadata:   `{KeyTypeDocMeta}{workspaceId}|{docId}`
-- Document words:      `{KeyTypeDocWords}{workspaceId}|{docId}`
 - Document path:       `{KeyTypeDocPath}{workspaceId}|{docId}`
 
 ## Values
 
 - Document metadata is stored as JSON (`Document`).
-- Document words are stored as a pipe-separated (`|`) string.
 - Workspace metadata is stored as JSON (`Workspace`).

--- a/core/documents/codec.go
+++ b/core/documents/codec.go
@@ -13,9 +13,11 @@ import (
 // it cannot be selected as a custom prefix.
 const (
 	DefaultKeyTypeDocCollection = byte(10)
-	DefaultKeyTypeDocWords      = byte(11)
-	DefaultKeyTypeDocMeta       = byte(12)
-	DefaultKeyTypeDocPath       = byte(13)
+	// byte 11 retired: was DefaultKeyTypeDocWords. Document keywords are now owned
+	// by the inverted index's forward map (in the separate `index` db). Do not
+	// reuse 11 in this (data) db without updating the key-space canary.
+	DefaultKeyTypeDocMeta = byte(12)
+	DefaultKeyTypeDocPath = byte(13)
 
 	// invalidCollectionID is returned by parse/decode functions when parsing fails.
 	invalidCollectionID = -1
@@ -104,38 +106,6 @@ func decodeDocumentMetaValue(data []byte) (*Document, error) {
 		return nil, err
 	}
 	return &doc, nil
-}
-
-// encodeDocumentWordsKey encodes the key for a document words entry.
-func (s *Store) encodeDocumentWordsKey(collectionID int, docid string) []byte {
-	return appendDocKey(s.keyTypeDocWords, collectionID, docid)
-}
-
-// decodeDocumentWordsKey decodes a document words key, returning (collectionID, docid).
-// Returns (invalidCollectionID, "") if the key is malformed or has the wrong type byte.
-func (s *Store) decodeDocumentWordsKey(key string) (int, string) {
-	if !isKeyType(key, s.keyTypeDocWords) {
-		return invalidCollectionID, ""
-	}
-	key = key[1:]
-	parts := strings.SplitN(key, "|", 2)
-	if len(parts) != 2 {
-		return invalidCollectionID, ""
-	}
-	return parseCollectionID(parts[0]), parts[1]
-}
-
-// encodeDocumentWordsValue encodes a slice of keywords as a pipe-separated byte slice.
-func encodeDocumentWordsValue(keywords []string) []byte {
-	return []byte(strings.Join(keywords, "|"))
-}
-
-// decodeDocumentWordsValue decodes a pipe-separated keywords string.
-func decodeDocumentWordsValue(data string) []string {
-	if len(data) == 0 {
-		return []string{}
-	}
-	return strings.Split(data, "|")
 }
 
 // encodeMetaKey encodes the key for a collection metadata entry.

--- a/core/documents/codec_additional_test.go
+++ b/core/documents/codec_additional_test.go
@@ -67,33 +67,6 @@ func TestDecodeDocumentMetaValue_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestEncodeDecodeDocumentWordsKey(t *testing.T) {
-	s := newTestStore()
-	key := s.encodeDocumentWordsKey(7, "words789")
-	wsId, docId := s.decodeDocumentWordsKey(string(key))
-	assert.Equal(t, 7, wsId)
-	assert.Equal(t, "words789", docId)
-}
-
-func TestDecodeDocumentWordsKey_Invalid(t *testing.T) {
-	s := newTestStore()
-	wsId, docId := s.decodeDocumentWordsKey("bad")
-	assert.Equal(t, invalidCollectionID, wsId)
-	assert.Equal(t, "", docId)
-}
-
-func TestEncodeDecodeDocumentWordsValue(t *testing.T) {
-	words := []string{"hello", "world", "test"}
-	encoded := encodeDocumentWordsValue(words)
-	decoded := decodeDocumentWordsValue(string(encoded))
-	assert.Equal(t, words, decoded)
-}
-
-func TestDecodeDocumentWordsValue_EmptyString(t *testing.T) {
-	decoded := decodeDocumentWordsValue("")
-	assert.Equal(t, []string{}, decoded)
-}
-
 func TestEncodeMetaKey(t *testing.T) {
 	s := newTestStore()
 	key := s.encodeMetaKey(10)

--- a/core/documents/codec_bench_test.go
+++ b/core/documents/codec_bench_test.go
@@ -13,9 +13,6 @@ func TestEncodeDocKeyGolden(t *testing.T) {
 	if got, want := string(s.encodeDocumentMetaKey(-3, "x")), "\x0c-3|x"; got != want {
 		t.Errorf("meta key = %q, want %q", got, want)
 	}
-	if got, want := string(s.encodeDocumentWordsKey(0, "")), "\x0b0|"; got != want {
-		t.Errorf("words key = %q, want %q", got, want)
-	}
 	if got, want := string(s.encodeMetaKey(7)), "\x0a7"; got != want {
 		t.Errorf("meta key = %q, want %q", got, want)
 	}
@@ -24,7 +21,6 @@ func TestEncodeDocKeyGolden(t *testing.T) {
 func benchStore() *Store {
 	return &Store{
 		keyTypeDocCollection: DefaultKeyTypeDocCollection,
-		keyTypeDocWords:      DefaultKeyTypeDocWords,
 		keyTypeDocMeta:       DefaultKeyTypeDocMeta,
 		keyTypeDocPath:       DefaultKeyTypeDocPath,
 	}

--- a/core/documents/codec_test.go
+++ b/core/documents/codec_test.go
@@ -10,7 +10,6 @@ import (
 func newTestStore() *Store {
 	return &Store{
 		keyTypeDocCollection: DefaultKeyTypeDocCollection,
-		keyTypeDocWords:      DefaultKeyTypeDocWords,
 		keyTypeDocMeta:       DefaultKeyTypeDocMeta,
 		keyTypeDocPath:       DefaultKeyTypeDocPath,
 	}
@@ -118,57 +117,6 @@ func TestDocumentMetaValue_RoundTrip(t *testing.T) {
 func TestDecodeDocumentMetaValue_InvalidJSON(t *testing.T) {
 	_, err := decodeDocumentMetaValue([]byte("{invalid"))
 	assert.Error(t, err)
-}
-
-// ---------------------------------------------------------------------------
-// encodeDocumentWordsKey / decodeDocumentWordsKey
-// ---------------------------------------------------------------------------
-
-func TestDocumentWordsKey_RoundTrip(t *testing.T) {
-	s := newTestStore()
-	key := s.encodeDocumentWordsKey(7, "wdoc")
-	wsid, docid := s.decodeDocumentWordsKey(string(key))
-	assert.Equal(t, 7, wsid)
-	assert.Equal(t, "wdoc", docid)
-}
-
-func TestDecodeDocumentWordsKey_WrongType(t *testing.T) {
-	s := newTestStore()
-	wsid, docid := s.decodeDocumentWordsKey("Q7|wdoc")
-	assert.Equal(t, invalidCollectionID, wsid)
-	assert.Empty(t, docid)
-}
-
-func TestDecodeDocumentWordsKey_NoPipe(t *testing.T) {
-	s := newTestStore()
-	key := []byte{DefaultKeyTypeDocWords}
-	key = append(key, []byte("nopipe")...)
-	wsid, docid := s.decodeDocumentWordsKey(string(key))
-	assert.Equal(t, invalidCollectionID, wsid)
-	assert.Empty(t, docid)
-}
-
-// ---------------------------------------------------------------------------
-// encodeDocumentWordsValue / decodeDocumentWordsValue
-// ---------------------------------------------------------------------------
-
-func TestDocumentWordsValue_RoundTrip(t *testing.T) {
-	words := []string{"alpha", "beta", "gamma"}
-	encoded := encodeDocumentWordsValue(words)
-	decoded := decodeDocumentWordsValue(string(encoded))
-	assert.Equal(t, words, decoded)
-}
-
-func TestDecodeDocumentWordsValue_Empty(t *testing.T) {
-	decoded := decodeDocumentWordsValue("")
-	assert.Empty(t, decoded)
-}
-
-func TestDocumentWordsValue_SingleWord(t *testing.T) {
-	words := []string{"single"}
-	encoded := encodeDocumentWordsValue(words)
-	decoded := decodeDocumentWordsValue(string(encoded))
-	assert.Equal(t, words, decoded)
 }
 
 // ---------------------------------------------------------------------------

--- a/core/documents/document.go
+++ b/core/documents/document.go
@@ -23,8 +23,7 @@ type Document struct {
 
 // GetDocument returns a document from the store.
 // Returns nil, nil if the document does not exist.
-// If includeWords is true, the document's Words field is populated.
-func (s *Store) GetDocument(collectionID int, docid string, includeWords bool) (*Document, error) {
+func (s *Store) GetDocument(collectionID int, docid string) (*Document, error) {
 	data, err := s.db.Get(s.encodeDocumentMetaKey(collectionID, docid))
 	if err != nil {
 		return nil, err
@@ -40,32 +39,7 @@ func (s *Store) GetDocument(collectionID int, docid string, includeWords bool) (
 	}
 
 	doc.ID = docid
-
-	if includeWords {
-		words, err := s.getDocumentWords(collectionID, docid)
-		if err != nil {
-			return nil, err
-		}
-
-		doc.Words = words
-	}
-
 	return doc, nil
-}
-
-// getDocumentWords returns the words of a document.
-// Returns an empty slice if the document does not exist.
-func (s *Store) getDocumentWords(collectionID int, docid string) ([]string, error) {
-	words, err := s.db.Get(s.encodeDocumentWordsKey(collectionID, docid))
-	if err != nil {
-		return nil, err
-	}
-
-	if len(words) == 0 {
-		return []string{}, nil
-	}
-
-	return decodeDocumentWordsValue(string(words)), nil
 }
 
 // SaveNewDocuments persists a batch of new documents and updates the
@@ -90,7 +64,7 @@ func (s *Store) SaveNewDocuments(collectionID int, docs []*Document) error {
 
 		batch := newBatch(s.db)
 		for _, doc := range docs {
-			s.indexDocument(ft.InvertedId, doc.ID, doc.Words, nil)
+			s.indexAddDocument(ft.InvertedId, doc.ID, doc.Words)
 			s.saveDocument(batch, collectionID, doc)
 		}
 		err = batch.Commit()
@@ -129,15 +103,7 @@ func (s *Store) UpdateDocuments(collectionID int, updatedDocs []*Document) error
 
 		batch := newBatch(s.db)
 		for _, updatedDoc := range updatedDocs {
-			// Get the current document words from the database
-			oldWords, err := s.getDocumentWords(collectionID, updatedDoc.ID)
-			if err != nil {
-				continue
-			}
-
-			s.indexDocument(ft.InvertedId, updatedDoc.ID, updatedDoc.Words, oldWords)
-
-			// Save the updated document
+			s.indexUpdateDocument(ft.InvertedId, updatedDoc.ID, updatedDoc.Words)
 			s.saveDocument(batch, collectionID, updatedDoc)
 		}
 		err = batch.Commit()
@@ -149,8 +115,8 @@ func (s *Store) UpdateDocuments(collectionID int, updatedDocs []*Document) error
 	})
 }
 
-// DeleteDocument removes a document, its words, and its path entry from the
-// store, and notifies the inverted index of the removal.
+// DeleteDocument removes a document and its path entry from the store, and
+// notifies the inverted index of the removal.
 func (s *Store) DeleteDocument(collectionID int, docId string) error {
 	return s.q.RunFunc(func() error {
 		if s.db.IsClosed() {
@@ -164,7 +130,7 @@ func (s *Store) DeleteDocument(collectionID int, docId string) error {
 			return err
 		}
 
-		doc, err := s.GetDocument(collectionID, docId, true)
+		doc, err := s.GetDocument(collectionID, docId)
 		if err != nil {
 			log.Println("[Documents] Error: failed to get document:", err)
 			return err
@@ -176,12 +142,11 @@ func (s *Store) DeleteDocument(collectionID int, docId string) error {
 
 		defer log.Printf("[Documents] Document `%s` deleted from collection `%d`", doc.RelPath, collectionID)
 
-		s.indexDocument(ft.InvertedId, docId, []string{}, doc.Words)
+		s.indexDeleteDocument(ft.InvertedId, docId)
 
-		// delete the document meta and words
+		// delete the document meta and path
 		batch := newBatch(s.db)
 		batch.Delete(s.encodeDocumentMetaKey(collectionID, docId))
-		batch.Delete(s.encodeDocumentWordsKey(collectionID, docId))
 		batch.Delete(s.encodeDocumentPathKey(collectionID, docId))
 		err = batch.Commit()
 		if err != nil {

--- a/core/documents/document_internal.go
+++ b/core/documents/document_internal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/codetrek/haystack/core/kv"
 )
 
-// saveDocument persists a document's metadata, words, and path to the batch.
+// saveDocument persists a document's metadata and path to the batch.
 func (s *Store) saveDocument(batch kv.Batch, collectionID int, doc *Document) {
 	doc.LastSyncTime = time.Now().UnixNano()
 	meta, err := encodeDocumentMetaValue(doc)
@@ -14,8 +14,8 @@ func (s *Store) saveDocument(batch kv.Batch, collectionID int, doc *Document) {
 		return
 	}
 
-	// Save the document meta and words
+	// Save the document meta and path. Keywords are owned by the inverted index's
+	// forward map, not persisted here.
 	batch.Put(s.encodeDocumentMetaKey(collectionID, doc.ID), meta)
-	batch.Put(s.encodeDocumentWordsKey(collectionID, doc.ID), encodeDocumentWordsValue(doc.Words))
 	batch.Put(s.encodeDocumentPathKey(collectionID, doc.ID), []byte(doc.RelPath))
 }

--- a/core/documents/document_test.go
+++ b/core/documents/document_test.go
@@ -100,7 +100,7 @@ func TestGetDocument_RoundTrip_WithoutWords(t *testing.T) {
 // SaveNewDocuments
 // ---------------------------------------------------------------------------
 
-func TestSaveNewDocuments_PersistsMetaWordsPath(t *testing.T) {
+func TestSaveNewDocuments_PersistsMetaAndPath(t *testing.T) {
 	env := setupTestEnv(t)
 	defer env.teardown()
 
@@ -278,9 +278,9 @@ func TestUpdateDocuments_NonExistentDocGraceful(t *testing.T) {
 
 	mustCreateWorkspace(t, env.St, 1)
 
-	// Update a document that was never saved -- should not panic,
-	// GetDocumentWords returns empty for missing docs so the
-	// inverted index diff is simply "add all new words".
+	// Update a document that was never saved -- should not panic. The index
+	// treats an unknown doc as an Add (its forward map has no prior set), so the
+	// update is simply "add all new words".
 	doc := &Document{
 		ID:      "ghost",
 		RelPath: "ghost.go",

--- a/core/documents/document_test.go
+++ b/core/documents/document_test.go
@@ -16,7 +16,7 @@ func TestGetDocument_Missing(t *testing.T) {
 
 	mustCreateWorkspace(t, env.St, 1)
 
-	doc, err := env.St.GetDocument(1, "nonexistent", false)
+	doc, err := env.St.GetDocument(1, "nonexistent")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -33,7 +33,7 @@ func TestGetDocument_DbGetError(t *testing.T) {
 	restore := simulateClosedDB(env.St)
 	defer restore()
 
-	doc, err := env.St.GetDocument(1, "any-doc", false)
+	doc, err := env.St.GetDocument(1, "any-doc")
 	assert.Error(t, err, "GetDocument should propagate db.Get error")
 	assert.Nil(t, doc)
 }
@@ -53,7 +53,7 @@ func TestGetDocument_DecodeError(t *testing.T) {
 		return
 	}
 
-	doc, err := env.St.GetDocument(1, docid, false)
+	doc, err := env.St.GetDocument(1, docid)
 	assert.Error(t, err, "GetDocument should propagate decode error")
 	assert.Nil(t, doc)
 }
@@ -79,7 +79,7 @@ func TestGetDocument_RoundTrip_WithoutWords(t *testing.T) {
 		return
 	}
 
-	doc, err := env.St.GetDocument(1, "doc1", false)
+	doc, err := env.St.GetDocument(1, "doc1")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -92,81 +92,8 @@ func TestGetDocument_RoundTrip_WithoutWords(t *testing.T) {
 	assert.Equal(t, int64(1234), doc.Size)
 	assert.Equal(t, "abc123", doc.Hash)
 	assert.Equal(t, int64(100), doc.ModifiedTime)
-	// Words should be empty when includeWords=false
+	// GetDocument no longer returns keywords
 	assert.Empty(t, doc.Words)
-}
-
-func TestGetDocument_RoundTrip_WithWords(t *testing.T) {
-	env := setupTestEnv(t)
-	defer env.teardown()
-
-	mustCreateWorkspace(t, env.St, 1)
-
-	orig := &Document{
-		ID:           "doc1",
-		RelPath:      "src/main.go",
-		Size:         1234,
-		Hash:         "abc123",
-		ModifiedTime: 100,
-		Words:        []string{"hello", "world"},
-	}
-
-	err := env.St.SaveNewDocuments(1, []*Document{orig})
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	doc, err := env.St.GetDocument(1, "doc1", true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	if !assert.NotNil(t, doc) {
-		return
-	}
-
-	assert.Equal(t, "doc1", doc.ID)
-	assert.Equal(t, []string{"hello", "world"}, doc.Words)
-}
-
-// ---------------------------------------------------------------------------
-// GetDocumentWords
-// ---------------------------------------------------------------------------
-
-func TestGetDocumentWords_Missing(t *testing.T) {
-	env := setupTestEnv(t)
-	defer env.teardown()
-
-	mustCreateWorkspace(t, env.St, 1)
-
-	words, err := env.St.getDocumentWords(1, "nonexistent")
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Empty(t, words)
-}
-
-func TestGetDocumentWords_RoundTrip(t *testing.T) {
-	env := setupTestEnv(t)
-	defer env.teardown()
-
-	mustCreateWorkspace(t, env.St, 1)
-
-	doc := &Document{
-		ID:      "doc1",
-		RelPath: "foo.go",
-		Words:   []string{"alpha", "beta", "gamma"},
-	}
-
-	err := env.St.SaveNewDocuments(1, []*Document{doc})
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	words, err := env.St.getDocumentWords(1, "doc1")
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Equal(t, []string{"alpha", "beta", "gamma"}, words)
 }
 
 // ---------------------------------------------------------------------------
@@ -193,7 +120,7 @@ func TestSaveNewDocuments_PersistsMetaWordsPath(t *testing.T) {
 	}
 
 	// Verify meta
-	got, err := env.St.GetDocument(1, "d1", false)
+	got, err := env.St.GetDocument(1, "d1")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -206,13 +133,6 @@ func TestSaveNewDocuments_PersistsMetaWordsPath(t *testing.T) {
 
 	// Verify LastSyncTime was set
 	assert.NotZero(t, got.LastSyncTime, "LastSyncTime should be set by saveDocument")
-
-	// Verify words
-	words, err := env.St.getDocumentWords(1, "d1")
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Equal(t, []string{"func", "util"}, words)
 
 	// Verify path
 	path := env.St.GetDocumentPath(1, "d1")
@@ -237,7 +157,7 @@ func TestSaveNewDocuments_MultipleDocuments(t *testing.T) {
 	}
 
 	for _, d := range docs {
-		got, err := env.St.GetDocument(1, d.ID, true)
+		got, err := env.St.GetDocument(1, d.ID)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -245,7 +165,6 @@ func TestSaveNewDocuments_MultipleDocuments(t *testing.T) {
 			return
 		}
 		assert.Equal(t, d.RelPath, got.RelPath)
-		assert.Equal(t, d.Words, got.Words)
 	}
 }
 
@@ -313,7 +232,7 @@ func TestUpdateDocuments_OverwriteExisting(t *testing.T) {
 		return
 	}
 
-	got, err := env.St.GetDocument(1, "d1", true)
+	got, err := env.St.GetDocument(1, "d1")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -323,7 +242,6 @@ func TestUpdateDocuments_OverwriteExisting(t *testing.T) {
 	assert.Equal(t, "new.go", got.RelPath)
 	assert.Equal(t, int64(20), got.Size)
 	assert.Equal(t, "newhash", got.Hash)
-	assert.Equal(t, []string{"new", "updated"}, got.Words)
 }
 
 func TestUpdateDocuments_ClosedDB(t *testing.T) {
@@ -374,7 +292,7 @@ func TestUpdateDocuments_NonExistentDocGraceful(t *testing.T) {
 	}
 
 	// The document should now exist (saveDocument is called regardless).
-	got, err := env.St.GetDocument(1, "ghost", true)
+	got, err := env.St.GetDocument(1, "ghost")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -382,7 +300,6 @@ func TestUpdateDocuments_NonExistentDocGraceful(t *testing.T) {
 		return
 	}
 	assert.Equal(t, "ghost.go", got.RelPath)
-	assert.Equal(t, []string{"phantom"}, got.Words)
 }
 
 // ---------------------------------------------------------------------------
@@ -410,17 +327,11 @@ func TestDeleteDocument_ExistingDoc(t *testing.T) {
 		return
 	}
 
-	got, err := env.St.GetDocument(1, "d1", false)
+	got, err := env.St.GetDocument(1, "d1")
 	if !assert.NoError(t, err) {
 		return
 	}
 	assert.Nil(t, got, "document should be deleted")
-
-	words, err := env.St.getDocumentWords(1, "d1")
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Empty(t, words, "words should be deleted")
 
 	path := env.St.GetDocumentPath(1, "d1")
 	assert.Empty(t, path, "path should be deleted")

--- a/core/documents/seams_test.go
+++ b/core/documents/seams_test.go
@@ -24,5 +24,7 @@ func TestStoreIndexSeams_NilIdx(t *testing.T) {
 
 	// Must not panic / touch a nil index.
 	s.indexDeleteTable(1)
-	s.indexDocument(1, "doc", []string{"a"}, []string{"b"})
+	s.indexAddDocument(1, "doc", []string{"a"})
+	s.indexUpdateDocument(1, "doc", []string{"a"})
+	s.indexDeleteDocument(1, "doc")
 }

--- a/core/documents/storage.go
+++ b/core/documents/storage.go
@@ -41,10 +41,6 @@ type Options struct {
 	// Zero selects DefaultKeyTypeDocCollection (10).
 	KeyTypeDocCollection byte
 
-	// KeyTypeDocWords is the on-disk prefix byte for document words keys.
-	// Zero selects DefaultKeyTypeDocWords (11).
-	KeyTypeDocWords byte
-
 	// KeyTypeDocMeta is the on-disk prefix byte for document metadata keys.
 	// Zero selects DefaultKeyTypeDocMeta (12).
 	KeyTypeDocMeta byte
@@ -64,7 +60,6 @@ type Store struct {
 
 	// resolved on-disk key-type bytes (set in New from opts with defaults applied)
 	keyTypeDocCollection byte
-	keyTypeDocWords      byte
 	keyTypeDocMeta       byte
 	keyTypeDocPath       byte
 
@@ -85,9 +80,6 @@ func New(store kv.Store, q queue.Queue, idx *invertedindex.Index, opts Options) 
 	if opts.KeyTypeDocCollection == 0 {
 		opts.KeyTypeDocCollection = DefaultKeyTypeDocCollection
 	}
-	if opts.KeyTypeDocWords == 0 {
-		opts.KeyTypeDocWords = DefaultKeyTypeDocWords
-	}
 	if opts.KeyTypeDocMeta == 0 {
 		opts.KeyTypeDocMeta = DefaultKeyTypeDocMeta
 	}
@@ -100,7 +92,6 @@ func New(store kv.Store, q queue.Queue, idx *invertedindex.Index, opts Options) 
 		q:                    q,
 		idx:                  idx,
 		keyTypeDocCollection: opts.KeyTypeDocCollection,
-		keyTypeDocWords:      opts.KeyTypeDocWords,
 		keyTypeDocMeta:       opts.KeyTypeDocMeta,
 		keyTypeDocPath:       opts.KeyTypeDocPath,
 		collections:          make(map[int]*CollectionInfo),
@@ -191,7 +182,6 @@ func (s *Store) Delete(collectionID int) error {
 
 		batch := s.db.NewBatch(0)
 		batch.DeletePrefix(s.encodeDocumentMetaKey(collectionID, ""))
-		batch.DeletePrefix(s.encodeDocumentWordsKey(collectionID, ""))
 
 		err = batch.Commit()
 		if err != nil {
@@ -256,13 +246,30 @@ func (s *Store) indexDeleteTable(tableId int) {
 	s.idx.DeleteTable(tableId)
 }
 
-// indexDocument is the seam for per-document index update (add/update words).
-func (s *Store) indexDocument(tableId int, docId string, newWords, oldWords []string) {
+// indexAddDocument is the seam for indexing a brand-new document's words. The
+// inverted index keys postings by the docid's int64 value; docId here is its
+// canonical 8-byte string form (as produced by idtable.GetId and used for the
+// document-store keys), so decode it at this boundary.
+func (s *Store) indexAddDocument(tableId int, docId string, words []string) {
 	if s.idx == nil {
 		return
 	}
-	// The inverted index keys postings by the docid's int64 value; docId here is
-	// its canonical 8-byte string form (as produced by idtable.GetId and used for
-	// the document-store keys), so decode it at this boundary.
-	s.idx.Update(tableId, idtable.DecodeId(docId), newWords, oldWords)
+	s.idx.Add(tableId, idtable.DecodeId(docId), words)
+}
+
+// indexUpdateDocument is the seam for re-indexing an existing document; the index
+// diffs against the keyword set it already owns, so no old set is passed.
+func (s *Store) indexUpdateDocument(tableId int, docId string, words []string) {
+	if s.idx == nil {
+		return
+	}
+	s.idx.Update(tableId, idtable.DecodeId(docId), words)
+}
+
+// indexDeleteDocument is the seam for removing a document from the index.
+func (s *Store) indexDeleteDocument(tableId int, docId string) {
+	if s.idx == nil {
+		return
+	}
+	s.idx.Delete(tableId, idtable.DecodeId(docId))
 }

--- a/core/documents/storage_test.go
+++ b/core/documents/storage_test.go
@@ -190,7 +190,7 @@ func TestDelete_MarksWorkspaceDeleted(t *testing.T) {
 	}
 
 	// Verify document exists before delete
-	got, err := env.St.GetDocument(1, "d1", false)
+	got, err := env.St.GetDocument(1, "d1")
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -16,6 +16,13 @@ const (
 	DefaultKeyTypeTable  = byte(21)
 	DefaultKeyTypeNextId = byte(22)
 
+	// DefaultKeyTypeForward is the on-disk key-type prefix byte for the
+	// per-document forward map (docid -> keyword set) that the index owns. Byte
+	// 11 is reused from the documents store's retired doc-words key: the inverted
+	// index lives in a physically separate `index` db where 11 is free (the index
+	// uses 20/21/22), so there is no collision with the data db's keys.
+	DefaultKeyTypeForward = byte(11)
+
 	InvalidId = -1
 )
 
@@ -194,4 +201,48 @@ func decodeInvertedValueStr(data string) []int64 {
 	// The merger holds row values as strings; copy once into a byte slice and
 	// reuse the byte decoder.
 	return decodeInvertedValue([]byte(data))
+}
+
+// encodeForwardKey builds "<keyTypeForward><tableId>|<docid>" where <docid> is its
+// fixed 8-byte big-endian form. The fixed-width 8-byte suffix needs no trailing
+// delimiter and no companion decode function — the caller that wrote the key
+// already holds the docid; the decimal tableId + '|' keeps table 1's prefix from
+// matching table 12's.
+func (idx *Index) encodeForwardKey(tableId int, docid int64) []byte {
+	b := make([]byte, 0, 1+11+1+8)
+	b = append(b, idx.keyTypeForward)
+	b = strconv.AppendInt(b, int64(tableId), 10)
+	b = append(b, '|')
+	var d [8]byte
+	binary.BigEndian.PutUint64(d[:], uint64(docid))
+	b = append(b, d[:]...)
+	return b
+}
+
+// encodeForwardKeyPrefix builds "<keyTypeForward><tableId>|", the DeletePrefix
+// argument that clears a whole table's forward map. The trailing '|' ensures
+// table 5's prefix does not also match table 50's rows.
+func (idx *Index) encodeForwardKeyPrefix(tableId int) []byte {
+	b := make([]byte, 0, 1+11+1)
+	b = append(b, idx.keyTypeForward)
+	b = strconv.AppendInt(b, int64(tableId), 10)
+	b = append(b, '|')
+	return b
+}
+
+// encodeForwardValue joins keywords with '|' — the same encoding the retired
+// doc-words value used. A keyword containing '|' splits the same lossy way it
+// always has (no behavior change vs. the old doc-words value).
+func encodeForwardValue(keywords []string) []byte {
+	return []byte(strings.Join(keywords, "|"))
+}
+
+// decodeForwardValue is the inverse of encodeForwardValue. An empty input decodes
+// to a zero-length slice (NOT []string{""}); a plain strings.Split("", "|") would
+// mis-yield the latter.
+func decodeForwardValue(data []byte) []string {
+	if len(data) == 0 {
+		return []string{}
+	}
+	return strings.Split(string(data), "|")
 }

--- a/core/invertedindex/codec_delimiter_test.go
+++ b/core/invertedindex/codec_delimiter_test.go
@@ -59,7 +59,7 @@ func TestMerge_KeywordWithDelimiter_NoOrphan(t *testing.T) {
 	for round := 0; round < 3; round++ {
 		for ki, kw := range keywords {
 			doc := makeDocID(fmt.Sprintf("d%d-%d", ki, round))
-			env.idx.Update(tableId, doc, []string{kw}, nil)
+			env.idx.Add(tableId, doc, []string{kw})
 			docsByKw[kw] = append(docsByKw[kw], doc)
 		}
 		forceFlush(env.idx)
@@ -102,7 +102,7 @@ func TestSearch_KeywordWithFF_Found(t *testing.T) {
 	const tableId = 1
 	doc := makeDocID("ffdoc")
 	// Keyword "x\xffy": the search prefix "x" is immediately followed by 0xff.
-	env.idx.Update(tableId, doc, []string{"x\xffy"}, nil)
+	env.idx.Add(tableId, doc, []string{"x\xffy"})
 	forceFlush(env.idx)
 
 	res := env.idx.Search(tableId, "x", 0, nil)

--- a/core/invertedindex/codec_test.go
+++ b/core/invertedindex/codec_test.go
@@ -10,9 +10,10 @@ import (
 // testCodecIdx is a minimal *Index with default key-type bytes used by codec tests.
 // It avoids the need for a full test environment (database + queue).
 var testCodecIdx = &Index{
-	keyTypeRow:    DefaultKeyTypeRow,
-	keyTypeTable:  DefaultKeyTypeTable,
-	keyTypeNextId: DefaultKeyTypeNextId,
+	keyTypeRow:     DefaultKeyTypeRow,
+	keyTypeTable:   DefaultKeyTypeTable,
+	keyTypeNextId:  DefaultKeyTypeNextId,
+	keyTypeForward: DefaultKeyTypeForward,
 }
 
 // ---------------------------------------------------------------------------

--- a/core/invertedindex/forward_test.go
+++ b/core/invertedindex/forward_test.go
@@ -217,3 +217,39 @@ func TestForward_ReadForwardKnownEmpty(t *testing.T) {
 		t.Errorf("expected zero-length keyword set, got %v", got)
 	}
 }
+
+func TestForward_AddEmptyIsNoOp(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("add-empty")
+	d := makeDocID("doc1")
+
+	// An empty keyword set indexes nothing and writes no forward entry.
+	env.idx.Add(tid, d, nil)
+	env.idx.Add(tid, d, []string{})
+
+	if _, known := env.idx.readForward(tid, d); known {
+		t.Error("empty Add must not write a forward entry")
+	}
+}
+
+func TestForward_DbErrorsAreLoggedNotPanicked(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("db-err")
+	d := makeDocID("doc1")
+
+	// Swap in a store whose every op errors. Each forward method must log and
+	// continue without panicking — covering the db.Get/Put/Delete error branches.
+	restore := simulateClosedDB(env.idx)
+	defer restore()
+
+	if _, known := env.idx.readForward(tid, d); known {
+		t.Error("readForward on a db error should report the doc as unknown")
+	}
+	env.idx.Add(tid, d, []string{"a"})    // db.Put(forward) errors
+	env.idx.Update(tid, d, []string{"b"}) // readForward errors -> Add -> db.Put errors
+	env.idx.Delete(tid, d)                // readForward errors -> db.Delete errors
+}

--- a/core/invertedindex/forward_test.go
+++ b/core/invertedindex/forward_test.go
@@ -34,3 +34,186 @@ func TestForwardKey_TableScopedPrefix(t *testing.T) {
 	assert.Equal(t, string(p5), string(k5[:len(p5)]))
 	assert.Equal(t, DefaultKeyTypeForward, k5[0])
 }
+
+func TestForward_AddWritesForwardAndPostings(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("add")
+	d := makeDocID("doc1")
+
+	env.idx.Add(tid, d, []string{"alpha", "beta"})
+
+	// Forward map is committed immediately (no flush needed).
+	old, known := env.idx.readForward(tid, d)
+	if !known {
+		t.Fatal("expected doc known in forward map after Add")
+	}
+	if len(old) != 2 || old[0] != "alpha" || old[1] != "beta" {
+		t.Fatalf("forward set = %v, want [alpha beta]", old)
+	}
+
+	// Postings are queryable after a flush.
+	forceFlush(env.idx)
+	if _, ok := env.idx.Search(tid, "alpha", 0, nil).DocIds[d]; !ok {
+		t.Error("expected doc1 in 'alpha' results after Add")
+	}
+}
+
+func TestForward_UpdateDiffsAgainstStoredSet(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("update")
+	d := makeDocID("doc1")
+
+	env.idx.Add(tid, d, []string{"keep", "remove"})
+	forceFlush(env.idx)
+
+	// No old set passed — Update reads it from the forward map.
+	env.idx.Update(tid, d, []string{"keep", "addnew"})
+	forceFlush(env.idx)
+
+	if _, ok := env.idx.Search(tid, "keep", 0, nil).DocIds[d]; !ok {
+		t.Error("expected doc1 still in 'keep'")
+	}
+	if _, ok := env.idx.Search(tid, "addnew", 0, nil).DocIds[d]; !ok {
+		t.Error("expected doc1 in 'addnew'")
+	}
+	if _, ok := env.idx.Search(tid, "remove", 0, nil).DocIds[d]; ok {
+		t.Error("expected doc1 NOT in 'remove'")
+	}
+}
+
+func TestForward_UpdateRewritesStoredSet(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("rewrite")
+	d := makeDocID("doc1")
+
+	env.idx.Add(tid, d, []string{"a"})
+	env.idx.Update(tid, d, []string{"b"}) // diffs against {a}; forward becomes {b}
+	env.idx.Update(tid, d, []string{"c"}) // must diff against {b}, not {a}
+	forceFlush(env.idx)
+
+	if _, ok := env.idx.Search(tid, "a", 0, nil).DocIds[d]; ok {
+		t.Error("expected 'a' gone")
+	}
+	if _, ok := env.idx.Search(tid, "b", 0, nil).DocIds[d]; ok {
+		t.Error("expected 'b' gone after second Update")
+	}
+	if _, ok := env.idx.Search(tid, "c", 0, nil).DocIds[d]; !ok {
+		t.Error("expected 'c' present")
+	}
+	got, known := env.idx.readForward(tid, d)
+	if !known || len(got) != 1 || got[0] != "c" {
+		t.Errorf("forward set = %v (known=%v), want [c]", got, known)
+	}
+}
+
+func TestForward_UpdateUnknownDocIsAdd(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("unknown")
+	d := makeDocID("doc1")
+
+	env.idx.Update(tid, d, []string{"x", "y"})
+	forceFlush(env.idx)
+
+	if _, ok := env.idx.Search(tid, "x", 0, nil).DocIds[d]; !ok {
+		t.Error("expected doc1 in 'x' after unknown-doc Update")
+	}
+	if _, known := env.idx.readForward(tid, d); !known {
+		t.Error("expected forward entry written")
+	}
+}
+
+func TestForward_UpdateEmptyDeletes(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("empty")
+	d := makeDocID("doc1")
+
+	env.idx.Add(tid, d, []string{"a"})
+	forceFlush(env.idx)
+
+	env.idx.Update(tid, d, nil) // empty => Delete
+	forceFlush(env.idx)
+
+	if _, ok := env.idx.Search(tid, "a", 0, nil).DocIds[d]; ok {
+		t.Error("expected doc1 removed from 'a'")
+	}
+	if _, known := env.idx.readForward(tid, d); known {
+		t.Error("expected forward entry gone after empty Update")
+	}
+}
+
+func TestForward_Delete(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("delete")
+	d := makeDocID("doc1")
+
+	env.idx.Add(tid, d, []string{"a", "b"})
+	forceFlush(env.idx)
+
+	env.idx.Delete(tid, d)
+	forceFlush(env.idx)
+
+	if _, ok := env.idx.Search(tid, "a", 0, nil).DocIds[d]; ok {
+		t.Error("expected doc1 removed from 'a'")
+	}
+	if _, ok := env.idx.Search(tid, "b", 0, nil).DocIds[d]; ok {
+		t.Error("expected doc1 removed from 'b'")
+	}
+	if _, known := env.idx.readForward(tid, d); known {
+		t.Error("expected forward entry gone after Delete")
+	}
+}
+
+func TestForward_DeleteUnknownIsNoOp(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("delete-unknown")
+	env.idx.Delete(tid, makeDocID("ghost"))
+	forceFlush(env.idx)
+}
+
+func TestForward_DeleteTableClearsForward(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("dt")
+	d := makeDocID("doc1")
+	env.idx.Add(tid, d, []string{"a"})
+
+	if err := env.idx.DeleteTable(tid); err != nil {
+		t.Fatalf("DeleteTable: %v", err)
+	}
+	if _, known := env.idx.readForward(tid, d); known {
+		t.Error("expected forward entry cleared by DeleteTable")
+	}
+}
+
+func TestForward_ReadForwardKnownEmpty(t *testing.T) {
+	env := setupTestEnv(t)
+	defer env.teardown()
+
+	tid, _ := env.idx.CreateTable("known-empty")
+	d := makeDocID("doc1")
+
+	// Stored value "" decodes to a zero-length slice but is still a KNOWN doc.
+	env.idx.Add(tid, d, []string{""})
+	got, known := env.idx.readForward(tid, d)
+	if !known {
+		t.Fatal("expected known doc for stored empty value")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero-length keyword set, got %v", got)
+	}
+}

--- a/core/invertedindex/forward_test.go
+++ b/core/invertedindex/forward_test.go
@@ -1,0 +1,36 @@
+package invertedindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForwardValueCodec_WireFormat(t *testing.T) {
+	assert.Equal(t, []byte("a|b|c"), encodeForwardValue([]string{"a", "b", "c"}))
+	assert.Equal(t, []string{"a", "b", "c"}, decodeForwardValue([]byte("a|b|c")))
+}
+
+func TestForwardValueCodec_Empty(t *testing.T) {
+	// An empty value decodes to a zero-length slice, NOT []string{""}.
+	assert.Equal(t, []string{}, decodeForwardValue([]byte{}))
+	assert.Equal(t, []string{}, decodeForwardValue(nil))
+}
+
+func TestForwardValueCodec_Single(t *testing.T) {
+	assert.Equal(t, []byte("only"), encodeForwardValue([]string{"only"}))
+	assert.Equal(t, []string{"only"}, decodeForwardValue([]byte("only")))
+}
+
+func TestForwardKey_TableScopedPrefix(t *testing.T) {
+	idx := &Index{keyTypeForward: DefaultKeyTypeForward}
+	// Table 5's prefix must NOT be a byte-prefix of table 50's keys.
+	p5 := idx.encodeForwardKeyPrefix(5)
+	k50 := idx.encodeForwardKey(50, 123)
+	assert.False(t, len(k50) >= len(p5) && string(k50[:len(p5)]) == string(p5),
+		"table 5 prefix must not match table 50 keys")
+	// The real key for (5, docid) IS under table 5's prefix.
+	k5 := idx.encodeForwardKey(5, 123)
+	assert.Equal(t, string(p5), string(k5[:len(p5)]))
+	assert.Equal(t, DefaultKeyTypeForward, k5[0])
+}

--- a/core/invertedindex/index_test.go
+++ b/core/invertedindex/index_test.go
@@ -79,7 +79,7 @@ func TestDeleteTable(t *testing.T) {
 	}
 
 	docid := makeDocID("doc1")
-	env.idx.Update(tableId, docid, []string{"hello", "world"}, nil)
+	env.idx.Add(tableId, docid, []string{"hello", "world"})
 	forceFlush(env.idx)
 
 	// Verify data exists
@@ -111,7 +111,7 @@ func TestUpdateAddKeywords(t *testing.T) {
 	tableId, _ := env.idx.CreateTable("update-test")
 	docid := makeDocID("doc1")
 
-	env.idx.Update(tableId, docid, []string{"alpha", "beta"}, nil)
+	env.idx.Add(tableId, docid, []string{"alpha", "beta"})
 	forceFlush(env.idx)
 
 	res := env.idx.Search(tableId, "alpha", 0, nil)
@@ -137,11 +137,11 @@ func TestUpdateRemoveAllKeywords(t *testing.T) {
 	docid := makeDocID("doc1")
 
 	// Add first
-	env.idx.Update(tableId, docid, []string{"gamma"}, nil)
+	env.idx.Add(tableId, docid, []string{"gamma"})
 	forceFlush(env.idx)
 
 	// Remove
-	env.idx.Update(tableId, docid, nil, []string{"gamma"})
+	env.idx.Delete(tableId, docid)
 	forceFlush(env.idx)
 
 	res := env.idx.Search(tableId, "gamma", 0, nil)
@@ -162,11 +162,11 @@ func TestUpdateDiffKeywords(t *testing.T) {
 	docid := makeDocID("doc1")
 
 	// Add initial keywords
-	env.idx.Update(tableId, docid, []string{"keep", "remove"}, nil)
+	env.idx.Add(tableId, docid, []string{"keep", "remove"})
 	forceFlush(env.idx)
 
 	// Update: keep stays, remove goes, addnew is added
-	env.idx.Update(tableId, docid, []string{"keep", "addnew"}, []string{"keep", "remove"})
+	env.idx.Update(tableId, docid, []string{"keep", "addnew"})
 	forceFlush(env.idx)
 
 	// "keep" should still have the doc
@@ -199,7 +199,7 @@ func TestUpdateIgnoresEmptyKeywords(t *testing.T) {
 	tableId, _ := env.idx.CreateTable("empty-kw-test")
 	docid := makeDocID("doc1")
 
-	env.idx.Update(tableId, docid, []string{"real", "", "word"}, []string{"", "old"})
+	env.idx.Add(tableId, docid, []string{"real", "", "word"})
 	forceFlush(env.idx)
 
 	res := env.idx.Search(tableId, "real", 0, nil)
@@ -220,8 +220,8 @@ func TestSearchBasic(t *testing.T) {
 	doc1 := makeDocID("doc1")
 	doc2 := makeDocID("doc2")
 
-	env.idx.Update(tableId, doc1, []string{"common", "unique1"}, nil)
-	env.idx.Update(tableId, doc2, []string{"common", "unique2"}, nil)
+	env.idx.Add(tableId, doc1, []string{"common", "unique1"})
+	env.idx.Add(tableId, doc2, []string{"common", "unique2"})
 	forceFlush(env.idx)
 
 	// "common" should return both
@@ -253,7 +253,7 @@ func TestSearchWithLimit(t *testing.T) {
 		// Each doc gets a unique keyword like "shared0", "shared1", etc.
 		// so they are stored in separate DB rows.
 		kw := "shared" + string(rune('0'+i))
-		env.idx.Update(tableId, docid, []string{kw}, nil)
+		env.idx.Add(tableId, docid, []string{kw})
 	}
 	forceFlush(env.idx)
 
@@ -278,7 +278,7 @@ func TestSearchCaseInsensitive(t *testing.T) {
 	tableId, _ := env.idx.CreateTable("case-test")
 	docid := makeDocID("doc1")
 	// Keywords are stored as-is; search lowercases the query
-	env.idx.Update(tableId, docid, []string{"hello"}, nil)
+	env.idx.Add(tableId, docid, []string{"hello"})
 	forceFlush(env.idx)
 
 	res := env.idx.Search(tableId, "HELLO", 0, nil)
@@ -295,8 +295,8 @@ func TestSearchWithFilter(t *testing.T) {
 	doc1 := makeDocID("doc1")
 	doc2 := makeDocID("doc2")
 
-	env.idx.Update(tableId, doc1, []string{"apple"}, nil)
-	env.idx.Update(tableId, doc2, []string{"applesauce"}, nil)
+	env.idx.Add(tableId, doc1, []string{"apple"})
+	env.idx.Add(tableId, doc2, []string{"applesauce"})
 	forceFlush(env.idx)
 
 	// Filter that rejects all keys
@@ -337,8 +337,8 @@ func TestGetDocs(t *testing.T) {
 	doc1 := makeDocID("doc1")
 	doc2 := makeDocID("doc2")
 
-	env.idx.Update(tableId, doc1, []string{"keyword"}, nil)
-	env.idx.Update(tableId, doc2, []string{"keyword"}, nil)
+	env.idx.Add(tableId, doc1, []string{"keyword"})
+	env.idx.Add(tableId, doc2, []string{"keyword"})
 	forceFlush(env.idx)
 
 	res := env.idx.GetDocs(tableId, "keyword")
@@ -378,9 +378,9 @@ func TestRemoveDocumentsFromInvertedIndex(t *testing.T) {
 	doc3 := makeDocID("doc3")
 
 	// Add all three docs to same keyword
-	env.idx.Update(tableId, doc1, []string{"target"}, nil)
-	env.idx.Update(tableId, doc2, []string{"target"}, nil)
-	env.idx.Update(tableId, doc3, []string{"target"}, nil)
+	env.idx.Add(tableId, doc1, []string{"target"})
+	env.idx.Add(tableId, doc2, []string{"target"})
+	env.idx.Add(tableId, doc3, []string{"target"})
 	forceFlush(env.idx)
 
 	// Remove doc2 via removeDocumentsFromInvertedIndex
@@ -443,7 +443,7 @@ func TestMultipleTablesIsolated(t *testing.T) {
 
 	doc := makeDocID("doc1")
 
-	env.idx.Update(t1, doc, []string{"word"}, nil)
+	env.idx.Add(t1, doc, []string{"word"})
 	forceFlush(env.idx)
 
 	// Table 1 should find the doc
@@ -622,7 +622,7 @@ func TestFlushPendingWritesTaskRun(t *testing.T) {
 	tableId, _ := env.idx.CreateTable("flush-task-test")
 	docid := makeDocID("doc1")
 
-	env.idx.Update(tableId, docid, []string{"taskword"}, nil)
+	env.idx.Add(tableId, docid, []string{"taskword"})
 
 	// Run the task directly
 	task := &flushPendingWritesTask{idx: env.idx, closing: true}
@@ -649,9 +649,9 @@ func TestUpdateBothEmpty(t *testing.T) {
 	tableId, _ := env.idx.CreateTable("both-empty-test")
 	docid := makeDocID("doc1")
 
-	// Both empty — should not panic or error
-	env.idx.Update(tableId, docid, nil, nil)
-	env.idx.Update(tableId, docid, []string{}, []string{})
+	// Both no-ops on an unknown doc — must not panic or error.
+	env.idx.Update(tableId, docid, nil)
+	env.idx.Delete(tableId, docid)
 	forceFlush(env.idx)
 }
 
@@ -667,8 +667,8 @@ func TestSearchMultipleKeywordsPrefix(t *testing.T) {
 	doc1 := makeDocID("doc1")
 	doc2 := makeDocID("doc2")
 
-	env.idx.Update(tableId, doc1, []string{"test"}, nil)
-	env.idx.Update(tableId, doc2, []string{"testing"}, nil)
+	env.idx.Add(tableId, doc1, []string{"test"})
+	env.idx.Add(tableId, doc2, []string{"testing"})
 	forceFlush(env.idx)
 
 	// Search for "test" — since Scan uses prefix scanning, this might
@@ -706,7 +706,7 @@ func TestUpdateManyDocuments(t *testing.T) {
 	docids := make([]int64, 20)
 	for i := 0; i < 20; i++ {
 		docids[i] = makeDocID("d" + string(rune('A'+i)))
-		env.idx.Update(tableId, docids[i], []string{"popular"}, nil)
+		env.idx.Add(tableId, docids[i], []string{"popular"})
 	}
 	forceFlush(env.idx)
 
@@ -769,7 +769,7 @@ func TestRemoveDocumentsPartial(t *testing.T) {
 	docs := make([]int64, 5)
 	for i := 0; i < 5; i++ {
 		docs[i] = makeDocID("p" + string(rune('1'+i)))
-		env.idx.Update(tableId, docs[i], []string{"partkey"}, nil)
+		env.idx.Add(tableId, docs[i], []string{"partkey"})
 	}
 	forceFlush(env.idx)
 

--- a/core/invertedindex/invertedindex.go
+++ b/core/invertedindex/invertedindex.go
@@ -107,33 +107,64 @@ func (idx *Index) GetDocs(tableId int, key string) SearchResult {
 	return results
 }
 
-// Update updates the keywords index for a document.
-// If len(newKeywords) == 0, it will remove the document from the keywords index.
-// This function MUST be called in dbMPSCQueue.
-func (idx *Index) Update(tableId int, docid int64, newKeywords, oldKeywords []string) {
-	// Handle the case of complete deletion
-	if len(newKeywords) == 0 {
-		if len(oldKeywords) > 0 {
-			idx.removeIndex(tableId, docid, oldKeywords)
-		}
+// readForward returns the document's stored keyword set from the forward map and
+// whether the document is known to the index. A nil db value (missing key) means
+// the document is unknown (ok=false); a non-nil value — including an empty one —
+// means it is known (ok=true) and decodes to its keyword set (a zero-length slice
+// for an empty value). This unknown / known-empty distinction mirrors db.Get's
+// nil vs non-nil-empty contract and drives Update's add-vs-diff branch.
+func (idx *Index) readForward(tableId int, docid int64) ([]string, bool) {
+	v, err := idx.db.Get(idx.encodeForwardKey(tableId, docid))
+	if err != nil {
+		log.Printf("[Inverted] Error reading forward map (table=%d): %v", tableId, err)
+		return nil, false
+	}
+	if v == nil {
+		return nil, false
+	}
+	return decodeForwardValue(v), true
+}
+
+// Add indexes a brand-new document's keywords and records them in the forward
+// map. It performs NO read and removes nothing, so it must only be used for
+// documents the index has not seen. An empty keyword set is a no-op. This
+// function MUST be called in dbMPSCQueue.
+func (idx *Index) Add(tableId int, docid int64, keywords []string) {
+	if len(keywords) == 0 {
+		return
+	}
+	idx.updateIndex(tableId, docid, keywords)
+	if err := idx.db.Put(idx.encodeForwardKey(tableId, docid), encodeForwardValue(keywords)); err != nil {
+		log.Printf("[Inverted] Error writing forward map (table=%d): %v", tableId, err)
+	}
+}
+
+// Update re-indexes a document to the given keyword set, diffing against the set
+// the index previously stored in its forward map (so the caller no longer passes
+// the old set). An empty keyword set deletes the document; an unknown document is
+// added. This function MUST be called in dbMPSCQueue.
+func (idx *Index) Update(tableId int, docid int64, keywords []string) {
+	if len(keywords) == 0 {
+		idx.Delete(tableId, docid)
 		return
 	}
 
-	// Handle the case of complete addition
-	if len(oldKeywords) == 0 {
-		idx.updateIndex(tableId, docid, newKeywords)
+	oldKeywords, known := idx.readForward(tableId, docid)
+	if !known {
+		idx.Add(tableId, docid, keywords)
 		return
 	}
 
-	// Convert the updated document words to a map for faster lookup
+	// Diff old vs new. Empty strings are excluded only when building the
+	// comparison maps (exactly as the previous caller-supplied-old Update did);
+	// the add/remove sets are still taken from the raw slices, so the result is
+	// byte-for-byte identical to the pre-forward-map behavior.
 	newMap := map[string]struct{}{}
-	for _, kw := range newKeywords {
+	for _, kw := range keywords {
 		if kw != "" {
 			newMap[kw] = struct{}{}
 		}
 	}
-
-	// Convert the current document words to a map for faster lookup
 	oldMap := map[string]struct{}{}
 	for _, kw := range oldKeywords {
 		if kw != "" {
@@ -142,16 +173,12 @@ func (idx *Index) Update(tableId int, docid int64, newKeywords, oldKeywords []st
 	}
 
 	removedWords := make([]string, 0, len(oldKeywords))
-	newWords := make([]string, 0, len(newKeywords))
-
-	// Find the words that are added to the current document
-	for _, kw := range newKeywords {
+	newWords := make([]string, 0, len(keywords))
+	for _, kw := range keywords {
 		if _, ok := oldMap[kw]; !ok {
 			newWords = append(newWords, kw)
 		}
 	}
-
-	// Find the words that are removed from the current document
 	for _, kw := range oldKeywords {
 		if _, ok := newMap[kw]; !ok {
 			removedWords = append(removedWords, kw)
@@ -159,9 +186,24 @@ func (idx *Index) Update(tableId int, docid int64, newKeywords, oldKeywords []st
 	}
 
 	idx.removeIndex(tableId, docid, removedWords)
-
-	// Add new words to the keywords index
 	if len(newWords) > 0 {
 		idx.updateIndex(tableId, docid, newWords)
+	}
+
+	if err := idx.db.Put(idx.encodeForwardKey(tableId, docid), encodeForwardValue(keywords)); err != nil {
+		log.Printf("[Inverted] Error writing forward map (table=%d): %v", tableId, err)
+	}
+}
+
+// Delete removes a document from every posting of its stored keyword set and
+// drops its forward-map entry. A document the index never saw is a no-op. This
+// function MUST be called in dbMPSCQueue.
+func (idx *Index) Delete(tableId int, docid int64) {
+	oldKeywords, known := idx.readForward(tableId, docid)
+	if known && len(oldKeywords) > 0 {
+		idx.removeIndex(tableId, docid, oldKeywords)
+	}
+	if err := idx.db.Delete(idx.encodeForwardKey(tableId, docid)); err != nil {
+		log.Printf("[Inverted] Error deleting forward map (table=%d): %v", tableId, err)
 	}
 }

--- a/core/invertedindex/key_robustness_test.go
+++ b/core/invertedindex/key_robustness_test.go
@@ -11,8 +11,8 @@ import (
 func TestGetDocs_NoPipePrefixLeak(t *testing.T) {
 	env := setupTestEnv(t)
 	defer env.teardown()
-	env.idx.Update(1, makeDocID("d1"), []string{"a"}, nil)
-	env.idx.Update(1, makeDocID("d2"), []string{"a|x"}, nil)
+	env.idx.Add(1, makeDocID("d1"), []string{"a"})
+	env.idx.Add(1, makeDocID("d2"), []string{"a|x"})
 	forceFlush(env.idx)
 
 	a := env.idx.GetDocs(1, "a")
@@ -31,11 +31,11 @@ func TestGetDocs_NoPipePrefixLeak(t *testing.T) {
 func TestRemoveDocuments_NoPipeCrossDelete(t *testing.T) {
 	env := setupTestEnv(t)
 	defer env.teardown()
-	env.idx.Update(1, makeDocID("d1"), []string{"a"}, nil)
-	env.idx.Update(1, makeDocID("d2"), []string{"a|x"}, nil)
+	env.idx.Add(1, makeDocID("d1"), []string{"a"})
+	env.idx.Add(1, makeDocID("d2"), []string{"a|x"})
 	forceFlush(env.idx)
 
-	env.idx.Update(1, makeDocID("d1"), nil, []string{"a"}) // delete d1 from "a"
+	env.idx.Delete(1, makeDocID("d1")) // delete d1 from "a"
 	forceFlush(env.idx)
 
 	if _, ok := env.idx.GetDocs(1, "a|x").DocIds[makeDocID("d2")]; !ok {
@@ -68,7 +68,7 @@ func TestUpdate_Int64DocidRoundTrip(t *testing.T) {
 
 	docids := []int64{0, 1, -1, 1 << 40, 9223372036854775807 /* max int64 */}
 	for _, id := range docids {
-		env.idx.Update(1, id, []string{"kw"}, nil)
+		env.idx.Add(1, id, []string{"kw"})
 	}
 	forceFlush(env.idx)
 
@@ -97,7 +97,7 @@ func TestMerge_SkipsInvalidIdGarbageRow(t *testing.T) {
 	env := setupTestEnv(t)
 	defer env.teardown()
 	for r := 0; r < 3; r++ {
-		env.idx.Update(1, makeDocID(fmt.Sprintf("d%d", r)), []string{"kw"}, nil)
+		env.idx.Add(1, makeDocID(fmt.Sprintf("d%d", r)), []string{"kw"})
 		forceFlush(env.idx)
 	}
 	// Garbage key with a non-numeric tableId ("\x01") -> decodes to InvalidId, and
@@ -130,7 +130,7 @@ func TestMerge_CompactsEmptyKeyword(t *testing.T) {
 	// "" is below docIDSize? No: keyword may be empty; docids are 8 bytes. Index
 	// several rows under the empty keyword across flushes.
 	for r := 0; r < 6; r++ {
-		env.idx.Update(1, makeDocID(fmt.Sprintf("e%d", r)), []string{""}, nil)
+		env.idx.Add(1, makeDocID(fmt.Sprintf("e%d", r)), []string{""})
 		forceFlush(env.idx)
 	}
 	rowsBefore := countRows(env, "")
@@ -154,11 +154,11 @@ func TestRemoveDocuments_RewritesTrueDoccount(t *testing.T) {
 	defer env.teardown()
 	// One row with a large doccount, then delete all but two docs.
 	for i := 0; i < 10; i++ {
-		env.idx.Update(1, makeDocID(fmt.Sprintf("d%02d", i)), []string{"kw"}, nil)
+		env.idx.Add(1, makeDocID(fmt.Sprintf("d%02d", i)), []string{"kw"})
 	}
 	forceFlush(env.idx)
 	for i := 0; i < 8; i++ {
-		env.idx.Update(1, makeDocID(fmt.Sprintf("d%02d", i)), nil, []string{"kw"})
+		env.idx.Delete(1, makeDocID(fmt.Sprintf("d%02d", i)))
 	}
 	forceFlush(env.idx)
 

--- a/core/invertedindex/pending_bound_test.go
+++ b/core/invertedindex/pending_bound_test.go
@@ -72,7 +72,7 @@ func TestMaxPendingPostingsForcesFlush(t *testing.T) {
 	bounded, cleanup := newBoundedIndex(t, Options{MaxPendingPostings: 4})
 	defer cleanup()
 	for i := 0; i < n; i++ {
-		bounded.Update(1, int64(i), []string{"kw"}, nil)
+		bounded.Add(1, int64(i), []string{"kw"})
 	}
 	// The bound guarantees the buffer never holds more than (bound + one update's
 	// worth) docids; with single-keyword updates that is < bound+1.
@@ -87,7 +87,7 @@ func TestMaxPendingPostingsForcesFlush(t *testing.T) {
 	unbounded, cleanup2 := newBoundedIndex(t, Options{} /* zero value: unbounded (opt-in default) */)
 	defer cleanup2()
 	for i := 0; i < n; i++ {
-		unbounded.Update(1, int64(i), []string{"kw"}, nil)
+		unbounded.Add(1, int64(i), []string{"kw"})
 	}
 	if unbounded.pendingWritePostings != n {
 		t.Fatalf("unbounded: pendingWritePostings=%d, want %d (no forced flush)", unbounded.pendingWritePostings, n)
@@ -151,7 +151,7 @@ func TestMaxPendingPostingsForcesDeleteFlush(t *testing.T) {
 
 	// Seed and flush n docs under "kw".
 	for i := 0; i < n; i++ {
-		idx.Update(1, int64(i), []string{"kw"}, nil)
+		idx.Add(1, int64(i), []string{"kw"})
 	}
 	forceFlush(idx)
 	if got := searchDocCount(idx, 1, "kw"); got != n {
@@ -162,7 +162,7 @@ func TestMaxPendingPostingsForcesDeleteFlush(t *testing.T) {
 	// the bound must force a delete flush, so the buffered deletes stay bounded
 	// and removals reach the store without an explicit flush.
 	for i := 0; i < n; i++ {
-		idx.Update(1, int64(i), nil, []string{"kw"})
+		idx.Delete(1, int64(i))
 	}
 	if idx.pendingDeletePostings > 4 {
 		t.Fatalf("pendingDeletePostings=%d exceeded the bound 4", idx.pendingDeletePostings)

--- a/core/invertedindex/search_bench_test.go
+++ b/core/invertedindex/search_bench_test.go
@@ -32,7 +32,7 @@ func benchSearchEnv(b *testing.B, nDocs int) (*Index, func()) {
 		b.Fatal(err)
 	}
 	for i := range nDocs {
-		idx.Update(1, makeDocID(fmt.Sprintf("d%07d", i)), []string{"kw"}, nil)
+		idx.Add(1, makeDocID(fmt.Sprintf("d%07d", i)), []string{"kw"})
 	}
 	forceFlush(idx)
 	cleanup := func() {

--- a/core/invertedindex/storage.go
+++ b/core/invertedindex/storage.go
@@ -32,6 +32,11 @@ type Options struct {
 	// A zero value selects DefaultKeyTypeNextId (22); byte 0 is reserved.
 	KeyTypeNextId byte
 
+	// KeyTypeForward is the on-disk key-type prefix byte for the per-document
+	// forward map (docid -> keyword set). A zero value selects
+	// DefaultKeyTypeForward (11); byte 0 is reserved.
+	KeyTypeForward byte
+
 	// FlushTicker is how often the flush goroutine enqueues a flush task.
 	// Default: 1 second.
 	FlushTicker time.Duration
@@ -145,9 +150,10 @@ type Index struct {
 	opts Options
 
 	// resolved on-disk key-type bytes (set in New from opts with defaults applied)
-	keyTypeRow    byte
-	keyTypeTable  byte
-	keyTypeNextId byte
+	keyTypeRow     byte
+	keyTypeTable   byte
+	keyTypeNextId  byte
+	keyTypeForward byte
 
 	// pending writes/deletes — accessed only from the single-threaded mpsc queue
 	pendingWrites      map[int]*pendingTableWrites
@@ -191,6 +197,9 @@ func New(store kv.Store, q queue.Queue, opts Options) (*Index, error) {
 	if opts.KeyTypeNextId == 0 {
 		opts.KeyTypeNextId = DefaultKeyTypeNextId
 	}
+	if opts.KeyTypeForward == 0 {
+		opts.KeyTypeForward = DefaultKeyTypeForward
+	}
 
 	idx := &Index{
 		db:                  store,
@@ -199,6 +208,7 @@ func New(store kv.Store, q queue.Queue, opts Options) (*Index, error) {
 		keyTypeRow:          opts.KeyTypeRow,
 		keyTypeTable:        opts.KeyTypeTable,
 		keyTypeNextId:       opts.KeyTypeNextId,
+		keyTypeForward:      opts.KeyTypeForward,
 		pendingWrites:       map[int]*pendingTableWrites{},
 		lastFlushWriteTime:  time.Now(),
 		pendingDeletes:      map[int]*pendingTableWrites{},

--- a/core/invertedindex/table.go
+++ b/core/invertedindex/table.go
@@ -39,6 +39,7 @@ func (idx *Index) DeleteTable(tableId int) error {
 
 	batch := idx.db.NewBatch(0)
 	batch.DeletePrefix(idx.encodeInvertedSearchKey(tableId, ""))
+	batch.DeletePrefix(idx.encodeForwardKeyPrefix(tableId))
 	batch.Delete(idx.encodeTableKey(tableId))
 	return batch.Commit()
 }

--- a/internal/core/storage/storage_test.go
+++ b/internal/core/storage/storage_test.go
@@ -144,6 +144,12 @@ func TestIsKeyType(t *testing.T) {
 // authoritative Default* constants from each core sub-package and the
 // storage-local symbol consts, then asserts there are no duplicates across
 // the entire shared on-disk key namespace.
+//
+// Byte 11 is intentionally reused across the two physically-separate dbs (the
+// document data db vs the inverted-index db): it was documents'
+// DefaultKeyTypeDocWords and is now invertedindex.DefaultKeyTypeForward in the
+// separate index db. Because the dbs never share a file, the flat list below
+// still asserts a single global uniqueness with byte 11 appearing exactly once.
 func TestKeyTypeConstants(t *testing.T) {
 	type entry struct {
 		name  string
@@ -153,15 +159,15 @@ func TestKeyTypeConstants(t *testing.T) {
 		// collection (1-2)
 		{"collection.DefaultKeyTypeIncrId", collection.DefaultKeyTypeIncrId},
 		{"collection.DefaultKeyTypeRecord", collection.DefaultKeyTypeRecord},
-		// documents (10-13)
+		// documents (10, 12-13; 11 freed, now invertedindex forward in the index db)
 		{"documents.DefaultKeyTypeDocCollection", documents.DefaultKeyTypeDocCollection},
-		{"documents.DefaultKeyTypeDocWords", documents.DefaultKeyTypeDocWords},
 		{"documents.DefaultKeyTypeDocMeta", documents.DefaultKeyTypeDocMeta},
 		{"documents.DefaultKeyTypeDocPath", documents.DefaultKeyTypeDocPath},
-		// invertedindex (20-22)
+		// invertedindex (20-22) + forward map (11, in the separate index db)
 		{"invertedindex.DefaultKeyTypeRow", invertedindex.DefaultKeyTypeRow},
 		{"invertedindex.DefaultKeyTypeTable", invertedindex.DefaultKeyTypeTable},
 		{"invertedindex.DefaultKeyTypeNextId", invertedindex.DefaultKeyTypeNextId},
+		{"invertedindex.DefaultKeyTypeForward", invertedindex.DefaultKeyTypeForward},
 		// idtable (28-29)
 		{"idtable.LegacyKeyTypeNextId", idtable.LegacyKeyTypeNextId},
 		{"idtable.LegacyKeyTypeKey", idtable.LegacyKeyTypeKey},

--- a/internal/core/symbols/function.go
+++ b/internal/core/symbols/function.go
@@ -176,7 +176,7 @@ func SplitCamelCase(name string) []string {
 	return result
 }
 
-func updateSymbolWordsInverseIndex(workspaceid int, docId string, newFuncNames, oldFuncNames []string) {
+func updateSymbolWordsInverseIndex(workspaceid int, docId string, newFuncNames []string) {
 	sw, err := GetSymbolWordsTable(workspaceid)
 	if err != nil {
 		log.Println("[Symbols] Error: failed to get symbol words table:", err)
@@ -190,22 +190,14 @@ func updateSymbolWordsInverseIndex(workspaceid int, docId string, newFuncNames, 
 			wordsInNewFuncNames = append(wordsInNewFuncNames, strings.ToLower(word))
 		}
 	}
-
-	wordsInOldFuncNames := []string{}
-	for _, fn := range oldFuncNames {
-		words := tokenizer.TokenizeForIndex(fn)
-		for _, word := range words {
-			wordsInOldFuncNames = append(wordsInOldFuncNames, strings.ToLower(word))
-		}
-	}
-	idxInst.Update(sw.InvertedId, idtable.DecodeId(docId), wordsInNewFuncNames, wordsInOldFuncNames)
+	idxInst.Update(sw.InvertedId, idtable.DecodeId(docId), wordsInNewFuncNames)
 
 	s, err := GetSymbolTable(workspaceid)
 	if err != nil {
 		log.Println("[Symbols] Error: failed to get symbol table:", err)
 		return
 	}
-	idxInst.Update(s.InvertedId, idtable.DecodeId(docId), newFuncNames, oldFuncNames)
+	idxInst.Update(s.InvertedId, idtable.DecodeId(docId), newFuncNames)
 }
 
 func DeleteDocument(workspaceId int, docId string) error {
@@ -224,12 +216,7 @@ func DeleteDocument(workspaceId int, docId string) error {
 			return err
 		}
 
-		oldFunctions, err := GetDocFunctions(workspaceId, docId)
-		if err != nil {
-			log.Println("[Symbols] Error: failed to get existing functions for document:", docId, err)
-			return err
-		}
-		idxInst.Update(s.InvertedId, idtable.DecodeId(docId), []string{}, getUniqueFunctionNames(oldFunctions))
+		idxInst.Delete(s.InvertedId, idtable.DecodeId(docId))
 
 		batch := NewBatch(db)
 		batch.Delete(EncodeDocFunctionsKey(workspaceId, docId))
@@ -252,15 +239,8 @@ func AddFunctions(workspaceid int, functions []DocFunction) error {
 		batch := NewBatch(db)
 
 		for _, df := range functions {
-			oldFunctions, err := GetDocFunctions(workspaceid, df.ID)
-			if err != nil {
-				log.Println("[Symbols] Error: failed to get existing functions for document:", df.ID, err)
-				continue
-			}
-
-			oldFuncNames := getUniqueFunctionNames(oldFunctions)
 			newFuncNames := getUniqueFunctionNames(df.Functions)
-			updateSymbolWordsInverseIndex(workspaceid, df.ID, newFuncNames, oldFuncNames)
+			updateSymbolWordsInverseIndex(workspaceid, df.ID, newFuncNames)
 
 			saveDocFunctions(batch, workspaceid, &df)
 		}

--- a/internal/core/symbols/symbols_test.go
+++ b/internal/core/symbols/symbols_test.go
@@ -725,52 +725,6 @@ func TestAddFunctions_DbClosed(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// AddFunctions – GetDocFunctions error path (continue)
-// ---------------------------------------------------------------------------
-
-func TestAddFunctions_GetDocFunctionsError(t *testing.T) {
-	env := setupTestEnv(t)
-	defer env.teardown()
-
-	// Do NOT create workspace – GetDocFunctions will succeed (returns empty)
-	// but GetSymbolWordsTable/GetSymbolTable inside updateSymbolWordsInverseIndex
-	// will fail. The important thing is that AddFunctions itself doesn't error
-	// out catastrophically on workspace issues.
-	//
-	// To trigger the GetDocFunctions error path specifically, we need db.Get
-	// to fail for the doc functions key but db to not be fully closed.
-	// We can achieve this by using a workspace that was never created: the
-	// doc functions key won't exist (returns nil, nil from pebble), so
-	// GetDocFunctions won't error. Instead, we exercise the continue path
-	// by temporarily swapping the db with a closed one after the IsClosed
-	// check passes.
-	//
-	// A simpler approach: create a workspace, add functions, then verify
-	// that even when updateSymbolWordsInverseIndex fails internally (because
-	// workspace 999 doesn't exist), the batch still commits for the valid docs.
-	mustCreateWorkspace(t, 1)
-
-	funcs := []DocFunction{
-		{
-			ID:      "doc_valid",
-			RelPath: "valid.go",
-			Functions: []Function{
-				{Name: "validFunc", Line: 1},
-			},
-		},
-	}
-
-	// This should succeed even though internal inverse index calls may log errors.
-	err := AddFunctions(1, funcs)
-	assert.NoError(t, err)
-
-	// Verify the function was saved despite any internal logging.
-	got, err := GetDocFunctions(1, "doc_valid")
-	assert.NoError(t, err)
-	assert.Len(t, got, 1)
-}
-
-// ---------------------------------------------------------------------------
 // DeleteDocument – db.IsClosed() early return
 // ---------------------------------------------------------------------------
 
@@ -797,47 +751,15 @@ func TestDeleteDocument_GetSymbolTableError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// DeleteDocument – GetDocFunctions error path
+// updateSymbolWordsInverseIndex – table-fetch error branch
 // ---------------------------------------------------------------------------
 
-func TestDeleteDocument_GetDocFunctionsError(t *testing.T) {
-	env := setupTestEnv(t)
-	defer env.teardown()
+// TestUpdateSymbolWordsInverseIndex_TableError covers the error branch when the
+// symbol-words table can't be fetched (closed db): it must log and return
+// without panicking (it never reaches idxInst).
+func TestUpdateSymbolWordsInverseIndex_TableError(t *testing.T) {
+	cleanup := setupClosedDbEnv(t)
+	defer cleanup()
 
-	mustCreateWorkspace(t, 1)
-
-	// Write a corrupted/malformed doc-functions key value that will still
-	// parse without error (pebble returns data fine). To actually trigger a
-	// GetDocFunctions error we need db.Get to fail. We can do this by
-	// closing the DB right after GetSymbolTable succeeds. Since both calls
-	// happen inside mpsc.RunFunc (serialised), we use a workaround: put a
-	// valid symbol table for workspace 50 but then remove the underlying DB
-	// state for the doc functions lookup.
-	//
-	// The simplest reliable way: create workspace, add functions, verify
-	// DeleteDocument with a doc that has no functions still works fine.
-	// The GetDocFunctions call returns empty, exercising the empty-old-functions
-	// path through the delete flow.
-	funcs := []DocFunction{
-		{
-			ID:      "doc1",
-			RelPath: "main.go",
-			Functions: []Function{
-				{Name: "foo", Line: 1},
-			},
-		},
-	}
-	err := AddFunctions(1, funcs)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	// Delete a doc that exists
-	err = DeleteDocument(1, "doc1")
-	assert.NoError(t, err)
-
-	// Verify it's gone
-	got, err := GetDocFunctions(1, "doc1")
-	assert.NoError(t, err)
-	assert.Empty(t, got)
+	updateSymbolWordsInverseIndex(1, "doc1", []string{"foo", "bar"})
 }

--- a/internal/server/indexer/indexer.go
+++ b/internal/server/indexer/indexer.go
@@ -116,7 +116,7 @@ func AddOrSyncFile(workspace *workspace.Workspace, relPath string) error {
 		return err
 	}
 
-	doc, err := st.GetDocument(workspace.Id, docid, false)
+	doc, err := st.GetDocument(workspace.Id, docid)
 	if err != nil {
 		return err
 	}

--- a/internal/server/indexer/parser.go
+++ b/internal/server/indexer/parser.go
@@ -122,7 +122,7 @@ func parse(file ParseFile) (doc *documents.Document, newfile bool, oversize bool
 		log.Printf("[Indexer] File `%s` (%.2f MiB) is too large to index, skipping", file.RelFilePath, float64(info.Size())/1024/1024)
 	}
 
-	existing, _ := stInst.GetDocument(file.Workspace.Id, id, false)
+	existing, _ := stInst.GetDocument(file.Workspace.Id, id)
 	// If the document exists and the modified time is the same, return nil.
 	// (Done before reading the file, so unchanged files cost only a stat.)
 	if existing != nil &&

--- a/internal/server/searcher/searcher.go
+++ b/internal/server/searcher/searcher.go
@@ -312,7 +312,7 @@ func SearchContent(workspace *workspace.Workspace, req *types.SearchContentReque
 			break
 		}
 
-		doc, err := stInst.GetDocument(workspace.Id, idtable.EncodeId(docid), false)
+		doc, err := stInst.GetDocument(workspace.Id, idtable.EncodeId(docid))
 		if err != nil || doc == nil {
 			continue
 		}

--- a/internal/server/searcher/searcher_coverage_test.go
+++ b/internal/server/searcher/searcher_coverage_test.go
@@ -929,7 +929,7 @@ func TestFullIntegration(t *testing.T) {
 			return relPath == "keep.go"
 		})
 		for _, docid := range sorted {
-			doc, _ := stInst.GetDocument(sharedWS.Id, idtable.EncodeId(docid), false)
+			doc, _ := stInst.GetDocument(sharedWS.Id, idtable.EncodeId(docid))
 			if doc != nil {
 				assert.Equal(t, "keep.go", doc.RelPath)
 			}
@@ -1964,7 +1964,7 @@ func TestFullIntegration(t *testing.T) {
 		// Only files containing BOTH terms should survive intersection.
 		// Verify by resolving doc IDs to paths.
 		for docId := range result.DocIds {
-			doc, _ := stInst.GetDocument(sharedWS.Id, idtable.EncodeId(docId), false)
+			doc, _ := stInst.GetDocument(sharedWS.Id, idtable.EncodeId(docId))
 			if doc != nil {
 				assert.Equal(t, "andfileA.go", doc.RelPath,
 					"only andfileA.go should survive AND intersection")

--- a/internal/server/searcher/symbols_searcher.go
+++ b/internal/server/searcher/symbols_searcher.go
@@ -65,7 +65,7 @@ func isFileChanged(workspace *workspace.Workspace, doc *documents.Document) bool
 }
 
 func getFunctionFileMatch(workspace *workspace.Workspace, queryFunctionWords []string, docId string) (map[string][]types.SymbolsFileMatch, error) {
-	doc, err := stInst.GetDocument(workspace.Id, docId, false)
+	doc, err := stInst.GetDocument(workspace.Id, docId)
 	if err != nil || doc == nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func searchSymbols(workspace *workspace.Workspace, req *types.SearchSymbolsReque
 	for docId := range r.DocIds {
 		docIdStr := idtable.EncodeId(docId)
 		// Get document info for file path
-		doc, err := stInst.GetDocument(workspace.Id, docIdStr, false)
+		doc, err := stInst.GetDocument(workspace.Id, docIdStr)
 		if err != nil || doc == nil {
 			continue
 		}


### PR DESCRIPTION
## What & why

The inverted index's `Update(tableId, docid, newKeywords, oldKeywords)` required the
caller to supply each document's **previous** keyword set so the index could diff. To
provide it, the documents store kept a second copy of every doc's keywords (the
`doc-words` key, byte `11`, in the `data` db) and read it back on every update — the
keyword set was stored twice and the update path did an extra read.

This moves ownership of the per-document keyword set **into the inverted index** as a
forward map (`docid -> keywords`). The index reads the old set itself, so `Update` no
longer takes it and the documents store stops persisting `doc-words` entirely.

## Changes

- **`core/invertedindex`** — new forward map under `DefaultKeyTypeForward = byte(11)`
  (reused from the retired doc-words slot; safe because the index lives in a physically
  separate `index` db where 11 was free). `Update(tid,docid,new,old)` is replaced by
  **`Add(tid,docid,kws)` / `Update(tid,docid,kws)` / `Delete(tid,docid)`** + `readForward`;
  `Update`/`Delete` read the old set from the forward map. `DeleteTable` clears the
  forward prefix. The diff reproduces the old behavior byte-for-byte (empties excluded
  only from the comparison maps). Forward map written via committed `db.Put`/`db.Delete`;
  postings stay on the existing buffered/lazy flush path (read-your-writes holds).
- **`core/documents`** — `saveDocument` stops writing doc-words; `GetDocument` drops
  `includeWords`; `getDocumentWords` + the doc-words codec + the `KeyTypeDocWords` option
  are removed; the `indexDocument` seam splits into `indexAddDocument`/`indexUpdateDocument`/
  `indexDeleteDocument`. **`Document.Words` is retained** as the in-memory parse→index carrier.
- **`core/collection`** — `Collection.GetDocument` drops `includeWords`.
- **`internal/core/symbols`** — both `updateSymbolWordsInverseIndex` index calls map to
  **`Update`** (NOT `Add`: `AddFunctions` is an upsert; `Add` would orphan stale postings
  on re-index); `DeleteDocument` → `Delete`; dropped the index-only `GetDocFunctions`/
  `oldFuncNames` reads.
- **`internal/server`** — `GetDocument` callers drop the bool.
- **Key-space canary** — byte 11 retired from the data db, added as the index forward key
  (still asserts global byte-uniqueness).

## Non-goals (by design)

- **No StorageVersion bump / migration.** `StorageVersion` is already `1.5` and 1.5 is
  unreleased, so every install builds a fresh `1.5` directory from this code and never
  writes byte 11 — no on-disk doc-words can pre-exist, nothing to migrate.
- **Atomicity is unchanged** ("no worse than today"): the forward map and postings were
  already separate writes; both dbs are derived caches rebuilt by reindex.

## Testing & gates

- `core` (`GOWORK=off`) and root (`go.work`): `go build` / `go vet` / `go test ./...` all green.
- `make coverage` → exit 0, per-function gate clean, **TOTAL 94.1%** (893 tests).
- New `core/invertedindex/forward_test.go` pins Add/Update/Delete/empty⇒Delete/unknown⇒Add/
  DeleteTable-clears-forward/known-empty/second-Update-rewrites; `TestCollection_Update`
  rewritten to assert delegation via metadata (deterministic — the index flush is async);
  doc-words tests removed cleanly; a focused closed-db test covers the symbols error branch.

## Note

This branch also includes one unrelated doc commit (`docs(agents): add Principle 3 —
author large files incrementally`) added per request in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)