### PR TITLE
perf(invertedindex): Tier-1 in-place allocation / build-RSS reductions (byte-identical)

### DIFF
--- a/core/invertedindex/batch_close_test.go
+++ b/core/invertedindex/batch_close_test.go
@@ -1,0 +1,115 @@
+package invertedindex
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codetrek/haystack/core/kv"
+	"github.com/codetrek/haystack/core/kv/pebblekv"
+	"github.com/codetrek/haystack/core/queue"
+)
+
+// recStore wraps a real kv.Store, delegating every method EXCEPT NewBatch, which
+// returns a recBatch so the test can observe Close() on every batch created.
+// Wrapping at the STORE captures both the three newBatch(idx.db) sites (flush
+// writes, flush deletes, merge) AND DeleteTable's direct idx.db.NewBatch(0),
+// which bypasses the newBatch package seam. batchCloses counts Close() across all
+// batches it hands out.
+type recStore struct {
+	kv.Store
+	batchCloses *atomic.Int64
+}
+
+func (s recStore) NewBatch(maxBatchSize int32) kv.Batch {
+	return &recBatch{Batch: s.Store.NewBatch(maxBatchSize), closes: s.batchCloses}
+}
+
+// recBatch embeds a real kv.Batch and overrides Close to increment the shared
+// counter (modelled on mockBatchWriteWithFuncs.Close) before delegating to the
+// embedded real Close.
+type recBatch struct {
+	kv.Batch
+	closes *atomic.Int64
+}
+
+func (b *recBatch) Close() error {
+	b.closes.Add(1)
+	return b.Batch.Close()
+}
+
+// TestBatchSitesCloseCommittedBatch proves every batch-creating site Closes its
+// committed batch (returning it to pebble's pool). Driving forceFlush (flush
+// writes + flush deletes), a synchronous merge, and DeleteTable exercises all
+// four sites; a store-level recorder observes Close on each. Before I5 no site
+// Closes (count 0 → fail); after I5 each op Closes at least once (count >= 4).
+func TestBatchSitesCloseCommittedBatch(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "haystack-ii-batchclose-*")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	real, err := pebblekv.Open(filepath.Join(tempDir, "data"), 0)
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+
+	var closes atomic.Int64
+	store := recStore{Store: real, batchCloses: &closes}
+
+	q := queue.NewMpsc("TestBatchCloseQueue")
+	q.Start()
+
+	// Reset the package test-injection seams to their production defaults so the
+	// three newBatch sites actually reach recStore.NewBatch — prior tests
+	// (setupTestEnv, newBoundedIndex, the merger tests) reassign them, and a
+	// mutated newBatch seam would bypass recStore.NewBatch. DeleteTable's direct
+	// NewBatch(0) is captured regardless.
+	newBatch = func(db kv.Store) kv.Batch { return db.NewBatch(MaxBatchSize) }
+	writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []int64, key []byte) {
+		batch.Put(key, encodeInvertedValue(docids))
+	}
+
+	// Disable the periodic ticker (FlushTicker = 1h) so the only batches created
+	// are the ones this test drives explicitly — single-goroutine and race-free.
+	idx, err := New(store, q, Options{FlushTicker: time.Hour})
+	if err != nil {
+		q.Stop()
+		real.Close()
+		t.Fatalf("new index: %v", err)
+	}
+	defer func() {
+		idx.CloseAndWait()
+		q.Stop()
+		real.Close()
+	}()
+
+	const tableId = 7
+	idx.updateIndex(tableId, makeDocID("d1"), []string{"kw"})
+
+	// (a) forceFlush -> flushPendingWrites + flushPendingDeletes = 2 batches.
+	forceFlush(idx)
+
+	// (b) a synchronous merge via the queue = 1 batch. pendingWrites is now empty
+	// (drained by forceFlush), so mergeKeywordTask.Run does not early-return.
+	if err := idx.q.RunTask(&mergeKeywordTask{
+		idx:     idx,
+		merging: merging{NextIter: string(DefaultKeyTypeRow)},
+	}); err != nil {
+		t.Fatalf("merge RunTask: %v", err)
+	}
+
+	// (c) DeleteTable = 1 batch (idx.db.NewBatch(0)).
+	if err := idx.DeleteTable(tableId); err != nil {
+		t.Fatalf("DeleteTable: %v", err)
+	}
+
+	// Each of the four batch-creating ops must Close its committed batch. Before
+	// I5 the count is 0; after I5 it is >= 1 per op (>= 4 total).
+	if got := closes.Load(); got < 4 {
+		t.Fatalf("batch Close count = %d, want >= 4 (one per flush-writes, flush-deletes, merge, DeleteTable)", got)
+	}
+}

