### PR TITLE
kv: add Reader read-only seam interface

### DIFF
--- a/core/kv/kv.go
+++ b/core/kv/kv.go
@@ -79,3 +79,21 @@ type Snapshot interface {
 	// through the Snapshot after its Close are undefined; callers must not do that.
 	Close() error
 }
+
+// Reader is the read-only surface shared by Store and Snapshot — the same
+// Get/Scan/ScanRange methods. Their semantics (value handling on Get; the
+// callback slice-validity and stop-on-false rules on Scan/ScanRange) are as
+// documented on Store and Snapshot, which remain the canonical contract; this
+// interface only names the shared subset so a read path can be written against
+// either the live Store or a consistent point-in-time Snapshot.
+type Reader interface {
+	Get(key []byte) ([]byte, error)
+	Scan(prefix []byte, cb func(key, value []byte) bool) error
+	ScanRange(begin, end []byte, cb func(key, value []byte) bool) error
+}
+
+// Store and Snapshot both satisfy Reader (compile-time assertions).
+var (
+	_ Reader = (Store)(nil)
+	_ Reader = (Snapshot)(nil)
+)


### PR DESCRIPTION
## What

Adds `kv.Reader { Get; Scan; ScanRange }` — the read-only surface shared by `kv.Store` and `kv.Snapshot` — plus two compile-time assertions that both satisfy it:

```go
var (
    _ Reader = (Store)(nil)
    _ Reader = (Snapshot)(nil)
)
```

## Why

`Store` and `Snapshot` (added in #108) expose the identical read triple, but as distinct types a read helper written against one can't accept the other. `Reader` names the shared subset so a read path can be written against **either** the live store or a consistent point-in-time snapshot. Because Go interface assignability (not embedding) is what applies, a `Store` or `Snapshot` value is already passable where a `Reader` is wanted, with no explicit conversion — so this is the seam the future search-on-a-snapshot wiring will use.

## Scope

Seam only. **No consumer** — no `engine`/`invertedindex`/`documents` re-parameterization, no pebblekv change. Wiring the read path onto a snapshot is a separate later change.

## Compatibility

Purely additive: `Store`/`Snapshot`/`Batch`/`Snapshotter` are left byte-identical, so every existing implementer keeps satisfying them. The assertions have teeth — they'd fail to compile if `Store` or `Snapshot` ever lost a read method. No on-disk format change.

## Verification (go1.24.2)

- core `build` green — the `var _ Reader = …` assertions **are** the compile-time check.
- `gofmt` clean; diff is a pure 18-line addition to `core/kv/kv.go`, zero deletions.
- No behavioral test (interface-only).

Built via the SDD flow (spec → review → workflow-driven implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)