### PR TITLE
perf(server): default the inverted index to MaxPendingPostings=Recommended (2M)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,11 +23,23 @@ import (
 	"github.com/codetrek/haystack/internal/shared/running"
 )
 
+// newInvertedIndex is the constructor seam; tests override it to capture the
+// Options the production wiring passes. Its type is invertedindex.New's:
+// func(kv.Store, queue.Queue, invertedindex.Options) (*invertedindex.Index, error)
+// — note the 2nd param is the queue.Queue INTERFACE (a test override must use
+// queue.Queue, not *queue.Mpsc; see server_maxpending_test.go).
+var newInvertedIndex = invertedindex.New
+
 // Function variables for Init calls, enabling test overrides.
 var (
 	invertedindexInit = func(db kv.Store, mpsc *queue.Mpsc) (*invertedindex.Index, error) {
-		// Zero-value Options selects production defaults inside New.
-		return invertedindex.New(db, mpsc, invertedindex.Options{})
+		// Cap the pending-write buffer at the measured-good bound so build-phase
+		// peak RSS is bounded and predictable (~0.66 GiB vs an unbounded, noisy
+		// ~1.3 GiB at scale) — a deliberate memory-over-build-speed default for the
+		// deployment, at a measured ~+11% build cost. See RecommendedMaxPendingPostings.
+		return newInvertedIndex(db, mpsc, invertedindex.Options{
+			MaxPendingPostings: invertedindex.RecommendedMaxPendingPostings,
+		})
 	}
 	documentsNew = func(db kv.Store, mpsc *queue.Mpsc, idx *invertedindex.Index) (*documents.Store, error) {
 		return documents.New(db, mpsc, idx, documents.Options{})

--- a/internal/server/server_maxpending_test.go
+++ b/internal/server/server_maxpending_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/codetrek/haystack/core/invertedindex"
+	"github.com/codetrek/haystack/core/kv"
+	"github.com/codetrek/haystack/core/queue"
+)
+
+// TestInvertedIndexInit_PassesRecommendedBound guards the PRODUCTION wiring: the
+// server's invertedindexInit closure must construct the inverted index with the
+// measured-good MaxPendingPostings bound, not the unbounded zero value. It
+// overrides the newInvertedIndex seam to capture the Options the real closure
+// passes, catching both revert vectors (dropping the bound, or editing the
+// closure body back to Options{}).
+func TestInvertedIndexInit_PassesRecommendedBound(t *testing.T) {
+	var captured invertedindex.Options
+	orig := newInvertedIndex
+	// NOTE: the override's 2nd param is queue.Queue (NOT *queue.Mpsc).
+	// newInvertedIndex is `var newInvertedIndex = invertedindex.New`, so it
+	// inherits New's signature func(kv.Store, queue.Queue, Options) — a
+	// *queue.Mpsc-typed func literal is NOT assignable to it (Go func types are
+	// parameter-invariant). The production closure passing a concrete *queue.Mpsc
+	// at the CALL site is fine (it satisfies the queue.Queue interface param).
+	newInvertedIndex = func(_ kv.Store, _ queue.Queue, opts invertedindex.Options) (*invertedindex.Index, error) {
+		captured = opts
+		return nil, nil
+	}
+	defer func() { newInvertedIndex = orig }()
+
+	if _, err := invertedindexInit(nil, nil); err != nil {
+		t.Fatalf("invertedindexInit: %v", err)
+	}
+	if captured.MaxPendingPostings != invertedindex.RecommendedMaxPendingPostings {
+		t.Fatalf("MaxPendingPostings = %d, want RecommendedMaxPendingPostings (%d)",
+			captured.MaxPendingPostings, invertedindex.RecommendedMaxPendingPostings)
+	}
+}


### PR DESCRIPTION
## What

The server built `core/invertedindex` with a zero-value `Options{}`, so `MaxPendingPostings` was 0 = **unbounded** — the in-memory pending-write buffer grew until the periodic flush drained it, giving a noisy **~1.1–1.5 GiB peak build RSS** at scale. This wires the production construction to pass the measured-good bound `RecommendedMaxPendingPostings` (2,000,000).

## Why (measured)

iibench on the linux corpus (94,559 docs / 41.4M postings, 4× interleaved avg, prod default vs 2M):

| | unbounded (today) | **2M (this PR)** |
|---|---|---|
| peak build RSS | ~1.28 GiB (noisy 1.1–1.5) | **~0.66 GiB (tight 0.6–0.7), −48%** |
| peak Go heap | ~1.15 GiB | ~0.54 GiB (−53%) |
| build wall-time | ~56 s | ~62 s (+11%) |
| alloc traffic / GC | 6.9 GiB / ~36 | 9.1 GiB / ~166 |
| search / hits | ~2063 µs / 2,414,505 | ~2140 µs / **2,414,505 (identical)** |

Peak build RSS is roughly **halved and made predictable** (unbounded is race-dependent and noisy), for a ~+11% build cost and more flush/GC churn — a deliberate memory-over-build-speed default for the possibly-small-RAM deployment target.

## Scope

**Consumer opt-in only.** The `core/invertedindex` zero-value contract (`MaxPendingPostings` 0 = unbounded) is unchanged, so the published `core` module and its other consumers are unaffected — only the server sets the bound. `git diff` touches only `internal/server/`.

A `newInvertedIndex` constructor seam lets a light unit test capture the `Options` the production `invertedindexInit` closure passes and assert the bound (a genuine red→green guard against a silent revert to unbounded — verified: dropping the bound makes the test fail with `MaxPendingPostings = 0`). No on-disk change; search/hits unaffected.

## Verification

Built via the full SDD flow (spec, 3 review rounds to a clean round, then workflow-driven TDD). Local gates green (go1.24.2 + go.work): build / vet / gofmt / `internal/server` tests; and the root **go-cov gate: zero CRITICAL, total 94.0%** (`internal/server` 95.3%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)