--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -146,11 +146,12 @@ func encodeTableValue(info TableInfo) []byte {
 // small, densely-allocated idtable ids, so the gaps are tiny and most encode to a
 // single byte — far smaller than the previous fixed 8-byte-per-id layout, and
 // cheaper to decode than a general-purpose block compressor. Order within a row
-// is irrelevant (the docids are a set), so sorting here is free; deduplication
-// remains the caller's responsibility. Sorting/subtracting in uint64 space (not
-// int64) keeps every gap non-negative and makes the round-trip exact for any
-// int64 docid, including negative and max values. This is an on-disk format
-// change from the old big-endian layout and requires a reindex.
+// is irrelevant (the docids are a set), so sorting here is free; the encoder sorts
+// AND dedups (adjacent-equal removal after the sort), so callers may pass a slice
+// containing duplicates. Sorting/subtracting in uint64 space (not int64) keeps
+// every gap non-negative and makes the round-trip exact for any int64 docid,
+// including negative and max values. This is an on-disk format change from the old
+// big-endian layout and requires a reindex.
 func encodeInvertedValue(docids []int64) []byte {
 	if len(docids) == 0 {
 		return []byte{}
@@ -160,17 +161,16 @@ func encodeInvertedValue(docids []int64) []byte {
 		us[i] = uint64(id)
 	}
 	slices.Sort(us)
+	us = slices.Compact(us) // adjacent-equal removal == set-dedup post-sort
 
 	buf := make([]byte, 0, len(us)+len(us)/2) // most ids encode to ~1 byte
-	var tmp [binary.MaxVarintLen64]byte
 	var prev uint64
 	for i, u := range us {
 		delta := u
 		if i > 0 {
 			delta = u - prev // non-negative: us is sorted ascending in uint64 space
 		}
-		n := binary.PutUvarint(tmp[:], delta)
-		buf = append(buf, tmp[:n]...)
+		buf = binary.AppendUvarint(buf, delta)
 		prev = u
 	}
 	return buf

--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -234,7 +234,21 @@ func (idx *Index) encodeForwardKeyPrefix(tableId int) []byte {
 // doc-words value used. A keyword containing '|' splits the same lossy way it
 // always has (no behavior change vs. the old doc-words value).
 func encodeForwardValue(keywords []string) []byte {
-	return []byte(strings.Join(keywords, "|"))
+	if len(keywords) == 0 {
+		return []byte{}
+	}
+	n := len(keywords) - 1
+	for _, k := range keywords {
+		n += len(k)
+	}
+	b := make([]byte, 0, n)
+	for i, k := range keywords {
+		if i > 0 {
+			b = append(b, '|')
+		}
+		b = append(b, k...)
+	}
+	return b
 }
 
 // decodeForwardValue is the inverse of encodeForwardValue. An empty input decodes

--- a/core/invertedindex/codec.go
+++ b/core/invertedindex/codec.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // Default on-disk key-type prefix bytes.  These values MUST NOT change after
@@ -69,18 +68,19 @@ func (idx *Index) encodeInvertedKeyPrefix(tableId int, keyword string) []byte {
 	return idx.appendInvertedKeyPrefix(b, tableId, keyword)
 }
 
-func (idx *Index) encodeInvertedKey(tableId int, keyword string, doccount int) []byte {
-	// "<prefix><doccount>|<tick>.<seq>" where tick is the current micros and seq
-	// is a per-Index monotonic counter. tick alone is not unique within a single
-	// microsecond, so two rows of the same (tableId,keyword,doccount) could get
-	// byte-identical keys and overwrite each other; the seq suffix makes every
-	// encoded key unique. decode treats everything after the last '|' as the
-	// opaque tick, so this does not change the on-disk format contract.
+func (idx *Index) encodeInvertedKey(tableId int, keyword string, doccount int, tick int64) []byte {
+	// "<prefix><doccount>|<tick>.<seq>" where tick is a decimal-micros timestamp
+	// SAMPLED ONCE PER flush/merge/delete batch by the caller and threaded in (not
+	// read per key), and seq is a per-Index monotonic counter. tick alone is not
+	// unique — two rows of the same (tableId,keyword,doccount) in one batch share
+	// it — so the seq suffix is the SOLE guarantor that every encoded key is
+	// distinct. decode treats everything after the last '|' as the opaque tick, so
+	// this does not change the on-disk format contract.
 	b := make([]byte, 0, 1+11+1+len(keyword)+1+11+1+19+1+20)
 	b = idx.appendInvertedKeyPrefix(b, tableId, keyword)
 	b = strconv.AppendInt(b, int64(doccount), 10)
 	b = append(b, '|')
-	b = strconv.AppendInt(b, time.Now().UnixMicro(), 10)
+	b = strconv.AppendInt(b, tick, 10)
 	b = append(b, '.')
 	b = strconv.AppendUint(b, idx.keySeq.Add(1), 10)
 	return b

--- a/core/invertedindex/codec_bench_test.go
+++ b/core/invertedindex/codec_bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkEncodeInvertedKey(b *testing.B) {
 	idx := benchIdx()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = idx.encodeInvertedKey(7, "handleRequest", 42)
+		_ = idx.encodeInvertedKey(7, "handleRequest", 42, 0)
 	}
 }
 
@@ -52,7 +52,7 @@ func BenchmarkEncodeInvertedKeyPrefix(b *testing.B) {
 // BenchmarkDecodeInvertedKey covers the per-row merge-scan key decoder (strings.Split).
 func BenchmarkDecodeInvertedKey(b *testing.B) {
 	idx := benchIdx()
-	key := string(idx.encodeInvertedKey(7, "handleRequest", 42))
+	key := string(idx.encodeInvertedKey(7, "handleRequest", 42, 0))
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_, _, _, _ = idx.decodeInvertedKey(key)

--- a/core/invertedindex/codec_delimiter_test.go
+++ b/core/invertedindex/codec_delimiter_test.go
@@ -32,7 +32,7 @@ func TestDecodeInvertedKey_KeywordWithDelimiter(t *testing.T) {
 		"a|b\xff|c", // delimiter + 0xff together
 	}
 	for _, kw := range cases {
-		key := idx.encodeInvertedKey(7, kw, 3)
+		key := idx.encodeInvertedKey(7, kw, 3, 0)
 		tid, gotKw, dc, tick := idx.decodeInvertedKey(string(key))
 		if tid != 7 || gotKw != kw || dc != 3 || tick == "" {
 			t.Errorf("decode(encode(kw=%q)) = (tableId=%d keyword=%q doccount=%d tick=%q); want (7, %q, 3, non-empty)",
@@ -53,8 +53,8 @@ func TestMerge_KeywordWithDelimiter_NoOrphan(t *testing.T) {
 	keywords := []string{"a|b", "c|d", "x\xffy", "plain"}
 
 	// Index several distinct docs per keyword across separate flushes (each flush
-	// writes a distinct tick'd row) so the merger's rewriteIndex path
-	// (len(Rows) >= 2) actually fires for every keyword.
+	// writes a distinct row, kept unique by the per-Index keySeq suffix) so the
+	// merger's rewriteIndex path (len(Rows) >= 2) actually fires for every keyword.
 	docsByKw := map[string][]int64{}
 	for round := 0; round < 3; round++ {
 		for ki, kw := range keywords {

--- a/core/invertedindex/codec_test.go
+++ b/core/invertedindex/codec_test.go
@@ -1,7 +1,9 @@
 package invertedindex
 
 import (
+	"bytes"
 	"encoding/json"
+	"math"
 	"slices"
 	"strings"
 	"testing"
@@ -324,6 +326,78 @@ func TestRemoveDuplicatesPreservesOrder(t *testing.T) {
 	for i, v := range expected {
 		if got[i] != v {
 			t.Errorf("index %d: got %d, want %d", i, got[i], v)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// encodeInvertedValue — set-dedup + byte-identity (I1)
+// ---------------------------------------------------------------------------
+
+// sortedUniqueUint64Space returns ids as the ascending-in-uint64-space set with
+// duplicates removed. It is an INDEPENDENT oracle for encodeInvertedValue's
+// sort+dedup contract — it never calls the function under test.
+func sortedUniqueUint64Space(ids []int64) []int64 {
+	us := make([]uint64, len(ids))
+	for i, id := range ids {
+		us[i] = uint64(id)
+	}
+	slices.Sort(us)
+	us = slices.Compact(us)
+	out := make([]int64, len(us))
+	for i, u := range us {
+		out[i] = int64(u)
+	}
+	return out
+}
+
+// TestEncodeInvertedValueGoldenBytes pins byte-identity against HAND-TYPED
+// delta-varint constants (never derived by calling encodeInvertedValue). The
+// encoder sorts the docids in uint64 space, drops duplicates, then writes the
+// first id followed by successive gaps as base-128 uvarints. This is the
+// load-bearing dedup guard: without slices.Compact the duplicate inputs encode
+// extra zero-gap varints and fail these goldens.
+func TestEncodeInvertedValueGoldenBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  []int64
+		want []byte
+	}{
+		// sort {1,1,2,3,3} -> unique {1,2,3} -> deltas 1,1,1
+		{"dups and unsorted", []int64{3, 1, 2, 1, 3}, []byte{0x01, 0x01, 0x01}},
+		// all identical -> {9} -> single absolute varint
+		{"all duplicates", []int64{9, 9, 9}, []byte{0x09}},
+		// already sorted, no dups -> deltas 1,1,2
+		{"sorted no dups", []int64{1, 2, 4}, []byte{0x01, 0x01, 0x02}},
+		// empty -> empty
+		{"empty", []int64{}, []byte{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeInvertedValue(tc.ids)
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("encodeInvertedValue(%v) = %v, want %v", tc.ids, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEncodeInvertedValueRoundTripFullIntRange proves the encode/decode round
+// trip is exact for the full int64 range (negatives, MinInt64, MaxInt64) AND
+// that duplicates are dropped, comparing against the independent sorted-unique
+// oracle rather than hand-typed 10-byte varints.
+func TestEncodeInvertedValueRoundTripFullIntRange(t *testing.T) {
+	tests := [][]int64{
+		{math.MinInt64},
+		{-1},
+		{math.MaxInt64},
+		{5, -1, 5, math.MaxInt64},
+	}
+	for _, ids := range tests {
+		want := sortedUniqueUint64Space(ids)
+		got := decodeInvertedValue(encodeInvertedValue(ids))
+		if !slices.Equal(got, want) {
+			t.Fatalf("round-trip(%v): got %v, want %v", ids, got, want)
 		}
 	}
 }

--- a/core/invertedindex/codec_test.go
+++ b/core/invertedindex/codec_test.go
@@ -88,7 +88,7 @@ func TestEncodeDecodeInvertedKeyRoundTrip(t *testing.T) {
 	keyword := "testing"
 	doccount := 42
 
-	key := testCodecIdx.encodeInvertedKey(tableId, keyword, doccount)
+	key := testCodecIdx.encodeInvertedKey(tableId, keyword, doccount, 0)
 	s := string(key)
 
 	// First byte is DefaultKeyTypeRow

--- a/core/invertedindex/forward_test.go
+++ b/core/invertedindex/forward_test.go
@@ -1,10 +1,74 @@
 package invertedindex
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestEncodeForwardValue_ByteIdentity is the non-drift guard: every case must
+// stay byte-for-byte identical to both a hand-written literal AND
+// strings.Join(kw, "|") (the encoding the retired doc-words value used). These
+// pass on the current strings.Join body; they exist to catch any drift when the
+// body is hand-rolled to a single allocation.
+func TestEncodeForwardValue_ByteIdentity(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []byte
+	}{
+		{"multi", []string{"a", "b", "c"}, []byte("a|b|c")},
+		{"single", []string{"only"}, []byte("only")},
+		{"nil-empty", []string{}, []byte{}},
+		{"single-empty", []string{""}, []byte{}}, // len==1 empty branch, distinct from {}
+		{"interior-empty", []string{"a", "", "b"}, []byte("a||b")},
+		{"pipe-in-keyword", []string{"a|x", "b"}, []byte("a|x|b")}, // lossy-identical to today
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeForwardValue(tc.in)
+			assert.Equal(t, tc.want, got, "literal golden")
+			assert.Equal(t, []byte(strings.Join(tc.in, "|")), got, "strings.Join parity")
+			assert.Len(t, got, len(tc.want))
+		})
+	}
+
+	// Round-trip: decode reverses encode for a multi-element set.
+	assert.Equal(t, []string{"a", "b", "c"},
+		decodeForwardValue(encodeForwardValue([]string{"a", "b", "c"})))
+}
+
+// forwardSink defeats dead-store elision of the encodeForwardValue result in the
+// allocation benchmark below.
+var forwardSink []byte
+
+// TestEncodeForwardValue_SingleAlloc is the load-bearing RED for T-I3: today the
+// []byte(strings.Join(...)) body allocates twice (the joined string + the []byte
+// copy) for a >=2-element input, so this fails at 2.0 allocs; the hand-rolled
+// single-alloc body passes at 1.0. A 1-element input cannot serve as the red
+// because strings.Join special-cases len==1 to a single alloc.
+//
+// testing.AllocsPerRun reads the process-global runtime.MemStats.Mallocs delta,
+// so a stray malloc from a background goroutine (flush/merge tickers, db worker)
+// or a GC cycle firing inside the microsecond measurement window is misattributed
+// to encodeForwardValue, inflating the average upward from 1 to 2 and flaking the
+// gate. Contamination is upward-only, so we take the MINIMUM across a few trials:
+// the single-alloc body reports 1 on at least one uncontended trial, while a
+// regression to the 2-alloc strings.Join body reports >=2 on EVERY trial (the 2
+// allocs are intrinsic), so the RED is preserved.
+func TestEncodeForwardValue_SingleAlloc(t *testing.T) {
+	kws := []string{"a", "b", "c"} // >=2 elements: strings.Join+[]byte = 2 allocs today
+	best := testing.AllocsPerRun(100, func() { forwardSink = encodeForwardValue(kws) })
+	for i := 0; i < 4; i++ {
+		if got := testing.AllocsPerRun(100, func() { forwardSink = encodeForwardValue(kws) }); got < best {
+			best = got
+		}
+	}
+	if best > 1 {
+		t.Fatalf("encodeForwardValue allocs = %v, want <= 1", best)
+	}
+}
 
 func TestForwardValueCodec_WireFormat(t *testing.T) {
 	assert.Equal(t, []byte("a|b|c"), encodeForwardValue([]string{"a", "b", "c"}))

--- a/core/invertedindex/index_test.go
+++ b/core/invertedindex/index_test.go
@@ -556,7 +556,7 @@ func TestWriteInvertedIndexDeduplicates(t *testing.T) {
 
 	// Directly call writeInvertedIndex with duplicates
 	batch := env.DB.NewBatch(0)
-	key := env.idx.encodeInvertedKey(tableId, "dupkw", 3)
+	key := env.idx.encodeInvertedKey(tableId, "dupkw", 3, 0)
 	writeInvertedIndex(batch, tableId, "dupkw", []int64{doc, doc, doc}, key)
 	batch.Commit()
 

--- a/core/invertedindex/invertedindex_internal.go
+++ b/core/invertedindex/invertedindex_internal.go
@@ -48,9 +48,9 @@ func (idx *Index) removeIndex(tableId int, docid int64, keywords []string) {
 // Callers must pass the pre-computed key via idx.encodeInvertedKey so that the
 // configured key-type bytes are honoured.
 var writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []int64, key []byte) {
-	// Remove duplicates to ensure the data stored is clean
-	uniqueDocids := removeDuplicatesEfficiently(docids)
-	content := encodeInvertedValue(uniqueDocids)
+	// encodeInvertedValue sorts AND dedups, so the raw docids (which the flush
+	// path intentionally leaves with duplicates) can be handed straight to it.
+	content := encodeInvertedValue(docids)
 	batch.Put(key, content)
 }
 

--- a/core/invertedindex/invertedindex_internal.go
+++ b/core/invertedindex/invertedindex_internal.go
@@ -108,6 +108,10 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 		return err
 	}
 
+	// Sample the opaque key tick ONCE for every rewritten row of this keyword
+	// (uniqueness is guaranteed by keySeq, not the tick), instead of reading the
+	// clock per row.
+	tick := time.Now().UnixMicro()
 	for len(docids) > 0 {
 		docs := []int64{}
 		for id := range docids {
@@ -123,7 +127,7 @@ func (idx *Index) removeDocumentsFromInvertedIndex(batch kv.Batch, tableId int, 
 		// the merger's `doccount > maxSize/2` guard then quarantines from
 		// compaction forever. encodeInvertedKey's seq suffix keeps the new key
 		// distinct from the originals, all of which are deleted below.
-		key := idx.encodeInvertedKey(tableId, kw, len(docs))
+		key := idx.encodeInvertedKey(tableId, kw, len(docs), tick)
 
 		writeInvertedIndex(batch, tableId, kw, docs, key)
 	}

--- a/core/invertedindex/invertedindex_internal.go
+++ b/core/invertedindex/invertedindex_internal.go
@@ -16,7 +16,7 @@ func (idx *Index) updateIndex(tableId int, docid int64, keywords []string) {
 	// corrupted by a malformed docid (the previous string-based ingress guard is
 	// no longer representable and has been removed).
 	cache := idx.getPendingWrite(tableId)
-	now := time.Now() // one timestamp for the whole update (per-keyword time.Now is hot)
+	now := time.Now().UnixNano() // one timestamp for the whole update (per-keyword time.Now is hot)
 	for _, kw := range keywords {
 		// Add to write cache to merge with other documents and flush later. docid may be
 		// duplicated; however for performance we don't check for duplicates here — all
@@ -32,7 +32,7 @@ func (idx *Index) updateIndex(tableId int, docid int64, keywords []string) {
 
 func (idx *Index) removeIndex(tableId int, docid int64, keywords []string) {
 	w := idx.getPendingDelete(tableId)
-	now := time.Now()
+	now := time.Now().UnixNano()
 	for _, kw := range keywords {
 		// Add to delete cache to merge with other documents and flush later.
 		w.InvertedIndex[kw] = relatedDocs{

--- a/core/invertedindex/key_robustness_test.go
+++ b/core/invertedindex/key_robustness_test.go
@@ -3,6 +3,7 @@ package invertedindex
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -43,17 +44,33 @@ func TestRemoveDocuments_NoPipeCrossDelete(t *testing.T) {
 	}
 }
 
-// B3 — encodeInvertedKey must be unique even for the same (tableId,keyword,
-// doccount) within one microsecond (else one row silently overwrites another).
-func TestEncodeInvertedKey_UniqueWithinMicrosecond(t *testing.T) {
+// B3 — encodeInvertedKey must be unique even when the tick is LITERALLY IDENTICAL
+// across rows of the same (tableId,keyword,doccount): the per-Index keySeq suffix,
+// not the micros tick, is the sole key-uniqueness guarantor. (The tick was the
+// current micros read per key before I4 sampled it once per flush/merge batch and
+// threaded it in; under an identical tick two rows would collide without keySeq.)
+func TestEncodeInvertedKey_UniqueUnderIdenticalTick(t *testing.T) {
 	idx := &Index{keyTypeRow: DefaultKeyTypeRow}
+	const tick = int64(0)
 	seen := make(map[string]struct{}, 2000)
 	for i := 0; i < 2000; i++ {
-		k := string(idx.encodeInvertedKey(7, "a", 5))
+		k := string(idx.encodeInvertedKey(7, "a", 5, tick))
 		if _, dup := seen[k]; dup {
 			t.Fatalf("duplicate key at i=%d: %q", i, k)
 		}
+		if tid, kw, dc, _ := idx.decodeInvertedKey(k); tid != 7 || kw != "a" || dc != 5 {
+			t.Fatalf("decode(encode(7,a,5)) = (%d,%q,%d); want (7,\"a\",5)", tid, kw, dc)
+		}
 		seen[k] = struct{}{}
+	}
+
+	// The tick param must actually be THREADED into the key: a GREEN impl that
+	// added the param but kept calling time.Now().UnixMicro() internally would
+	// still pass the distinctness check above. Encode with a recognizable tick and
+	// assert the decoded tail is "<tick>.<seq>".
+	const K = int64(1234567)
+	if _, _, _, gotTick := idx.decodeInvertedKey(string(idx.encodeInvertedKey(7, "a", 5, K))); !strings.HasPrefix(gotTick, "1234567.") {
+		t.Fatalf("tick not threaded: decoded tick = %q, want prefix %q", gotTick, "1234567.")
 	}
 }
 

--- a/core/invertedindex/keywords_merger.go
+++ b/core/invertedindex/keywords_merger.go
@@ -174,7 +174,10 @@ var rewriteIndex = func(batch kv.Batch, idx *Index, index *invertedIndexEntry, m
 
 	mergedCount := 0
 	// Merge the keyword docids in old
-	// and write the new keyword to the database
+	// and write the new keyword to the database.
+	// Sample the opaque key tick ONCE for every row this rewrite emits (uniqueness
+	// is guaranteed by keySeq, not the tick), instead of reading the clock per row.
+	tick := time.Now().UnixMicro()
 	rows := index.Rows
 	remainingDocCount := index.DocCount
 	for len(rows) > 1 {
@@ -195,7 +198,7 @@ var rewriteIndex = func(batch kv.Batch, idx *Index, index *invertedIndexEntry, m
 			ids = append(ids, id)
 		}
 
-		key := idx.encodeInvertedKey(index.TableId, index.Keyword, len(ids))
+		key := idx.encodeInvertedKey(index.TableId, index.Keyword, len(ids), tick)
 		writeInvertedIndex(batch, index.TableId, index.Keyword, ids, key)
 		mergedCount++
 	}

--- a/core/invertedindex/keywords_merger.go
+++ b/core/invertedindex/keywords_merger.go
@@ -213,6 +213,7 @@ func (idx *Index) mergeKeywordsIndex(m merging, maxKeywordIndexSize int) merging
 	}
 
 	batch := newBatch(idx.db)
+	defer func() { _ = batch.Close() }()
 	lastTableId := -1
 	current := &invertedIndexEntry{Rows: []recordRow{}}
 	nextIter := m.NextIter

--- a/core/invertedindex/keywords_merger_test.go
+++ b/core/invertedindex/keywords_merger_test.go
@@ -1084,7 +1084,7 @@ func TestKeywordsMerger_RunWithPendingWrites(t *testing.T) {
 	pw := env.idx.getPendingWrite(1)
 	pw.InvertedIndex["testword"] = relatedDocs{
 		DocIds:    []int64{Doc2ID("doc1")},
-		UpdatedAt: time.Now(),
+		UpdatedAt: time.Now().UnixNano(),
 	}
 
 	km := &keywordsMerger{idx: env.idx, InitialDelay: 10 * time.Millisecond}

--- a/core/invertedindex/keywords_merger_test.go
+++ b/core/invertedindex/keywords_merger_test.go
@@ -405,8 +405,8 @@ func TestMergeKeywordsIndexSingleTable(t *testing.T) {
 		scanRangeFunc: func(start, end []byte, fn func(k, v []byte) bool) {
 			// Create real formatted keys and values
 			keys := [][]byte{
-				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 2),
-				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 3),
+				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 2, 0),
+				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 3, 0),
 			}
 			values := []string{
 				MakeDocsForKeyword("doc1", "doc2"),
@@ -538,10 +538,10 @@ func TestMergeKeywordsIndexMultipleTables(t *testing.T) {
 		scanRangeFunc: func(start, end []byte, fn func(k, v []byte) bool) {
 			// Create real formatted keys and values
 			keys := [][]byte{
-				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 2),
-				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 3),
-				testCodecIdx.encodeInvertedKey(testTable2, "keyword1", 2),
-				testCodecIdx.encodeInvertedKey(testTable2, "keyword1", 3),
+				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 2, 0),
+				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 3, 0),
+				testCodecIdx.encodeInvertedKey(testTable2, "keyword1", 2, 0),
+				testCodecIdx.encodeInvertedKey(testTable2, "keyword1", 3, 0),
 			}
 			values := []string{
 				MakeDocsForKeyword("doc1", "doc2"),
@@ -714,7 +714,7 @@ func TestMergeKeywordsIndexTimeout(t *testing.T) {
 	// Generate properly formatted keys and values
 	for i := 0; i < keyCount; i++ {
 		keyword := "keyword" + string(rune('a'+i%26))
-		keys[i] = testCodecIdx.encodeInvertedKey(testTable1, keyword, 2)
+		keys[i] = testCodecIdx.encodeInvertedKey(testTable1, keyword, 2, 0)
 		values[i] = fmt.Sprintf("doc%d|doc%d", i*2, i*2+1)
 	}
 
@@ -922,8 +922,8 @@ func TestKeywordsMerger_RunMergeWithData(t *testing.T) {
 			}
 			scanCalled = true
 			keys := [][]byte{
-				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 2),
-				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 3),
+				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 2, 0),
+				testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 3, 0),
 			}
 			values := []string{
 				MakeDocsForKeyword("doc1", "doc2"),
@@ -1053,7 +1053,7 @@ func TestMergeKeywordsIndex_WellBatchedSkip(t *testing.T) {
 	// Create a row with doccount=6 (> maxSize/2=5) → well batched, should be skipped.
 	mdb := &mockDB{
 		scanRangeFunc: func(start, end []byte, fn func(k, v []byte) bool) {
-			key := testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 6) // doccount=6 > 5
+			key := testCodecIdx.encodeInvertedKey(testTable1, "keyword1", 6, 0) // doccount=6 > 5
 			value := MakeDocsForKeyword("d1", "d2", "d3", "d4", "d5", "d6")
 			fn(key, []byte(value))
 		},

--- a/core/invertedindex/pending_bound_test.go
+++ b/core/invertedindex/pending_bound_test.go
@@ -33,7 +33,7 @@ func newBoundedIndex(t *testing.T, opts Options) (*Index, func()) {
 	// Reset the package test-injection seams (mirrors setupTestEnv).
 	newBatch = func(db kv.Store) kv.Batch { return db.NewBatch(MaxBatchSize) }
 	writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []int64, key []byte) {
-		batch.Put(key, encodeInvertedValue(removeDuplicatesEfficiently(docids)))
+		batch.Put(key, encodeInvertedValue(docids))
 	}
 
 	opts.FlushTicker = time.Hour // disable the periodic ticker for the test

--- a/core/invertedindex/pending_bound_test.go
+++ b/core/invertedindex/pending_bound_test.go
@@ -141,6 +141,143 @@ func TestClearPendingWritesKeepsCounters(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Flush age heuristic (I2): UpdatedAt as int64 unix-nanos. These pin BOTH
+// directions of the edited age comparison on the write AND delete sides via
+// periodic flushes (false,false) — never forceFlush, whose force=true short-
+// circuits the age term. The aged cases direct-seed UpdatedAt as an int64, which
+// is the compile RED until relatedDocs.UpdatedAt becomes int64, and pin the
+// sign + nanosecond scale of the age math.
+// ---------------------------------------------------------------------------
+
+// TestFlushWriteYoungEntrySurvives seeds the write cache via the PRODUCTION
+// updateIndex path (pinning the .UnixNano() scale end-to-end) and asserts a
+// young, sub-batch-size entry is SKIPPED by a periodic flush (the count=0 skip
+// branch at pending_writes.go:104).
+func TestFlushWriteYoungEntrySurvives(t *testing.T) {
+	// FlushWaitTimeout=1h makes "young" deterministic: the seed->flush gap can
+	// never exceed 1h, so a scheduler stall (slow/loaded CI) cannot age the
+	// entry out and drain it (kills the flake). The .UnixNano() scale stays
+	// pinned despite the large timeout: a .Unix() (seconds) scale bug would make
+	// nowNanos-UpdatedAt ~1.75e18 ns (~55 years) >> 1h -> the entry would drain
+	// -> this survives-assert would fail.
+	idx, cleanup := newBoundedIndex(t, Options{FlushWaitTimeout: time.Hour})
+	defer cleanup()
+
+	idx.updateIndex(7, makeDocID("d1"), []string{"kw"})
+
+	// Cooldown satisfied so the flush actually runs; the entry is still young.
+	idx.lastFlushWriteTime = time.Now().Add(-time.Hour)
+	idx.flushPendingWrites(false, false)
+
+	wp := idx.pendingWrites[7]
+	if wp == nil {
+		t.Fatalf("expected pending write table to survive a periodic flush, got nil")
+	}
+	if _, ok := wp.InvertedIndex["kw"]; !ok {
+		t.Fatalf("expected young entry 'kw' to survive a periodic flush")
+	}
+}
+
+// TestFlushWriteAgedEntryDrains direct-seeds a small write entry with UpdatedAt
+// WELL past the 3s write timeout (as int64 nanos) and asserts a periodic flush
+// DRAINS it — the FALSE branch that pins the age math's sign and nanosecond
+// scale (a swapped operand or seconds-vs-nanos regression fails here).
+func TestFlushWriteAgedEntryDrains(t *testing.T) {
+	idx, cleanup := newBoundedIndex(t, Options{} /* unbounded, ticker disabled */)
+	defer cleanup()
+
+	docid := makeDocID("d1")
+	wp := idx.getPendingWrite(7)
+	wp.InvertedIndex["kw"] = relatedDocs{
+		DocIds:    []int64{docid},
+		UpdatedAt: time.Now().Add(-time.Hour).UnixNano(),
+	}
+	idx.pendingWritePostings += 1 // mirror what updateIndex would have bumped
+
+	idx.lastFlushWriteTime = time.Now().Add(-time.Hour) // cooldown satisfied
+	pre := idx.pendingWritePostings
+	idx.flushPendingWrites(false, false)
+
+	if wp2 := idx.pendingWrites[7]; wp2 != nil {
+		if _, ok := wp2.InvertedIndex["kw"]; ok {
+			t.Fatalf("expected aged entry 'kw' to drain on a periodic flush")
+		}
+	}
+	if idx.pendingWritePostings >= pre {
+		t.Fatalf("expected write posting counter to drop after drain: pre=%d post=%d", pre, idx.pendingWritePostings)
+	}
+	if got := searchDocCount(idx, 7, "kw"); got != 1 {
+		t.Fatalf("expected drained entry written to the store, Search found %d, want 1", got)
+	}
+}
+
+// TestFlushDeleteYoungEntrySurvives seeds the delete cache via the PRODUCTION
+// removeIndex path and asserts a young, sub-batch-size entry is SKIPPED by a
+// periodic flush (the count=0 skip branch at pending_writes.go:159).
+func TestFlushDeleteYoungEntrySurvives(t *testing.T) {
+	// FlushDeleteWaitTimeout=1h makes "young" deterministic: the seed->flush gap
+	// can never exceed 1h, so a scheduler stall (slow/loaded CI) cannot age the
+	// entry out and drain it (kills the flake). The .UnixNano() scale stays
+	// pinned despite the large timeout: a .Unix() (seconds) scale bug would make
+	// nowNanos-UpdatedAt ~1.75e18 ns (~55 years) >> 1h -> the entry would drain
+	// -> this survives-assert would fail.
+	idx, cleanup := newBoundedIndex(t, Options{FlushDeleteWaitTimeout: time.Hour})
+	defer cleanup()
+
+	idx.removeIndex(7, makeDocID("d1"), []string{"kw"})
+
+	idx.lastFlushDeleteTime = time.Now().Add(-time.Hour) // cooldown satisfied
+	idx.flushPendingDeletes(false, false, MaxInvertedIndexSize)
+
+	wp := idx.pendingDeletes[7]
+	if wp == nil {
+		t.Fatalf("expected pending delete table to survive a periodic flush, got nil")
+	}
+	if _, ok := wp.InvertedIndex["kw"]; !ok {
+		t.Fatalf("expected young delete entry 'kw' to survive a periodic flush")
+	}
+}
+
+// TestFlushDeleteAgedEntryDrains seeds a doc in the store, then direct-seeds a
+// small delete entry with UpdatedAt WELL past the 5s delete timeout (int64
+// nanos) and asserts a periodic flush DRAINS it and removes the doc from the
+// store — the delete-side FALSE branch pinning sign + nanosecond scale.
+func TestFlushDeleteAgedEntryDrains(t *testing.T) {
+	idx, cleanup := newBoundedIndex(t, Options{} /* unbounded, ticker disabled */)
+	defer cleanup()
+
+	docid := makeDocID("d1")
+	idx.updateIndex(7, docid, []string{"kw"})
+	forceFlush(idx)
+	if got := searchDocCount(idx, 7, "kw"); got != 1 {
+		t.Fatalf("seed: expected 1 doc in store, got %d", got)
+	}
+
+	wp := idx.getPendingDelete(7)
+	wp.InvertedIndex["kw"] = relatedDocs{
+		DocIds:    []int64{docid},
+		UpdatedAt: time.Now().Add(-time.Hour).UnixNano(),
+	}
+	idx.pendingDeletePostings += 1 // mirror what removeIndex would have bumped
+
+	idx.lastFlushDeleteTime = time.Now().Add(-time.Hour) // cooldown satisfied
+	pre := idx.pendingDeletePostings
+	idx.flushPendingDeletes(false, false, MaxInvertedIndexSize)
+
+	if wp2 := idx.pendingDeletes[7]; wp2 != nil {
+		if _, ok := wp2.InvertedIndex["kw"]; ok {
+			t.Fatalf("expected aged delete entry 'kw' to drain on a periodic flush")
+		}
+	}
+	if idx.pendingDeletePostings >= pre {
+		t.Fatalf("expected delete posting counter to drop after drain: pre=%d post=%d", pre, idx.pendingDeletePostings)
+	}
+	if got := searchDocCount(idx, 7, "kw"); got != 0 {
+		t.Fatalf("expected doc removed from the store after aged delete drain, got %d, want 0", got)
+	}
+}
+
 // TestMaxPendingPostingsForcesDeleteFlush covers the delete-side pressure branch:
 // buffered deletes crossing the bound trigger a forced flushPendingDeletes that
 // applies the removals to the store without an explicit flush.

--- a/core/invertedindex/pending_writes.go
+++ b/core/invertedindex/pending_writes.go
@@ -6,8 +6,18 @@ import (
 )
 
 type relatedDocs struct {
-	DocIds    []int64
-	UpdatedAt time.Time
+	DocIds []int64
+	// UpdatedAt is a wall-clock unix-nanos timestamp (time.Now().UnixNano()),
+	// not a monotonic reading. It backs ONLY the soft young-entry flush-skip
+	// heuristic (forced/closing/pressure flushes drain regardless), so a wall
+	// step (e.g. NTP) can at worst skip/drain an entry one cycle early or late —
+	// no correctness impact. Two edge cases resolve the same safe way as today's
+	// time.Since: a backward clock step makes (now-UpdatedAt) negative → < timeout
+	// → treated as "young"/skipped (drained by the next forced flush); a zero
+	// value (never set) yields a huge positive delta → flushed. int64 instead of
+	// time.Time keeps this per-keyword struct pointer-free (no GC-scanned
+	// *Location) and 16B smaller across the unbounded pending map.
+	UpdatedAt int64
 }
 
 type pendingTableWrites struct {
@@ -72,6 +82,7 @@ func (idx *Index) flushPendingWrites(closing, force bool) {
 	}
 	now := time.Now()
 	idx.lastFlushWriteTime = now
+	nowNanos := now.UnixNano()
 
 	if closing {
 		log.Println("[Inverted] Flushing pending writes...")
@@ -90,7 +101,7 @@ func (idx *Index) flushPendingWrites(closing, force bool) {
 			// Skip young, small keyword entries on a periodic flush; a forced or
 			// closing flush drains them regardless.
 			if !closing && !force && len(relatedDocs.DocIds) < flushWaitBatchSize &&
-				time.Since(relatedDocs.UpdatedAt) < flushWaitTimeout {
+				time.Duration(nowNanos-relatedDocs.UpdatedAt) < flushWaitTimeout {
 				continue
 			}
 
@@ -127,7 +138,9 @@ func (idx *Index) flushPendingDeletes(closing, force bool, maxKeywordIndexSize i
 	if !closing && !force && time.Since(idx.lastFlushDeleteTime) < idx.opts.flushCooldown() {
 		return
 	}
-	idx.lastFlushDeleteTime = time.Now()
+	now := time.Now()
+	idx.lastFlushDeleteTime = now
+	nowNanos := now.UnixNano()
 
 	if closing {
 		log.Println("[Inverted] Flushing pending deletes...")
@@ -143,7 +156,7 @@ func (idx *Index) flushPendingDeletes(closing, force bool, maxKeywordIndexSize i
 			// Skip young, small delete entries on a periodic flush; a forced or
 			// closing flush drains them regardless.
 			if !closing && !force && len(relatedDocs.DocIds) < idx.opts.flushDeleteWaitBatchSize() &&
-				time.Since(relatedDocs.UpdatedAt) < idx.opts.flushDeleteWaitTimeout() {
+				time.Duration(nowNanos-relatedDocs.UpdatedAt) < idx.opts.flushDeleteWaitTimeout() {
 				continue
 			}
 

--- a/core/invertedindex/pending_writes.go
+++ b/core/invertedindex/pending_writes.go
@@ -92,6 +92,7 @@ func (idx *Index) flushPendingWrites(closing, force bool) {
 	}
 
 	batch := newBatch(idx.db)
+	defer func() { _ = batch.Close() }()
 
 	flushWaitTimeout := idx.opts.flushWaitTimeout()
 	flushWaitBatchSize := idx.opts.flushWaitBatchSize()
@@ -150,6 +151,7 @@ func (idx *Index) flushPendingDeletes(closing, force bool, maxKeywordIndexSize i
 	}
 
 	batch := newBatch(idx.db)
+	defer func() { _ = batch.Close() }()
 
 	for _, wp := range idx.pendingDeletes {
 		for kw, relatedDocs := range wp.InvertedIndex {

--- a/core/invertedindex/pending_writes.go
+++ b/core/invertedindex/pending_writes.go
@@ -70,7 +70,8 @@ func (idx *Index) flushPendingWrites(closing, force bool) {
 	if !closing && !force && time.Since(idx.lastFlushWriteTime) < idx.opts.flushCooldown() {
 		return
 	}
-	idx.lastFlushWriteTime = time.Now()
+	now := time.Now()
+	idx.lastFlushWriteTime = now
 
 	if closing {
 		log.Println("[Inverted] Flushing pending writes...")
@@ -93,7 +94,7 @@ func (idx *Index) flushPendingWrites(closing, force bool) {
 				continue
 			}
 
-			writeInvertedIndex(batch, wp.TableId, kw, relatedDocs.DocIds, idx.encodeInvertedKey(wp.TableId, kw, len(relatedDocs.DocIds)))
+			writeInvertedIndex(batch, wp.TableId, kw, relatedDocs.DocIds, idx.encodeInvertedKey(wp.TableId, kw, len(relatedDocs.DocIds), now.UnixMicro()))
 			idx.pendingWritePostings -= len(relatedDocs.DocIds)
 			delete(wp.InvertedIndex, kw)
 

--- a/core/invertedindex/table.go
+++ b/core/invertedindex/table.go
@@ -38,6 +38,7 @@ func (idx *Index) DeleteTable(tableId int) error {
 	idx.clearPendingWrites(tableId)
 
 	batch := idx.db.NewBatch(0)
+	defer func() { _ = batch.Close() }()
 	batch.DeletePrefix(idx.encodeInvertedSearchKey(tableId, ""))
 	batch.DeletePrefix(idx.encodeForwardKeyPrefix(tableId))
 	batch.Delete(idx.encodeTableKey(tableId))

--- a/core/invertedindex/test_helper_test.go
+++ b/core/invertedindex/test_helper_test.go
@@ -46,8 +46,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 		return db.NewBatch(MaxBatchSize)
 	}
 	writeInvertedIndex = func(batch kv.Batch, tableId int, kw string, docids []int64, key []byte) {
-		uniqueDocids := removeDuplicatesEfficiently(docids)
-		content := encodeInvertedValue(uniqueDocids)
+		content := encodeInvertedValue(docids)
 		batch.Put(key, content)
 	}
 


### PR DESCRIPTION
## What

Five small, **in-place, byte-identical-on-disk** changes to `core/invertedindex` that cut allocator/GC churn and build-phase peak RSS — the top-priority axes (**build/ingest ≫ memory > search**). No on-disk format change, **no reindex**.

Sourced from a multi-agent audit of the package's hot paths (26 findings → 15 distinct, each adversarially verified); this PR is the "Tier 1" bundle — the CONFIRMED, zero-risk, top-axis wins. One commit per item:

| Commit | Change | Axis |
|---|---|---|
| `c196692` | **encodeForwardValue**: hand-rolled single-alloc join (was `[]byte(strings.Join(...))` = 2 allocs + full copy per document) | build/mem |
| `1111c2d` | **encodeInvertedValue**: fold set-dedup into the encoder (`slices.Compact` after the existing sort) + `binary.AppendUvarint`; drop the redundant per-row `removeDuplicatesEfficiently` map (100% wasted on the merge/delete callers) | build/mem |
| `24d774d` | **encodeInvertedKey**: sample the opaque tick once per flush/merge/delete batch instead of `time.Now().UnixMicro()` per key (~10.6M+ vDSO reads/build → ~one per flush); `keySeq` still the sole uniqueness guarantor | build |
| `07b0230` | **relatedDocs.UpdatedAt** `time.Time` → `int64` unix-nanos: 48B→32B per in-flight keyword, drops a GC-scanned `*Location` pointer (~10.6M fewer on a full build) | memory |
| `6df3e30` | **defer batch.Close()** at the 4 batch sites so committed batches return to pebble's pool instead of GC | memory (hygiene) |

## Why / honest framing

None of these is a wall-clock game-changer on its own (pebble commit + per-posting append/hash dominate build; per-file I/O dominates search). The value is a clean reduction of **allocator/GC churn and peak build RSS** — which is exactly what matters for the low-RAM deployment target where memory outranks search latency. All byte-identical on disk (proven by golden tests), so they ship together with zero migration risk.

## Correctness / invariants

- **On-disk bytes unchanged** for the codec items — pinned by hand-typed golden-byte tests (`encodeForwardValue`, `encodeInvertedValue`) + the unchanged decode round-trip suites. `encodeInvertedKey` preserves the key grammar (tick is opaque; `keySeq` guarantees uniqueness under an identical tick — tested).
- `relatedDocs.UpdatedAt` is never serialized; the flush-age heuristic moves monotonic→wall clock (soft skip only; forced/closing/pressure flushes drain regardless). Symmetric young-survives / aged-drains tests (write + delete) pin the age math's sign and nanosecond scale.
- `defer Close()` is contract-safe on `kv.Batch` (Commit doesn't release; Close returns the batch to pebble's pool). Exactly one Close per site (no double-close); a store-level Close recorder test guards all four sites.

## Verification

Every item built via strict TDD (real red → green) with a multi-agent review loop per item. Full gates green with `go1.24.2` (CI parity): `build ./...`, `test ./invertedindex/ ./engine/`, `test -race ./invertedindex/`, `gofmt`, `vet`, and **go-cov zero CRITICAL** (all touched functions ≥80%; the `writeInvertedIndex` package-var seam is an EFFECT=0 tolerated range). `git diff main` touches only `core/invertedindex/*.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)